### PR TITLE
Fix an inconsistency with RFC 7230 3.3.3 which clearly states:

### DIFF
--- a/lib/DAV/CorePlugin.php
+++ b/lib/DAV/CorePlugin.php
@@ -288,8 +288,7 @@ class CorePlugin extends ServerPlugin {
         $this->server->emit('afterUnbind', [$path]);
 
         $response->setStatus(204);
-        $response->setHeader('Content-Length', '0');
-
+        
         // Sending back false will interrupt the event chain and tell the server
         // we've handled this method.
         return false;
@@ -514,7 +513,6 @@ class CorePlugin extends ServerPlugin {
                 return false;
             }
 
-            $response->setHeader('Content-Length', '0');
             if ($etag) $response->setHeader('ETag', $etag);
             $response->setStatus(204);
 
@@ -650,7 +648,10 @@ class CorePlugin extends ServerPlugin {
         $this->server->emit('afterBind', [$moveInfo['destination']]);
 
         // If a resource was overwritten we should send a 204, otherwise a 201
-        $response->setHeader('Content-Length', '0');
+        if (!$moveInfo['destinationExists']) {
+            $response->setHeader('Content-Length', '0');
+        }
+        
         $response->setStatus($moveInfo['destinationExists'] ? 204 : 201);
 
         // Sending back false will interrupt the event chain and tell the server
@@ -685,7 +686,10 @@ class CorePlugin extends ServerPlugin {
         $this->server->emit('afterBind', [$copyInfo['destination']]);
 
         // If a resource was overwritten we should send a 204, otherwise a 201
-        $response->setHeader('Content-Length', '0');
+        if (!$moveInfo['destinationExists']) {
+            $response->setHeader('Content-Length', '0');
+        }
+        
         $response->setStatus($copyInfo['destinationExists'] ? 204 : 201);
 
         // Sending back false will interrupt the event chain and tell the server

--- a/tests/Sabre/DAV/FSExt/ServerTest.php
+++ b/tests/Sabre/DAV/FSExt/ServerTest.php
@@ -121,8 +121,6 @@ class ServerTest extends DAV\AbstractServer{
         $this->server->httpRequest = ($request);
         $this->server->exec();
 
-        $this->assertEquals('0', $this->response->getHeader('Content-Length'));
-
         $this->assertEquals(204, $this->response->status);
         $this->assertEquals('', $this->response->body);
         $this->assertEquals('Testing updated file', file_get_contents($this->tempDir . '/test.txt'));
@@ -136,8 +134,7 @@ class ServerTest extends DAV\AbstractServer{
         $this->server->exec();
 
         $this->assertEquals([
-            'X-Sabre-Version' => [DAV\Version::VERSION],
-            'Content-Length'  => ['0'],
+            'X-Sabre-Version' => [DAV\Version::VERSION]
         ], $this->response->getHeaders());
 
         $this->assertEquals(204, $this->response->status);

--- a/tests/Sabre/DAV/HttpDeleteTest.php
+++ b/tests/Sabre/DAV/HttpDeleteTest.php
@@ -48,8 +48,7 @@ class HttpDeleteTest extends DAVServerTest {
 
         $this->assertEquals(
             [
-                'X-Sabre-Version' => [Version::VERSION],
-                'Content-Length'  => ['0'],
+                'X-Sabre-Version' => [Version::VERSION]
             ],
             $response->getHeaders()
         );
@@ -74,7 +73,6 @@ class HttpDeleteTest extends DAVServerTest {
         $this->assertEquals(
             [
                 'X-Sabre-Version' => [Version::VERSION],
-                'Content-Length'  => ['0'],
             ],
             $response->getHeaders()
         );


### PR DESCRIPTION
A server MUST NOT send a Content-Length header field in any response
with a status code of 1xx (Informational) or 204 (No Content)

This violation breaks applications behind OpenBSD relayd (version 1.61 and up) load balancer running http protocol handler as the relayd’s http protocol hendler implementation very closely follows RFC. This issue appears with HTTP method DELETE but other method, which return 204 are affected as well.