### PR TITLE
Issue 203

### DIFF
--- a/tests/Sabre/CalDAV/Issue203Test.php
+++ b/tests/Sabre/CalDAV/Issue203Test.php
@@ -52,7 +52,7 @@ END:VCALENDAR
         ),
     );
 
-    function testIssue201() {
+    function testIssue203() {
 
         $request = new Sabre_HTTP_Request(array(
             'REQUEST_METHOD' => 'REPORT',


### PR DESCRIPTION
Matching the 2 expected events against the 2 from the response is a bit complicated, but it works I think. Maybe you have a better idea to detect wrong events.
I hope the .ics is not the problem?! Looks pretty simple...

short summary:
expected: 26.03. ("original summary") and 28.03. ("overwritten summary", RECURRENCE-ID: 20120327T155200)
response: 26.03. ("original summary") and 28.03. ("original summary", RECURRENCE-ID: 20120328T155200)
