### PR TITLE
Make sure that files that are siblings of directories, are reported as files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 ChangeLog
 =========
 
+3.2.3 (????-??-??)
+------------------
+
+* #982: Make sure that files that are siblings of directories, are reported
+  as files (@nickvergessen)
+
 3.2.2 (2017-02-14)
 ------------------
 

--- a/lib/DAV/Server.php
+++ b/lib/DAV/Server.php
@@ -893,15 +893,16 @@ class Server extends EventEmitter implements LoggerAwareInterface {
             $newDepth--;
         }
 
+        $propertyNames = $propFind->getRequestedProperties();
+        $propFindType = !empty($propertyNames) ? PropFind::NORMAL : PropFind::ALLPROPS;
+
         foreach ($this->tree->getChildren($path) as $childNode) {
-            $subPropFind = clone $propFind;
-            $subPropFind->setDepth($newDepth);
             if ($path !== '') {
                 $subPath = $path . '/' . $childNode->getName();
             } else {
                 $subPath = $childNode->getName();
             }
-            $subPropFind->setPath($subPath);
+            $subPropFind = new PropFind($subPath, $propertyNames, $newDepth, $propFindType);
 
             yield [
                 $subPropFind,


### PR DESCRIPTION
Without the patch, the two files are reported to be a collection:
```xml
...
	<d:response>
		<d:href>/col/col/test.txt</d:href>
		<d:propstat>
			<d:prop>
				<d:resourcetype>
					<d:collection/>
				</d:resourcetype>
			</d:prop>
			<d:status>HTTP/1.1 200 OK</d:status>
		</d:propstat>
	</d:response>
...
	<d:response>
		<d:href>/dir/child.txt</d:href>
		<d:propstat>
			<d:prop>
				<d:resourcetype>
					<d:collection/>
				</d:resourcetype>
			</d:prop>
			<d:status>HTTP/1.1 200 OK</d:status>
		</d:propstat>
	</d:response>
...
```

Reported in https://github.com/nextcloud/server/issues/5543 Proposed patch is from @blancjerome I just wrote the test case and cleaned it up a bit...