### PR TITLE
remove leading backslash in calendar example

### DIFF
--- a/examples/calendarserver.php
+++ b/examples/calendarserver.php
@@ -16,12 +16,12 @@ date_default_timezone_set('Canada/Eastern');
 // $baseUri = '/';
 
 /* Database */
-$pdo = new \PDO('sqlite:data/db.sqlite');
+$pdo = new PDO('sqlite:data/db.sqlite');
 $pdo->setAttribute(PDO::ATTR_ERRMODE,PDO::ERRMODE_EXCEPTION);
 
 //Mapping PHP errors to exceptions
 function exception_error_handler($errno, $errstr, $errfile, $errline ) {
-    throw new \ErrorException($errstr, 0, $errno, $errfile, $errline);
+    throw new ErrorException($errstr, 0, $errno, $errfile, $errline);
 }
 set_error_handler("exception_error_handler");
 
@@ -29,33 +29,33 @@ set_error_handler("exception_error_handler");
 require_once 'vendor/autoload.php';
 
 // Backends
-$authBackend = new \Sabre\DAV\Auth\Backend\PDO($pdo);
-$calendarBackend = new \Sabre\CalDAV\Backend\PDO($pdo);
-$principalBackend = new \Sabre\DAVACL\PrincipalBackend\PDO($pdo);
+$authBackend = new Sabre\DAV\Auth\Backend\PDO($pdo);
+$calendarBackend = new Sabre\CalDAV\Backend\PDO($pdo);
+$principalBackend = new Sabre\DAVACL\PrincipalBackend\PDO($pdo);
 
 // Directory structure
 $tree = [
-    new \Sabre\CalDAV\Principal\Collection($principalBackend),
-    new \Sabre\CalDAV\CalendarRootNode($principalBackend, $calendarBackend),
+    new Sabre\CalDAV\Principal\Collection($principalBackend),
+    new Sabre\CalDAV\CalendarRootNode($principalBackend, $calendarBackend),
 ];
 
-$server = new \Sabre\DAV\Server($tree);
+$server = new Sabre\DAV\Server($tree);
 
 if (isset($baseUri))
     $server->setBaseUri($baseUri);
 
 /* Server Plugins */
-$authPlugin = new \Sabre\DAV\Auth\Plugin($authBackend,'SabreDAV');
+$authPlugin = new Sabre\DAV\Auth\Plugin($authBackend,'SabreDAV');
 $server->addPlugin($authPlugin);
 
-$aclPlugin = new \Sabre\DAVACL\Plugin();
+$aclPlugin = new Sabre\DAVACL\Plugin();
 $server->addPlugin($aclPlugin);
 
-$caldavPlugin = new \Sabre\CalDAV\Plugin();
+$caldavPlugin = new Sabre\CalDAV\Plugin();
 $server->addPlugin($caldavPlugin);
 
 // Support for html frontend
-$browser = new \Sabre\DAV\Browser\Plugin();
+$browser = new Sabre\DAV\Browser\Plugin();
 $server->addPlugin($browser);
 
 // And off we go!


### PR DESCRIPTION
I noticed that the calendar and addressbook examples are not "compliant" in the way backslash are used.
This pull request enable to remove leading backslash in the calendarserver.php and be compliant with addressbookserver.php.

The 2 files are working fine and tested on a personal server with thunderbird and iOS6.
