### PR TITLE
Trigger event "afterCreateCollection" after collection creation

### DIFF
--- a/lib/DAV/Server.php
+++ b/lib/DAV/Server.php
@@ -1210,6 +1210,7 @@ class Server extends EventEmitter {
         }
         $this->tree->markDirty($parentUri);
         $this->emit('afterBind',[$uri]);
+        $this->emit('afterCreateCollection',[$uri, $parent]);
 
     }
 


### PR DESCRIPTION
This is to make it possible to return additional headers after a MKCOL call.

Ref https://github.com/owncloud/core/issues/9000
