### PR TITLE
Fix restoring state of external entity loader

### DIFF
--- a/lib/Sabre/DAV/XMLUtil.php
+++ b/lib/Sabre/DAV/XMLUtil.php
@@ -134,7 +134,7 @@ class XMLUtil {
 
         // Restoring old mechanism for error handling
         if ($oldErrorSetting===false) libxml_use_internal_errors(false);
-        if ($oldEntityLoaderSetting===false) libxml_disable_entity_loader(false);
+        libxml_disable_entity_loader($oldEntityLoaderSetting);
 
         return $dom;
 


### PR DESCRIPTION
Commit e3f46e0ecf83 introduces a fix for an XXE security issue on older PHP versions but in case of one of the affected files the patch fails to restore the state of the external entity loader, see comment by @staabm in the commit comments. Commit 22ce7965 was obviously intended to fix this issue, but fails to do so.
