### PR TITLE
Use VObject\Writer in CalDAV and CardDAV exporters

### DIFF
--- a/lib/CalDAV/ICSExportPlugin.php
+++ b/lib/CalDAV/ICSExportPlugin.php
@@ -244,10 +244,10 @@ class ICSExportPlugin extends DAV\ServerPlugin {
 
         switch($format) {
             case 'text/calendar' :
-                $mergedCalendar = $mergedCalendar->serialize();
+                $mergedCalendar = VObject\Writer::write($mergedCalendar);
                 break;
             case 'application/calendar+json' :
-                $mergedCalendar = json_encode($mergedCalendar->jsonSerialize());
+                $mergedCalendar = VObject\Writer::writeJson($mergedCalendar);
                 break;
         }
 

--- a/lib/CardDAV/VCFExportPlugin.php
+++ b/lib/CardDAV/VCFExportPlugin.php
@@ -99,8 +99,7 @@ class VCFExportPlugin extends DAV\ServerPlugin {
             $nodeData = $node[200]['{' . Plugin::NS_CARDDAV . '}address-data'];
 
             // Parsing this node so VObject can clean up the output.
-            $output .=
-               VObject\Reader::read($nodeData)->serialize();
+            $output .= VObject\Writer::write(VObject\Reader::read($nodeData));
 
         }
 


### PR DESCRIPTION
When sabre/dav will use a version of sabre/vobject that includes `Sabre\VObject\Writer`, we could merge this PR.
