### PR TITLE
added mysql INDEX to calendarobject and calendar table

### DIFF
--- a/examples/sql/mysql.calendars.sql
+++ b/examples/sql/mysql.calendars.sql
@@ -9,7 +9,9 @@ CREATE TABLE calendarobjects (
     componenttype VARCHAR(8),
     firstoccurence INT(11) UNSIGNED,
     lastoccurence INT(11) UNSIGNED,
-    UNIQUE(calendarid, uri)
+    UNIQUE(calendarid, uri),
+    INDEX(calendarid),
+    INDEX(uri)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 CREATE TABLE calendars (
@@ -23,5 +25,6 @@ CREATE TABLE calendars (
     calendarcolor VARCHAR(10),
     timezone TEXT,
     components VARCHAR(20),
-    UNIQUE(principaluri, uri)
+    UNIQUE(principaluri, uri),
+    INDEX(principaluri)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;


### PR DESCRIPTION
I activated MySQL log-queries-not-using-indexes and then did some things with Apple iCal and my own client. Then checking the slow query log file for queries that are not using an INDEX and added them for these calendar queries.

Maybe you can do the same for CardDAV, normal WebDAV, the build in PDO authentication (I'm using another authentication method). There should be some missing INDEXes in the other tables.

I'm not sure about SQLite and Postgres, if and how Indexes can be added there.

http://dev.mysql.com/doc/refman/5.1/en/server-options.html#option_mysqld_log-queries-not-using-indexes
