### PR TITLE
Fix issue #178

### DIFF
--- a/lib/Sabre/DAV/Locks/Plugin.php
+++ b/lib/Sabre/DAV/Locks/Plugin.php
@@ -378,7 +378,7 @@ class Plugin extends DAV\ServerPlugin {
         if ($header) {
 
             if (stripos($header,'second-')===0) $header = (int)(substr($header,7));
-            else if (strtolower($header)=='infinite') $header = LockInfo::TIMEOUT_INFINITE;
+            else if (stripos($header,'infinite')===0) $header = LockInfo::TIMEOUT_INFINITE;
             else throw new DAV\Exception\BadRequest('Invalid HTTP timeout header');
 
         } else {


### PR DESCRIPTION
This change allows a lock timout header to have multiple values, per RFC 4918 section 10.7.
All but the first value are ignored.
