### PR TITLE
Issue #482: PropFind::set() hard adds properties during ALLPROPS

### DIFF
--- a/lib/DAV/PropFind.php
+++ b/lib/DAV/PropFind.php
@@ -120,17 +120,23 @@ class PropFind {
      */
     public function set($propertyName, $value, $status = null) {
 
-        if (isset($this->result[$propertyName])) {
-            if (is_null($status)) {
-                $status = is_null($value) ? 404 : 200;
-            }
-            if ($status!==404 && $this->result[$propertyName][0]===404) {
-                $this->itemsLeft--;
-            } elseif ($status === 404 && $this->result[$propertyName][0] !== 404) {
-                $this->itemsLeft++;
-            }
-            $this->result[$propertyName] = [$status, $value];
+        if (is_null($status)) {
+            $status = is_null($value) ? 404 : 200;
         }
+        // If this is an ALLPROPS request and the property is
+        // unknown, add it to the result; else ignore it:
+        if (!isset($this->result[$propertyName])) {
+            if ($this->requestType === self::ALLPROPS) {
+                $this->result[$propertyName] = [$status, $value];
+            }
+            return;
+        }
+        if ($status!==404 && $this->result[$propertyName][0]===404) {
+            $this->itemsLeft--;
+        } elseif ($status === 404 && $this->result[$propertyName][0] !== 404) {
+            $this->itemsLeft++;
+        }
+        $this->result[$propertyName] = [$status, $value];
 
     }
 

--- a/tests/Sabre/DAV/PropFindTest.php
+++ b/tests/Sabre/DAV/PropFindTest.php
@@ -50,6 +50,17 @@ class PropFindTest extends \PHPUnit_Framework_TestCase {
 
     }
 
+    function testSetAllpropCustom() {
+
+        $propFind = new PropFind('foo', ['{DAV:}displayname'], 0, PropFind::ALLPROPS);
+        $propFind->set('{DAV:}customproperty', 'bar');
+
+        $this->assertEquals([
+            200 => ['{DAV:}customproperty' => 'bar'],
+        ], $propFind->getResultForMultiStatus());
+
+    }
+
     function testSetUnset() {
 
         $propFind = new PropFind('foo', ['{DAV:}displayname']);


### PR DESCRIPTION
Here's my crack at solving Issue #482 myself. Works when I test with `cadaver` and verify the response with a tcpdump. I'm not too confident in my understanding of the property code at large though, so please review.

Most of the diff are whitespace changes since I removed an indentation level; running a `git diff -w HEAD~` gives a better idea of the changes made.
