### PR TITLE
range requests for non-seekable streams

### DIFF
--- a/lib/Sabre/DAV/CorePlugin.php
+++ b/lib/Sabre/DAV/CorePlugin.php
@@ -168,16 +168,16 @@ class CorePlugin extends ServerPlugin {
             // New read/write stream
             $newStream = fopen('php://temp','r+');
 
-			// fseek will return 0 only if $streem is seekable (and -1 otherwise)
+            // fseek will return 0 only if $streem is seekable (and -1 otherwise)
             // for a seekable $body stream we set the pointer write before copying it
             // for a non-seekable $body stream we set the pointer on the copy
-			if ((fseek($body, $start, SEEK_SET)) === 0) {
-				stream_copy_to_stream($body, $newStream, $end-$start+1, $start);
-				rewind($newStream);
-			} else {
-				stream_copy_to_stream($body, $newStream, $end+1);
-				fseek($newStream,$start, SEEK_SET);
-			}
+            if ((fseek($body, $start, SEEK_SET)) === 0) {
+                stream_copy_to_stream($body, $newStream, $end-$start+1, $start);
+                rewind($newStream);
+            } else {
+                stream_copy_to_stream($body, $newStream, $end+1);
+                fseek($newStream,$start, SEEK_SET);
+            }
 
             $response->setHeader('Content-Length', $end-$start+1);
             $response->setHeader('Content-Range','bytes ' . $start . '-' . $end . '/' . $nodeSize);


### PR DESCRIPTION
Fix for range requests for non-seekable streams. With the old code the offset is not set correctly, as fseek doesn't do anything on non-seekable streams. This is a pull request for issue #441.
