### PR TITLE
phpcbf: Drop extra ending spaces

### DIFF
--- a/lib/CalDAV/Schedule/IInbox.php
+++ b/lib/CalDAV/Schedule/IInbox.php
@@ -4,7 +4,7 @@ namespace Sabre\CalDAV\Schedule;
 
 /**
  * Implement this interface to have a node be recognized as a CalDAV scheduling
- * inbox. 
+ * inbox.
  *
  * @copyright Copyright (C) 2007-2014 fruux GmbH (https://fruux.com/).
  * @author Evert Pot (http://evertpot.com/)

--- a/lib/CalDAV/UserCalendars.php
+++ b/lib/CalDAV/UserCalendars.php
@@ -6,7 +6,7 @@ namespace Sabre\CalDAV;
  * This class is deprecated!
  *
  * It has been renamed to Sabre\CalDAV\CalendarHome.
- * 
+ *
  * This stub class will be removed in a future version of sabredav.
  *
  * @deprecated

--- a/lib/DAV/Exception/InvalidSyncToken.php
+++ b/lib/DAV/Exception/InvalidSyncToken.php
@@ -5,14 +5,14 @@ namespace Sabre\DAV\Exception;
 use Sabre\DAV;
 
 /**
- * InvalidSyncToken 
+ * InvalidSyncToken
  *
  * This exception is emited for the {DAV:}valid-sync-token pre-condition, as
  * defined in rfc6578, section 3.2.
  *
  * http://tools.ietf.org/html/rfc6578#section-3.2
  *
- * This is emitted in cases where the the sync-token, supplied by a client is 
+ * This is emitted in cases where the the sync-token, supplied by a client is
  * either completely unknown, or has expired.
  *
  * @author Evert Pot (http://evertpot.com/)

--- a/lib/DAV/PartialUpdate/Plugin.php
+++ b/lib/DAV/PartialUpdate/Plugin.php
@@ -189,7 +189,7 @@ class Plugin extends DAV\ServerPlugin {
 
     }
 
-   /**
+    /**
      * Returns the HTTP custom range update header
      *
      * This method returns null if there is no well-formed HTTP range request

--- a/lib/DAV/URLUtil.php
+++ b/lib/DAV/URLUtil.php
@@ -7,13 +7,13 @@ use Sabre\HTTP;
 /**
  * URLUtil
  *
- * This file moved to the HTTP package and is now deprecated. Use 
+ * This file moved to the HTTP package and is now deprecated. Use
  * Sabre\HTTP\URLUtil instead.
  *
- * This file will be removed in a future version. 
- * 
+ * This file will be removed in a future version.
+ *
  * @copyright Copyright (C) 2007-2014 fruux GmbH. All rights reserved.
- * @author Evert Pot (http://evertpot.com/) 
+ * @author Evert Pot (http://evertpot.com/)
  * @deprecated Use Sabre\HTTP\URLUtil instead!
  * @license http://sabre.io/license/ Modified BSD License
  */


### PR DESCRIPTION
Even if the latest stable version of phpcs runs fine, the latest experimental version (2.0.0~rc1) notices a few details to fix.
The proposed fix was automatically generated by phpcbf, available in the latest experimental version of php_codesniffer.
