### PR TITLE
Bugfix: HTTP HEAD requests do not work properly

### DIFF
--- a/lib/Sabre/DAV/Client.php
+++ b/lib/Sabre/DAV/Client.php
@@ -320,7 +320,14 @@ class Sabre_DAV_Client {
         }
 
         if ($response['statusCode']>=400) {
-            throw new Sabre_DAV_Exception('HTTP error response. (errorcode ' . $response['statusCode'] . ')');
+            switch ($response['statusCode']) {
+                case 404:
+                    throw new Sabre_DAV_Exception_NotFound('Resource ' . $url . ' not found.');
+                    break;
+
+                default:
+                    throw new Sabre_DAV_Exception('HTTP error response. (errorcode ' . $response['statusCode'] . ')');
+            }
         }
 
         return $response;


### PR DESCRIPTION
cURL by default tries to read the body of HTTP requests, but servers do not deliver it (that's after all the purpose of HEAD vs GET...). When a Content-Length header is present, cURL is tricked into thinking that there are still some bytes to follow, but the header is only informative. To prevent this error, CURLOPT_NOBODY should be set to TRUE for HEAD requests.
