### PR TITLE
Update Client.php

### DIFF
--- a/lib/DAV/Client.php
+++ b/lib/DAV/Client.php
@@ -217,6 +217,10 @@ class Client extends HTTP\Client {
 
             $prop->appendChild($element);
         }
+        
+        if (!$prop->hasChildNodes()) {
+            $prop = $dom->createElement('d:allprop');
+        }
 
         $dom->appendChild($root)->appendChild($prop);
         $body = $dom->saveXML();


### PR DESCRIPTION
Noted that on older WebDAV servers, a self closed d:prop will return a 400 Bad Request when no properties are provided.  Added modification to check for properties, if none found instead use d:allprop.