### PR TITLE
Support for custom copy operations

### DIFF
--- a/lib/DAV/FSExt/Directory.php
+++ b/lib/DAV/FSExt/Directory.php
@@ -12,7 +12,7 @@ use Sabre\DAV\FS\Node;
  * @author Evert Pot (http://evertpot.com/)
  * @license http://sabre.io/license/ Modified BSD License
  */
-class Directory extends Node implements DAV\ICollection, DAV\IQuota, DAV\IMoveTarget {
+class Directory extends Node implements DAV\ICollection, DAV\IQuota, DAV\IMoveTarget, DAV\ICopyTarget {
 
     /**
      * Creates a new file in the directory
@@ -203,6 +203,35 @@ class Directory extends Node implements DAV\ICollection, DAV\IQuota, DAV\IMoveTa
         // long as they are defined in a class that has a shared inheritance
         // with the current class.
         rename($sourceNode->path, $this->path . '/' . $targetName);
+
+        return true;
+
+    }
+
+    /**
+     * Copies a node into this collection.
+     *
+     * It is up to the implementors to:
+     *   1. Create the new resource.
+     *   2. Copy the data and any properties.
+     *
+     * If you return true from this function, the assumption
+     * is that the copy was successful.
+     * If you return false, sabre/dav will handle the copy itself.
+     *
+     * @param string $targetName New local file/collection name.
+     * @param string $sourcePath Full path to source node
+     * @param DAV\INode $sourceNode Source node itself
+     * @return bool
+     */
+    function copyInto($targetName, $sourcePath, DAV\INode $sourceNode) {
+
+        // We only support FSExt\File objects for now.
+        if (!$sourceNode instanceof File) {
+            return false;
+        }
+
+        copy($sourceNode->path, $this->path . '/' . $targetName);
 
         return true;
 

--- a/lib/DAV/ICopyTarget.php
+++ b/lib/DAV/ICopyTarget.php
@@ -1,0 +1,36 @@
+<?php declare (strict_types=1);
+
+namespace Sabre\DAV;
+
+/**
+ * By implementing this interface, a collection can effectively say "other
+ * nodes may be copied into this collection".
+ *
+ * If a backend supports a better optimized copy operation, e.g. by avoiding
+ * copying the contents, this can trigger some huge speed gains.
+ *
+ * @copyright Copyright (C) fruux GmbH (https://fruux.com/)
+ * @author Evert Pot (http://evertpot.com/)
+ * @license http://sabre.io/license/ Modified BSD License
+ */
+interface ICopyTarget extends ICollection {
+
+    /**
+     * Copies a node into this collection.
+     *
+     * It is up to the implementors to:
+     *   1. Create the new resource.
+     *   2. Copy the data and any properties.
+     *
+     * If you return true from this function, the assumption
+     * is that the copy was successful.
+     * If you return false, sabre/dav will handle the copy itself.
+     *
+     * @param string $targetName New local file/collection name.
+     * @param string $sourcePath Full path to source node
+     * @param INode $sourceNode Source node itself
+     * @return bool
+     */
+    function copyInto($targetName, $sourcePath, INode $sourceNode);
+
+}

--- a/lib/DAV/Tree.php
+++ b/lib/DAV/Tree.php
@@ -127,7 +127,10 @@ class Tree {
         list($destinationDir, $destinationName) = Uri\split($destinationPath);
 
         $destinationParent = $this->getNodeForPath($destinationDir);
-        $this->copyNode($sourceNode, $destinationParent, $destinationName);
+        // Check if the target can handle the copy itself. If not, we do it ourselves.
+        if (!$destinationParent instanceof ICopyTarget || !$destinationParent->copyInto($destinationName, $sourcePath, $sourceNode)) {
+            $this->copyNode($sourceNode, $destinationParent, $destinationName);
+        }
 
         $this->markDirty($destinationDir);
 

--- a/tests/Sabre/DAV/FSExt/ServerTest.php
+++ b/tests/Sabre/DAV/FSExt/ServerTest.php
@@ -243,4 +243,25 @@ class ServerTest extends DAV\AbstractServer{
         );
 
     }
+
+    function testCopy() {
+
+        mkdir($this->tempDir . '/testcol');
+
+        $request = new HTTP\Request('COPY', '/test.txt', ['Destination' => '/testcol/test2.txt']);
+        $this->server->httpRequest = ($request);
+        $this->server->exec();
+
+        $this->assertEquals(201, $this->response->status);
+        $this->assertEquals('', $this->response->body);
+
+        $this->assertEquals([
+            'Content-Length'  => ['0'],
+            'X-Sabre-Version' => [DAV\Version::VERSION],
+        ], $this->response->getHeaders());
+
+        $this->assertTrue(is_file($this->tempDir . '/test.txt'));
+        $this->assertTrue(is_file($this->tempDir . '/testcol/test2.txt'));
+
+    }
 }


### PR DESCRIPTION
This patch adds support for custom copy operations (in the same spirit as `IMoveTarget`). It helps especially in cases when users copy large file trees or when the underlying system supports some kind of copy-on-write technique.