### PR TITLE
Flush and disable the output buffer if enabled

### DIFF
--- a/lib/Sabre/HTTP/Response.php
+++ b/lib/Sabre/HTTP/Response.php
@@ -158,6 +158,8 @@ class Response {
      * @return void
      */
     public function sendBody($body) {
+        
+        if (ob_get_level() > 0) ob_end_flush();
 
         if (is_resource($body)) {
 


### PR DESCRIPTION
In case the output buffer is active (many php installations come with "output_buffering = 4096" in php.ini), it should be flushed and deactivated before sending big files through fpassthru(), otherwise you get memory-limit-errors when downloading big files.
Related Pull Request in OwnCloud: https://github.com/owncloud/core/pull/576
