### PR TITLE
Fix foreign key in postgresql schema

### DIFF
--- a/examples/sql/pgsql.principals.sql
+++ b/examples/sql/pgsql.principals.sql
@@ -28,10 +28,9 @@ ALTER TABLE ONLY groupmembers
     ADD CONSTRAINT groupmembers_principal_id_fkey FOREIGN KEY (principal_id) REFERENCES principals(id)
         ON DELETE CASCADE;
 
--- Is this correct correct link ... or not?
--- ALTER TABLE ONLY groupmembers
---     ADD CONSTRAINT groupmembers_member_id_id_fkey FOREIGN KEY (member_id) REFERENCES users(id)
---         ON DELETE CASCADE;
+ALTER TABLE ONLY groupmembers
+    ADD CONSTRAINT groupmembers_member_id_id_fkey FOREIGN KEY (member_id) REFERENCES principals(id)
+        ON DELETE CASCADE;
 
 INSERT INTO principals (uri,email,displayname) VALUES
 ('principals/admin', 'admin@example.org','Administrator'),


### PR DESCRIPTION
I fixed the foreign key `groupmembers_member_id_id_fkey`. 

See https://github.com/fruux/sabre-dav/blob/master/lib/DAVACL/PrincipalBackend/PDO.php#L310
`ON groupmembers.member_id = principals.id` 
