### PR TITLE
Browser plugin: sort by type first, then by display path.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -10,6 +10,7 @@ ChangeLog
 * Changed: Restructured the zip distribution to be a little bit more lean
   and consistent.
 * #472: Always returning lock tokens in the lockdiscovery property.
+* Directory entries in the Browser plugin are sorted by type and name.
 
 
 2.0.3 (2014-07-14)


### PR DESCRIPTION
The SabreDAV browser plugin previously displayed all entries in no
particular order. To make the list easier to digest for the end user,
sort all nodes based on their type first, and their display path second.
Use a custom sort order for the node type, that for instance sorts all
directories above all files.
