### PR TITLE
Fix for a fatal error in parsePropFindRequest

### DIFF
--- a/lib/Sabre/DAV/Server.php
+++ b/lib/Sabre/DAV/Server.php
@@ -2125,6 +2125,9 @@ class Sabre_DAV_Server {
 
         $dom = Sabre_DAV_XMLUtil::loadDOMDocument($body);
         $elem = $dom->getElementsByTagNameNS('DAV:','propfind')->item(0);
+        // if element could not be found return empty array
+        if (!$elem) return array();
+
         return array_keys(Sabre_DAV_XMLUtil::parseProperties($elem));
 
     }


### PR DESCRIPTION
Had an issue with an DAV client sending a wrong propfind request to SabreDAV. The request did not contain a propfind element which then would throw a PHP fatal error due to the typehint of XMLUtil::parseProperties()
