### PR TITLE
Hardcoded table name

### DIFF
--- a/lib/CalDAV/Backend/PDO.php
+++ b/lib/CalDAV/Backend/PDO.php
@@ -766,9 +766,9 @@ class PDO extends AbstractBackend implements SyncSupport, SubscriptionSupport, S
 SELECT
     calendars.uri AS calendaruri, calendarobjects.uri as objecturi
 FROM
-    $this->calendarObjectTableName
+    $this->calendarObjectTableName AS calendarobjects
 LEFT JOIN
-    calendars
+    $this->calendarTableName AS calendars
     ON calendarobjects.calendarid = calendars.id
 WHERE
     calendars.principaluri = ?


### PR DESCRIPTION
- No longer using hardcoded table name (reported in #541).
