### PR TITLE
Add codecov.io integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ env:
     - SABRE_MYSQLPASS=""
     - SABRE_MYSQLDSN="mysql:host=127.0.0.1;dbname=sabredav_test"
   matrix:
-    - LOWEST_DEPS="" TEST_DEPS=""
-    - LOWEST_DEPS="--prefer-lowest" TEST_DEPS="tests/Sabre/"
+    - LOWEST_DEPS="" TEST_DEPS="" WITH_COVERAGE="--coverage-clover=coverage.xml"
+    - LOWEST_DEPS="--prefer-lowest" TEST_DEPS="tests/Sabre/" $WITH_COVERAGE=""
 
 services:
   - mysql
@@ -33,7 +33,8 @@ addons:
    postgresql: "9.5"
 
 script:
-  - ./bin/phpunit --verbose --configuration tests/phpunit.xml.dist $TEST_DEPS
+  - ./bin/phpunit --verbose --configuration tests/phpunit.xml.dist $WITH_COVERAGE $TEST_DEPS
+  - rm -f ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini
   - ./bin/sabre-cs-fixer fix . --dry-run --diff
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,9 @@ script:
   - ./bin/phpunit --verbose --configuration tests/phpunit.xml.dist $TEST_DEPS
   - ./bin/sabre-cs-fixer fix . --dry-run --diff
 
+after_success:
+  - bash <(curl -s https://codecov.io/bash)
+
 cache:
   directories:
     - $HOME/.composer/cache


### PR DESCRIPTION
## ToDo:
- [x] only enable coverage generation selectively - the execution time is extremly higher with coverage generation
- [ ] maybe use phpdbg for coverage runs - see https://hackernoon.com/generating-code-coverage-with-phpunite-and-phpdbg-4d20347ffb45
- [x] make decision to enable this at all