### PR TITLE
Empty default timezone with freeBusyQueryReport

### DIFF
--- a/lib/CalDAV/Plugin.php
+++ b/lib/CalDAV/Plugin.php
@@ -687,7 +687,7 @@ class Plugin extends DAV\ServerPlugin {
         // times.
         $calendarProps = $this->server->getProperties($uri, [$tzProp]);
 
-        if (isset($calendarProps[$tzProp])) {
+        if (isset($calendarProps[$tzProp]) && !empty($calendarProps[$tzProp])) {
             $vtimezoneObj = VObject\Reader::read($calendarProps[$tzProp]);
             $calendarTimeZone = $vtimezoneObj->VTIMEZONE->getTimeZone();
             // Destroy circular references so PHP will garbage collect the object.


### PR DESCRIPTION
If the default timezone for the calendar is an empty string, `VObject\Reader` will return `EofException`. Why the timezone is an empty string should be investigated! This fixes https://github.com/fruux/Baikal/issues/697