### PR TITLE
WIP: Added php 7.2 to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: php
 php:
   - 7.0
   - 7.1
+  - 7.2
 
 env:
   global:


### PR DESCRIPTION
Interessting... 

> count(): Parameter must be an array or an object that implements Countable

Seems we rely on non countable params.. needs fixing