### PR TITLE
[3.2] Fix copyNode for case of file named 0

### DIFF
--- a/lib/DAV/Tree.php
+++ b/lib/DAV/Tree.php
@@ -298,7 +298,9 @@ class Tree {
      */
     protected function copyNode(INode $source, ICollection $destinationParent, $destinationName = null) {
 
-        if (!$destinationName) $destinationName = $source->getName();
+        if ((string)$destinationName === '') {
+            $destinationName = $source->getName();
+        }
 
         if ($source instanceof IFile) {
 

--- a/tests/Sabre/DAV/TreeTest.php
+++ b/tests/Sabre/DAV/TreeTest.php
@@ -24,6 +24,22 @@ class TreeTest extends \PHPUnit_Framework_TestCase {
 
     }
 
+    function testCopyFile() {
+
+        $tree = new TreeMock();
+        $tree->copy('hi/file', 'hi/newfile');
+
+        $this->assertArrayHasKey('newfile', $tree->getNodeForPath('hi')->newFiles);
+    }
+
+    function testCopyFile0() {
+
+        $tree = new TreeMock();
+        $tree->copy('hi/file', 'hi/0');
+
+        $this->assertArrayHasKey('0', $tree->getNodeForPath('hi')->newFiles);
+    }
+
     function testMove() {
 
         $tree = new TreeMock();


### PR DESCRIPTION
Backport #1022 to 3.2 branch
Issue #1021 