### PR TITLE
Fix for #1026: return only calendar objects owned by principal itself

### DIFF
--- a/lib/CalDAV/Backend/AbstractBackend.php
+++ b/lib/CalDAV/Backend/AbstractBackend.php
@@ -162,7 +162,7 @@ abstract class AbstractBackend implements BackendInterface {
      *
      * If the uid is not found, return null.
      *
-     * This method should only consider * objects that the principal owns, so
+     * This method should only consider objects that the principal owns, so
      * any calendars owned by other principals that also appear in this
      * collection should be ignored.
      *

--- a/lib/CalDAV/Backend/PDO.php
+++ b/lib/CalDAV/Backend/PDO.php
@@ -873,7 +873,7 @@ SQL
      *
      * If the uid is not found, return null.
      *
-     * This method should only consider * objects that the principal owns, so
+     * This method should only consider objects that the principal owns, so
      * any calendars owned by other principals that also appear in this
      * collection should be ignored.
      *
@@ -895,6 +895,8 @@ WHERE
     calendar_instances.principaluri = ?
     AND
     calendarobjects.uid = ?
+    AND
+    calendar_instances.access = 1
 SQL;
 
         $stmt = $this->pdo->prepare($query);


### PR DESCRIPTION
Align the implementation of `getCalendarObjectByUID` with its documentation. 

I'd love to provide a unit test for #1026 that proves this actually fixes it, but I have zero experience with PHP development, so this would take prohibitively long. I did test it manually though (in 3.2.2)!

Thank you!