### PR TITLE
DAV-Filesystem: Allow browsing of directorys with broken symlinks

### DIFF
--- a/lib/DAV/FS/Directory.php
+++ b/lib/DAV/FS/Directory.php
@@ -73,7 +73,11 @@ class Directory extends Node implements DAV\ICollection, DAV\IQuota {
 
         $path = $this->path . '/' . $name;
 
-        if (!file_exists($path)) throw new DAV\Exception\NotFound('File with name ' . $path . ' could not be located');
+        if (!$this->childExists($name)) {
+
+            throw new DAV\Exception\NotFound('File with name ' . $path . ' could not be located');
+
+        }
 
         if (is_dir($path)) {
 
@@ -118,7 +122,7 @@ class Directory extends Node implements DAV\ICollection, DAV\IQuota {
     function childExists($name) {
 
         $path = $this->path . '/' . $name;
-        return file_exists($path);
+        return file_exists($path) || is_link($path);
 
     }
 

--- a/lib/DAV/FS/Node.php
+++ b/lib/DAV/FS/Node.php
@@ -96,7 +96,14 @@ abstract class Node implements INode {
      */
     function getLastModified() {
 
-        return filemtime($this->path);
+        $time = @filemtime($this->path);
+        if ($time === false) {
+
+            // broken symlink?
+            $time = lstat($this->path)['mtime'];
+
+        }
+        return $time;
 
     }
 

--- a/tests/Sabre/DAV/FS/DirectoryTest.php
+++ b/tests/Sabre/DAV/FS/DirectoryTest.php
@@ -1,0 +1,63 @@
+<?php declare (strict_types=1);
+
+namespace Sabre\DAV\FS;
+
+class DirectoryTest extends \PHPUnit_Framework_TestCase {
+
+    function setUp() {
+
+        file_put_contents(SABRE_TEMPDIR . '/file.txt', 'Contents');
+        symlink('missing-file', SABRE_TEMPDIR . '/symlink');
+
+    }
+
+    function tearDown() {
+
+        \Sabre\TestUtil::clearTempDir();
+
+    }
+
+    function create() {
+
+        return new Directory(SABRE_TEMPDIR);
+
+    }
+
+    function testCreate() {
+
+        $dir = $this->create();
+        $this->assertEquals(basename(SABRE_TEMPDIR), $dir->getName());
+
+    }
+
+    function testChildExists() {
+
+        $dir = $this->create();
+        $this->assertFalse($dir->childExists('notfound.txt'));
+
+    }
+
+    function testChildExistsBrokenSymlink() {
+
+        $dir = $this->create();
+        $this->assertTrue($dir->childExists('symlink'));
+
+    }
+
+    function testChildExistsNormal() {
+
+        $dir = $this->create();
+        $this->assertTrue($dir->childExists('file.txt'));
+
+    }
+
+    /**
+     * @expectedException \Sabre\DAV\Exception\NotFound
+     */
+    function testGetChildNotFound() {
+
+        $dir = $this->create();
+        $dir->getChild('notfound.txt');
+
+    }
+}

--- a/tests/Sabre/DAV/FS/FileTest.php
+++ b/tests/Sabre/DAV/FS/FileTest.php
@@ -1,0 +1,99 @@
+<?php declare (strict_types=1);
+
+namespace Sabre\DAV\FS;
+
+require_once 'Sabre/TestUtil.php';
+
+class FileTest extends \PHPUnit_Framework_TestCase {
+
+    function setUp() {
+
+        file_put_contents(SABRE_TEMPDIR . '/file.txt', 'Contents');
+        symlink('missing-file', SABRE_TEMPDIR . '/symlink');
+
+    }
+
+    function tearDown() {
+
+        \Sabre\TestUtil::clearTempDir();
+
+    }
+
+    function testPut() {
+
+        $filename = SABRE_TEMPDIR . '/file.txt';
+        $file = new File($filename);
+        $result = $file->put('New contents');
+
+        $this->assertEquals('New contents', file_get_contents(SABRE_TEMPDIR . '/file.txt'));
+
+    }
+
+    function testGet() {
+
+        $file = new File(SABRE_TEMPDIR . '/file.txt');
+        $this->assertEquals('Contents', stream_get_contents($file->get()));
+
+    }
+
+    function testDelete() {
+
+        $file = new File(SABRE_TEMPDIR . '/file.txt');
+        $file->delete();
+
+        $this->assertFalse(file_exists(SABRE_TEMPDIR . '/file.txt'));
+
+    }
+
+    function testGetETag() {
+
+        $filename = SABRE_TEMPDIR . '/file.txt';
+        $file = new File($filename);
+        $this->assertEquals(
+            '"' .
+            sha1(
+                fileinode($filename) .
+                filesize($filename) .
+                filemtime($filename)
+            ) . '"',
+            $file->getETag()
+        );
+    }
+
+    function testGetETagBrokenSymlink() {
+
+        $filename = SABRE_TEMPDIR . '/symlink';
+        $file = new File($filename);
+        $this->assertEquals(
+            '"' .
+            sha1(
+                lstat($filename)['ino'] .
+                0 .
+                $time = lstat($filename)['mtime']
+            ) . '"',
+            $file->getETag()
+        );
+    }
+
+    function testGetContentType() {
+
+        $file = new File(SABRE_TEMPDIR . '/file.txt');
+        $this->assertNull($file->getContentType());
+
+    }
+
+    function testGetSize() {
+
+        $file = new File(SABRE_TEMPDIR . '/file.txt');
+        $this->assertEquals(8, $file->getSize());
+
+    }
+
+    function testGetSizeBrokenSymlink() {
+
+        $file = new File(SABRE_TEMPDIR . '/symlink');
+        $this->assertEquals(0, $file->getSize());
+
+    }
+
+}

--- a/tests/Sabre/TestUtil.php
+++ b/tests/Sabre/TestUtil.php
@@ -22,7 +22,7 @@ class TestUtil {
 
             if ($node == '.' || $node == '..') continue;
             $myPath = $path . '/' . $node;
-            if (is_file($myPath)) {
+            if (is_file($myPath) || is_link($myPath)) {
                 unlink($myPath);
             } else {
                 self::deleteTree($myPath);


### PR DESCRIPTION
Broken symlinks inside a Directory cause E_WARNINGs and prevent clients from viewing this directory.
This is a very simple Solution.
