### PR TITLE
Replace `scandir` by `FilesystemIterator`

### DIFF
--- a/lib/DAV/FS/Directory.php
+++ b/lib/DAV/FS/Directory.php
@@ -92,7 +92,16 @@ class Directory extends Node implements DAV\ICollection, DAV\IQuota {
     function getChildren() {
 
         $nodes = [];
-        foreach(scandir($this->path) as $node) if($node!='.' && $node!='..') $nodes[] = $this->getChild($node);
+        $iterator = new \FilesystemIterator(
+            $this->path,
+            \FilesystemIterator::CURRENT_AS_SELF
+          | \FilesystemIterator::SKIP_DOTS
+        );
+        foreach($iterator as $entry) {
+
+            $nodes[] = $this->getChild($entry->getFilename());
+
+        }
         return $nodes;
 
     }

--- a/lib/DAV/FSExt/Directory.php
+++ b/lib/DAV/FSExt/Directory.php
@@ -116,7 +116,21 @@ class Directory extends Node implements DAV\ICollection, DAV\IQuota, DAV\IMoveTa
     function getChildren() {
 
         $nodes = [];
-        foreach(scandir($this->path) as $node) if($node!='.' && $node!='..' && $node!='.sabredav') $nodes[] = $this->getChild($node);
+        $iterator = new \FilesystemIterator(
+            $this->path,
+            \FilesystemIterator::CURRENT_AS_SELF
+          | \FilesystemIterator::SKIP_DOTS
+        );
+        foreach($iterator as $entry) {
+
+            $node = $entry->getFilename();
+
+            if($node === '.sabredav')
+                continue;
+
+            $nodes[] = $this->getChild($node);
+
+        }
         return $nodes;
 
     }


### PR DESCRIPTION
1. `scandir` is slow compared to `FilesystemIterator`,
2. `FilesystemIterator::SKIP_DOTS` is cross-FS,
3. using an iterator is better than looping on a huge array (in the case
   where there is a lot of entries in the directory), it saves memory.
