### PR TITLE
If pre-conditions check fails, send response

### DIFF
--- a/lib/DAV/Server.php
+++ b/lib/DAV/Server.php
@@ -462,6 +462,7 @@ class Server extends EventEmitter {
         $this->transactionType = strtolower($method);
 
         if (!$this->checkPreconditions($request, $response)) {
+            $this->sapi->sendResponse($response);
             return;
         }
 


### PR DESCRIPTION
If the pre-conditions check doesn't throw an exception and instead updates the response and returns false then that response should be sent.

This fixes an issue encountered using the browser plugin whereby if the request had an If-Modified-Since header a blank page was served instead of the expected 304.
