### PR TITLE
Add a test for a full synchronization after changes

### DIFF
--- a/tests/Sabre/CalDAV/Backend/AbstractPDOTest.php
+++ b/tests/Sabre/CalDAV/Backend/AbstractPDOTest.php
@@ -684,6 +684,14 @@ abstract class AbstractPDOTest extends \PHPUnit_Framework_TestCase {
             'added'     => ["todo3.ics"],
         ], $result);
 
+        $result = $backend->getChangesForCalendar($id, null, 1);
+
+        $this->assertEquals([
+            'syncToken' => 6,
+            'modified' => [],
+            'deleted' => [],
+            'added' => ["todo1.ics", "todo3.ics"],
+        ], $result);
     }
 
     function testCreateSubscriptions() {


### PR DESCRIPTION
In our non-PDO backend I had some lines without coverage that could be solved by adding this test and I thought it wouldn't hurt to add it to core sabre-dav too.
