### PR TITLE
added getter for realm

### DIFF
--- a/lib/Sabre/DAV/Auth/Plugin.php
+++ b/lib/Sabre/DAV/Auth/Plugin.php
@@ -42,7 +42,7 @@ class Plugin extends DAV\ServerPlugin {
     /**
      * @return string
      */
-    protected function getRealm() {
+    public function getRealm() {
         return $this->realm;
     }
 

--- a/tests/Sabre/DAV/Auth/PluginTest.php
+++ b/tests/Sabre/DAV/Auth/PluginTest.php
@@ -80,5 +80,14 @@ class PluginTest extends \PHPUnit_Framework_TestCase {
 
     }
 
+    /**
+     * @depends testInit
+     */
+    function testPlugin() {
+        $myRealmName = 'some_realm';
+        $plugin = new Plugin(new Backend\Mock(),$myRealmName);
+        $this->assertEquals($myRealmName, $plugin->getRealm());
+    }
+
 }
 


### PR DESCRIPTION
An extending class might want to override 'beforeMethod'. There it needs to have read access to the 'realm'.
