### PR TITLE
[CalDAV] Fixed validateICalendar() to keep data

### DIFF
--- a/lib/Sabre/CalDAV/Plugin.php
+++ b/lib/Sabre/CalDAV/Plugin.php
@@ -624,7 +624,7 @@ class Sabre_CalDAV_Plugin extends Sabre_DAV_ServerPlugin {
      * @param resource|string $data
      * @return void
      */
-    protected function validateICalendar($data) {
+    protected function validateICalendar(&$data) {
 
         if (is_resource($data)) {
             $data = stream_get_contents($data);


### PR DESCRIPTION
The `validateICalendar()` method gets content of a `$data` parameter,
if this parameter is a resource, then it uses `stream_get_contents()`
to check real data.

But it's wrong as the resource has been consumed, and it won't keep
data for next steps (in the `put()` method for instance).

So, to pass the `$data` parameter as reference seems fine.
