### PR TITLE
Improved AbstractBasic.php log messages

### DIFF
--- a/lib/DAV/Auth/Backend/AbstractBasic.php
+++ b/lib/DAV/Auth/Backend/AbstractBasic.php
@@ -73,7 +73,7 @@ abstract class AbstractBasic implements BackendInterface {
         // Authenticates the user
         if (!$this->validateUserPass($userpass[0],$userpass[1])) {
             $auth->requireLogin();
-            throw new DAV\Exception\NotAuthenticated('Username or password does not match, User: ' . $userpass[0]);
+            throw new DAV\Exception\NotAuthenticated('Username or password does not match, Username: ' . $userpass[0]);
         }
         $this->currentUser = $userpass[0];
         return true;


### PR DESCRIPTION
There are two possible log messages in function authenticate.

a.) The current message text "No basic authentication headers were found" doesn´t give a clear statement what is going on, if there is a problem or not. According to a explanation of @evert, this can also be triggered when a client (eg a browser) tries to login and with this first attempt no headers are sent. Then they negotiate and with the second attempt the authentication method negotiated is used. Therefore I adopted this message to make this negotiating process more visible and better understandable.

b.) The second message just tells that there is a mismatch between a user and a password given. Currently no information is logged with which user this attempt was made. I extended the message text to printout the user used making it easier finding login related issues.
