### PR TITLE
Fixed a problem in the date and datetime parser where a year > 4000 thro...

### DIFF
--- a/lib/Sabre/VObject/DateTimeParser.php
+++ b/lib/Sabre/VObject/DateTimeParser.php
@@ -28,7 +28,7 @@ class Sabre_VObject_DateTimeParser {
     static public function parseDateTime($dt,DateTimeZone $tz = null) {
 
         // Format is YYYYMMDD + "T" + hhmmss
-        $result = preg_match('/^([1-3][0-9]{3})([0-1][0-9])([0-3][0-9])T([0-2][0-9])([0-5][0-9])([0-5][0-9])([Z]?)$/',$dt,$matches);
+        $result = preg_match('/^([1-4][0-9]{3})([0-1][0-9])([0-3][0-9])T([0-2][0-9])([0-5][0-9])([0-5][0-9])([Z]?)$/',$dt,$matches);
 
         if (!$result) {
             throw new Sabre_DAV_Exception_BadRequest('The supplied iCalendar datetime value is incorrect: ' . $dt);
@@ -54,7 +54,7 @@ class Sabre_VObject_DateTimeParser {
     static public function parseDate($date) {
 
         // Format is YYYYMMDD
-        $result = preg_match('/^([1-3][0-9]{3})([0-1][0-9])([0-3][0-9])$/',$date,$matches);
+        $result = preg_match('/^([1-4][0-9]{3})([0-1][0-9])([0-3][0-9])$/',$date,$matches);
 
         if (!$result) {
             throw new Sabre_DAV_Exception_BadRequest('The supplied iCalendar date value is incorrect: ' . $date);

--- a/tests/Sabre/VObject/DateTimeParserTest.php
+++ b/tests/Sabre/VObject/DateTimeParserTest.php
@@ -106,6 +106,38 @@ class Sabre_VObject_DateTimeParserTest extends PHPUnit_Framework_TestCase {
     }
 
     /**
+     * TCheck if a date with year > 4000 will not throw an exception. iOS seems to use 45001231 in yearly recurring events
+     */
+    function testParseICalendarDateGreaterThan4000() {
+
+        $dateTime = Sabre_VObject_DateTimeParser::parseDate('45001231');
+
+        $expected = new DateTime('4500-12-31 00:00:00',new DateTimeZone('UTC'));
+
+        $this->assertEquals($expected, $dateTime);
+
+        $dateTime = Sabre_VObject_DateTimeParser::parse('45001231');
+        $this->assertEquals($expected, $dateTime);
+
+    }
+
+    /**
+     * Check if a datetime with year > 4000 will not throw an exception. iOS seems to use 45001231T235959 in yearly recurring events
+     */
+    function testParseICalendarDateTimeGreaterThan4000() {
+
+        $dateTime = Sabre_VObject_DateTimeParser::parseDateTime('45001231T235959');
+
+        $expected = new DateTime('4500-12-31 23:59:59',new DateTimeZone('UTC'));
+
+        $this->assertEquals($expected, $dateTime);
+
+        $dateTime = Sabre_VObject_DateTimeParser::parse('45001231T235959');
+        $this->assertEquals($expected, $dateTime);
+
+    }
+
+    /**
      * @depends testParseICalendarDate
      * @expectedException Sabre_DAV_Exception_BadRequest
      */


### PR DESCRIPTION
...ws exceptions, but iOS is using year 4500 in some cases
