### PR TITLE
allow user to set ssl certificate for webdav client

### DIFF
--- a/lib/Sabre/DAV/Client.php
+++ b/lib/Sabre/DAV/Client.php
@@ -34,6 +34,7 @@ class Sabre_DAV_Client {
     protected $userName;
     protected $password;
     protected $proxy;
+    protected $trustedCertificates;
 
     /**
      * Basic authentication
@@ -99,6 +100,18 @@ class Sabre_DAV_Client {
 
     }
 
+    /**
+	 * Add trusted root certificates to the webdav client.
+	 * 
+	 * The parameter certificates should be a absulute path to a file
+	 * which contains all trusted certificates
+     *
+     * @param string $certificates
+     */
+    public function addTrustedCertificates($certificates) {
+    	$this->trustedCertificates = $certificates;
+    }
+    
     /**
      * Does a PROPFIND request
      *
@@ -290,6 +303,10 @@ class Sabre_DAV_Client {
             CURLOPT_FOLLOWLOCATION => true,
             CURLOPT_MAXREDIRS => 5,
         );
+        
+        if($this->trustedCertificates) {
+        	$curlSettings[CURLOPT_CAINFO] = $this->trustedCertificates;
+        }
 
         switch ($method) {
             case 'HEAD' :


### PR DESCRIPTION
Like discussed in issue #223 I implemented a method to allow users to set trusted ssl certificates to make the webdav client work with user-trusted certificates even if they are not part of the system wide certificate bundle.  Sorry for not providing a test for this patch but I'm not yet familiar with PHP unit test.
