### PR TITLE
Fix typo

### DIFF
--- a/lib/DAV/Server.php
+++ b/lib/DAV/Server.php
@@ -916,7 +916,7 @@ class Server extends EventEmitter {
             $this->addPathNodesRecursively($propFindRequests, $propFind);
         }
 
-        $returnProperties = [];
+        $returnPropertyList = [];
 
         foreach($propFindRequests as $propFindRequest) {
 


### PR DESCRIPTION
Little typo in latest commit for 2.0.2:
https://github.com/fruux/sabre-dav/commit/712f415b907173db5e4415e320409efb9bc81ece

This way, the potential error would still be thrown ;)
