### PR TITLE
Add calendar URI before requesting calendar object.

### DIFF
--- a/lib/Sabre/CalDAV/Calendar.php
+++ b/lib/Sabre/CalDAV/Calendar.php
@@ -107,7 +107,7 @@ class Calendar implements ICalendar, DAV\IProperties, DAVACL\IACL {
      */
     public function getChild($name) {
 
-        $obj = $this->caldavBackend->getCalendarObject($this->calendarInfo['id'],$name);
+        $obj = $this->caldavBackend->getCalendarObject($this->calendarInfo['id'],$this->calendarInfo['uri'] . '/' . $name);
 
         if (!$obj) throw new DAV\Exception\NotFound('Calendar object not found');
 


### PR DESCRIPTION
If the custom CalDAV backend is called via this stack trace:

```
 4. Sabre\DAV\Server->invokeMethod() /home/jan/horde-git/framework/Dav/vendor/sabre/dav/lib/Sabre/DAV/Server.php:214
 5. Sabre\DAV\Server->broadcastEvent() /home/jan/horde-git/framework/Dav/vendor/sabre/dav/lib/Sabre/DAV/Server.php:455
 6. call_user_func_array() /home/jan/horde-git/framework/Dav/vendor/sabre/dav/lib/Sabre/DAV/Server.php:433
 7. Sabre\DAV\Browser\Plugin->httpGetInterceptor()
 8. Sabre\DAV\Browser\Plugin->generateDirectoryIndex() /home/jan/horde-git/framework/Dav/vendor/sabre/dav/lib/Sabre/DAV/Browser/Plugin.php:137
 9. Sabre\DAV\ObjectTree->getNodeForPath() /home/jan/horde-git/framework/Dav/vendor/sabre/dav/lib/Sabre/DAV/Browser/Plugin.php:343
10. Sabre\CalDAV\Calendar->getChild() /home/jan/horde-git/framework/Dav/vendor/sabre/dav/lib/Sabre/DAV/ObjectTree.php:72
11. Horde_Dav_CalDav->getCalendarObject() /home/jan/horde-git/framework/Dav/vendor/sabre/dav/lib/Sabre/CalDAV/Calendar.php:110
```

the parameter $objectUri to getCalendarObject() was an incomplete URI that only contains the object's base name.
