### PR TITLE
ICSExportPlugin filter component automatically if time-range

### DIFF
--- a/lib/CalDAV/ICSExportPlugin.php
+++ b/lib/CalDAV/ICSExportPlugin.php
@@ -110,12 +110,14 @@ class ICSExportPlugin extends DAV\ServerPlugin {
                 throw new BadRequest('The start= parameter must contain a unix timestamp');
             }
             $start = DateTime::createFromFormat('U', $queryParams['start']);
+            $componentType = 'VEVENT';
         }
         if (isset($queryParams['end'])) {
             if (!ctype_digit($queryParams['end'])) {
                 throw new BadRequest('The end= parameter must contain a unix timestamp');
             }
             $end = DateTime::createFromFormat('U', $queryParams['end']);
+            $componentType = 'VEVENT';
         }
         if (isset($queryParams['expand']) && !!$queryParams['expand']) {
             if (!$start || !$end) {


### PR DESCRIPTION
The [documentation](http://sabre.io/dav/ics-export-plugin/) mentions that "Using start, end or expand automatically filters out VTODO and VJOURNAL, because only VEVENT is currently supported." It is currently not the case. This commit fixes https://github.com/fruux/Baikal/issues/698.