### PR TITLE
iCal on Snow Leopard request for path / after some operations

### DIFF
--- a/lib/Sabre/DAV/Server.php
+++ b/lib/Sabre/DAV/Server.php
@@ -1080,6 +1080,12 @@ class Sabre_DAV_Server {
 
             return '';
 
+        // A special case for iCal, requesting / path after some operations like creating a calendar
+        // throws an error if baseUri != /
+        } elseif ($uri === '/') {
+
+            return '';
+
         } else {
 
             throw new Sabre_DAV_Exception_Forbidden('Requested uri (' . $uri . ') is out of base uri (' . $this->getBaseUri() . ')');


### PR DESCRIPTION
iCal on Snow Leopard request for path / after some operations (create calendar for example).
When you setup the base url for your server on a subfolder and iCal checks the path /, it throws an error.
I think that in these cases, we need to accept the request too.
