### PR TITLE
Backport fix for httpDelete to 1.7

### DIFF
--- a/lib/Sabre/DAV/Server.php
+++ b/lib/Sabre/DAV/Server.php
@@ -684,6 +684,10 @@ class Sabre_DAV_Server {
     protected function httpDelete($uri) {
 
         if (!$this->broadcastEvent('beforeUnbind',array($uri))) return;
+
+        // Checking If-None-Match and related headers.
+        if (!$this->checkPreconditions()) return;
+
         $this->tree->delete($uri);
         $this->broadcastEvent('afterUnbind',array($uri));
 


### PR DESCRIPTION
In 89f8fcbaaf7710701fe40e51c126eea858e9bc57 there was a bug fixed where 
httpDelete wouldn't check for preconditions. This fix never made it to 1.7.

It seems to fix a testcase in
[vdirsyncer](https://github.com/untitaker/vdirsyncer) when testing against
ownCloud, at least for me this is good enough validation.
