### PR TITLE
text/x-card is deprecated in favour of text/card

### DIFF
--- a/lib/DAV/Browser/GuessContentType.php
+++ b/lib/DAV/Browser/GuessContentType.php
@@ -41,7 +41,7 @@ class GuessContentType extends DAV\ServerPlugin {
 
         // groupware
         'ics' => 'text/calendar',
-        'vcf' => 'text/x-vcard',
+        'vcf' => 'text/vcard',
 
         // text
         'txt' => 'text/plain',


### PR DESCRIPTION
Quoting the [RFC6350, Section 10.1. Media Type Registration](https://tools.ietf.org/html/rfc6350#section-10.1):

> ```
>   In addition, the following media types are known to have been used
>   to refer to vCard data.  They should be considered deprecated in
>   favor of text/vcard.
> 
>   *  text/directory
>   *  text/directory; profile=vcard
>   *  text/x-vcard
> ```
