### PR TITLE
no longer stripping \r in CardDAV xml output

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -31,6 +31,8 @@
 	* Fixed: Uploaded VCards without a UID are now rejected. (thanks Dominik!)
 	* Fixed: Rejecting calendar objects if they are not in the
 	  supported-calendar-component list. (thanks Armin!)
+	* Fixed: Workaround for 10.8 Mountain Lion vCards, as it needs \r line
+	  endings to parse them correctly.
 
 1.6.4-stable (2012-??-??)
 	* Fixed: Issue 220: Calendar-query filters may fail when filtering on

--- a/lib/Sabre/CardDAV/Plugin.php
+++ b/lib/Sabre/CardDAV/Plugin.php
@@ -154,8 +154,7 @@ class Sabre_CardDAV_Plugin extends Sabre_DAV_ServerPlugin {
                 if (is_resource($val))
                     $val = stream_get_contents($val);
 
-                // Taking out \r to not screw up the xml output
-                $returnedProperties[200][$addressDataProp] = str_replace("\r","", $val);
+                $returnedProperties[200][$addressDataProp] = $val;
 
             }
         }


### PR DESCRIPTION
Certain clients, such as the Adressbook application of the soon to be released "Redacted" seem to sometimes need the /r. Especially to correctly parse "X-ADDRESSBOOKSERVER-KIND:group" cards.

rdar://problem/11849410
