### PR TITLE
[WIP] Feature PSR-7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: php
 php:
+  - 7.0
   - 7.1
-  - 7.2
-
 env:
   global:
     - SABRE_MYSQLUSER="root"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: php
 php:
-  - 7.0
   - 7.1
+  - 7.2
+  - nightly
 env:
   global:
     - SABRE_MYSQLUSER="root"

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ before_script:
   - psql -c "create database sabredav_test" -U postgres
   - psql -c "create user sabredav with PASSWORD 'sabredav';GRANT ALL PRIVILEGES ON DATABASE sabredav_test TO sabredav" -U postgres
   - composer update --prefer-dist $LOWEST_DEPS
-
+  - cat -n tests/Sabre/DAV/FSExt/ServerTest.php
 # Required for postgres 9.5
 dist: trusty
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,6 @@ script:
 after_success:
   - bash <(curl -s https://codecov.io/bash)
 
-cache:
-  directories:
-    - $HOME/.composer/cache
+#cache:
+#  directories:
+#    - $HOME/.composer/cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ addons:
 script:
   - ./bin/phpunit --verbose --configuration tests/phpunit.xml.dist $WITH_COVERAGE $TEST_DEPS
   - rm -f ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini
-  - ./bin/sabre-cs-fixer fix . --dry-run --diff
+#  - ./bin/sabre-cs-fixer fix . --dry-run --diff
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,6 @@ before_script:
   - psql -c "create database sabredav_test" -U postgres
   - psql -c "create user sabredav with PASSWORD 'sabredav';GRANT ALL PRIVILEGES ON DATABASE sabredav_test TO sabredav" -U postgres
   - composer update --prefer-dist $LOWEST_DEPS
-  - cat -n tests/Sabre/DAV/FSExt/ServerTest.php
 # Required for postgres 9.5
 dist: trusty
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: php
 php:
-  - 7.0
   - 7.1
+  - 7.2
 
 env:
   global:
@@ -21,7 +21,7 @@ sudo: false
 
 before_script:
 #  - mysql -u root -h 127.0.0.1 sabredav_test -e 'SELECT VERSION();'
-#- mysql -u root -h 127.0.0.1 -e 'create database sabredav_test'
+  - mysql -u root -h 127.0.0.1 -e 'create database sabredav_test'
   - psql -c "create database sabredav_test" -U postgres
   - psql -c "create user sabredav with PASSWORD 'sabredav';GRANT ALL PRIVILEGES ON DATABASE sabredav_test TO sabredav" -U postgres
   - composer update --prefer-dist $LOWEST_DEPS

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,6 @@ script:
 after_success:
   - bash <(curl -s https://codecov.io/bash)
 
-#cache:
-#  directories:
-#    - $HOME/.composer/cache
+cache:
+  directories:
+    - $HOME/.composer/cache

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": ">=7.1.0",
+        "php": ">=7.0.0",
         "sabre/vobject": "^4.1.5",
         "sabre/event" : "^5.0.3",
         "sabre/xml"  : "^2.0.0",

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,8 @@
         "lib-libxml" : ">=2.7.0",
         "psr/log": "^1.0",
         "psr/http-message": "^1.0",
-        "psr/http-server-handler": "^1.0"
+        "psr/http-server-handler": "^1.0",
+        "http-interop/response-sender": "^1.0"
     },
     "require-dev" : {
         "phpunit/phpunit" : "^7.0.0",

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,8 @@
         "ext-iconv" : "*",
         "lib-libxml" : ">=2.7.0",
         "psr/log": "^1.0",
-        "psr/http-message": "^1.0"
+        "psr/http-message": "^1.0",
+        "psr/http-server-handler": "^1.0"
     },
     "require-dev" : {
         "phpunit/phpunit" : "> 4.8, <6.0.0",

--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,8 @@
     ],
     "require": {
         "php": ">=7.1.0",
-        "sabre/vobject": "^4.1.2",
-        "sabre/event" : "^5.0",
+        "sabre/vobject": "^4.1.5",
+        "sabre/event" : "^5.0.3",
         "sabre/xml"  : "^2.0.0",
         "sabre/http" : "dev-master",
         "sabre/uri" : "^2.0",
@@ -34,7 +34,7 @@
         "psr/http-server-handler": "^1.0"
     },
     "require-dev" : {
-        "phpunit/phpunit" : "> 4.8, <6.0.0",
+        "phpunit/phpunit" : "^6.0.0",
         "evert/phpdoc-md" : "~0.1.0",
         "sabre/cs"        : "^1.0.0",
         "monolog/monolog": "^1.18",
@@ -54,7 +54,7 @@
     },
     "support" : {
         "forum" : "https://groups.google.com/group/sabredav-discuss",
-        "source" : "https://github.com/fruux/sabre-dav"
+        "source" : "https://github.com/sabre-io/dav"
     },
     "bin" : [
         "bin/sabredav",

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": ">=5.5.0",
+        "php": ">=7.1.0",
         "sabre/vobject": "^4.1.2",
         "sabre/event" : "^5.0",
         "sabre/xml"  : "^2.0.0",
@@ -29,13 +29,15 @@
         "ext-date" : "*",
         "ext-iconv" : "*",
         "lib-libxml" : ">=2.7.0",
-        "psr/log": "^1.0"
+        "psr/log": "^1.0",
+        "psr/http-message": "^1.0"
     },
     "require-dev" : {
         "phpunit/phpunit" : "> 4.8, <6.0.0",
         "evert/phpdoc-md" : "~0.1.0",
         "sabre/cs"        : "^1.0.0",
-        "monolog/monolog": "^1.18"
+        "monolog/monolog": "^1.18",
+        "guzzlehttp/psr7": "^1.4"
     },
     "suggest" : {
         "ext-curl" : "*",

--- a/composer.json
+++ b/composer.json
@@ -34,9 +34,8 @@
         "psr/http-server-handler": "^1.0"
     },
     "require-dev" : {
-        "phpunit/phpunit" : "^6.0.0",
+        "phpunit/phpunit" : "^7.0.0",
         "evert/phpdoc-md" : "~0.1.0",
-        "sabre/cs"        : "^1.0.0",
         "monolog/monolog": "^1.18",
         "guzzlehttp/psr7": "^1.4"
     },

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,10 +26,11 @@ services:
       SABRE_PGSQLDSN: pgsql:host=pgsql;dbname=test;user=root;password=secret
     image: phpunit/phpunit
     tty: true
+    working_dir: /project
     entrypoint: [
-      "/project/bin/phpunit",
+      "bin/phpunit",
       "-c",
-      "/project/tests/phpunit.xml.dist"
+      "tests/phpunit.xml.dist"
     ]
     volumes:
       - ./:/project

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3.4'
+services:
+  phpunit:
+    image: phpunit/phpunit
+    tty: true
+    entrypoint: [
+      "/project/bin/phpunit",
+      "-c",
+      "/project/tests/phpunit.xml.dist"
+    ]
+    volumes:
+      - ./:/project

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,29 @@
 version: '3.4'
 services:
+  pgsql:
+    image: postgres
+    environment:
+      POSTGRES_DB: test
+      POSTGRES_PASSWORD: secret
+      POSTGRES_USER: root
+    tmpfs:
+      - /var/lib/postgresql/data
+  mysql:
+    image: mysql
+    environment:
+      MYSQL_ROOT_PASSWORD: secret
+      MYSQL_DATABASE: test
+    tmpfs:
+      - /var/lib/mysql
   phpunit:
+    depends_on:
+      - mysql
+      - pgsql
+    environment:
+      SABRE_MYSQLUSER: root
+      SABRE_MYSQLPASS: secret
+      SABRE_MYSQLDSN: mysql:host=mysql;dbname=test
+      SABRE_PGSQLDSN: pgsql:host=pgsql;dbname=test;user=root;password=secret
     image: phpunit/phpunit
     tty: true
     entrypoint: [

--- a/docker/DockerFile
+++ b/docker/DockerFile
@@ -1,0 +1,1 @@
+FROM phpunit/phpunit

--- a/docker/DockerFile
+++ b/docker/DockerFile
@@ -1,1 +1,0 @@
-FROM phpunit/phpunit

--- a/lib/CalDAV/Schedule/Plugin.php
+++ b/lib/CalDAV/Schedule/Plugin.php
@@ -3,6 +3,8 @@
 namespace Sabre\CalDAV\Schedule;
 
 use DateTimeZone;
+use function GuzzleHttp\Psr7\stream_for;
+use GuzzleHttp\Psr7\StreamWrapper;
 use Sabre\CalDAV\ICalendar;
 use Sabre\CalDAV\ICalendarObject;
 use Sabre\CalDAV\Xml\Property\ScheduleCalendarTransp;
@@ -737,7 +739,8 @@ class Plugin extends ServerPlugin {
 
         // Parsing the request body
         try {
-            $vObject = VObject\Reader::read($request->getBody());
+            $body = stream_get_contents($request->getBody());
+            $vObject = VObject\Reader::read(StreamWrapper::getResource(stream_for($body)));
         } catch (VObject\ParseException $e) {
             throw new BadRequest('The request body must be a valid iCalendar object. Parse error: ' . $e->getMessage());
         }

--- a/lib/CalDAV/SharingPlugin.php
+++ b/lib/CalDAV/SharingPlugin.php
@@ -242,7 +242,6 @@ class SharingPlugin extends DAV\ServerPlugin {
         }
 
         $requestBody = $request->getBodyAsString();
-
         // If this request handler could not deal with this POST request, it
         // will return 'null' and other plugins get a chance to handle the
         // request.

--- a/lib/DAV/Client.php
+++ b/lib/DAV/Client.php
@@ -370,7 +370,7 @@ class Client extends HTTP\Client {
 
         $url = $this->getAbsoluteUrl($url);
 
-        $response = $this->send(new HTTP\Request($method, $url, $headers, $body));
+        $response = $this->send(new ServerRequest($method, $url, $headers, $body));
         return [
             'body'       => $response->getBodyAsString(),
             'statusCode' => (int)$response->getStatus(),

--- a/lib/DAV/Locks/Plugin.php
+++ b/lib/DAV/Locks/Plugin.php
@@ -242,7 +242,6 @@ class Plugin extends DAV\ServerPlugin {
             // $this->server->emit('beforeWriteContent',array($uri));
 
         } catch (DAV\Exception\NotFound $e) {
-
             // It didn't, lets create it
             $this->server->createFile($uri, fopen('php://memory', 'r'));
             $newFile = true;

--- a/lib/DAV/Psr7RequestWrapper.php
+++ b/lib/DAV/Psr7RequestWrapper.php
@@ -138,7 +138,7 @@ class Psr7RequestWrapper implements RequestInterface
      */
     function setHeader(string $name, $value)
     {
-        throw new \Exception('not used');
+        $this->request = $this->request->withHeader($name, $value);
     }
 
     /**
@@ -254,7 +254,7 @@ class Psr7RequestWrapper implements RequestInterface
      */
     function setUrl(string $url)
     {
-        throw new \Exception('not used');
+        $this->request = $this->request->withUri(new Uri($url));
     }
 
     /**

--- a/lib/DAV/Psr7RequestWrapper.php
+++ b/lib/DAV/Psr7RequestWrapper.php
@@ -239,11 +239,12 @@ class Psr7RequestWrapper implements RequestInterface
     function getUrl(): string
     {
         $uri = $this->request->getUri();
-        if ($uri instanceof  Uri) {
-            return $uri->__toString();
-        } else {
-            return Uri::composeComponents($uri->getScheme(), $uri->getAuthority(), $uri->getPath(), $uri->getQuery(), $uri->getFragment());
+        $query = $uri->getQuery();
+        if (empty($query)) {
+            return $uri->getPath();
         }
+
+        return $uri->getPath() . '?' . $query;
     }
 
     /**
@@ -304,6 +305,7 @@ class Psr7RequestWrapper implements RequestInterface
 
         // Removing duplicated slashes.
         $uri = str_replace('//', '/', $this->getUrl());
+
 
         $uri = normalize($uri);
         $baseUri = normalize($this->getBaseUrl());

--- a/lib/DAV/Psr7RequestWrapper.php
+++ b/lib/DAV/Psr7RequestWrapper.php
@@ -6,6 +6,7 @@ namespace Sabre\DAV;
 
 use function GuzzleHttp\Psr7\stream_for;
 use GuzzleHttp\Psr7\StreamWrapper;
+use GuzzleHttp\Psr7\Uri;
 use Psr\Http\Message\ServerRequestInterface;
 use function Sabre\HTTP\decodePath;
 use Sabre\HTTP\RequestInterface;
@@ -237,7 +238,12 @@ class Psr7RequestWrapper implements RequestInterface
      */
     function getUrl(): string
     {
-        return $this->request->getRequestTarget();
+        $uri = $this->request->getUri();
+        if ($uri instanceof  Uri) {
+            return $uri->__toString();
+        } else {
+            return Uri::composeComponents($uri->getScheme(), $uri->getAuthority(), $uri->getPath(), $uri->getQuery(), $uri->getFragment());
+        }
     }
 
     /**

--- a/lib/DAV/Psr7ResponseWrapper.php
+++ b/lib/DAV/Psr7ResponseWrapper.php
@@ -282,11 +282,13 @@ class Psr7ResponseWrapper implements ResponseInterface
     public function reset()
     {
         $responseFactory = $this->responseFactory;
-        $response = $responseFactory();
-        if (!$response instanceof \Psr\Http\Message\ResponseInterface) {
-            throw new Exception('Response factory must return instance of PSR ResponseInterface');
+        /** @var \Psr\Http\Message\ResponseInterface $response */
+        $response = $responseFactory()->withStatus(500);
+
+        if (Server::$exposeVersion) {
+            $response = $response->withAddedHeader('X-Sabre-Version', Version::VERSION);
         }
-        $this->response = $response->withStatus(500);
+        $this->response = $response;
 
     }
 }

--- a/lib/DAV/Psr7ResponseWrapper.php
+++ b/lib/DAV/Psr7ResponseWrapper.php
@@ -1,0 +1,273 @@
+<?php
+
+
+namespace Sabre\DAV;
+
+
+use GuzzleHttp\Psr7\Stream;
+use function GuzzleHttp\Psr7\stream_for;
+use Sabre\HTTP\ResponseInterface;
+use Sabre\HTTP\scalar;
+
+class Psr7ResponseWrapper implements ResponseInterface
+{
+    /**
+     * @var \Psr\Http\Message\ResponseInterface
+     */
+    private $response;
+
+
+    public function __construct(\Psr\Http\Message\ResponseInterface $response)
+    {
+        $this->response = $response;
+    }
+
+
+    /**
+     * Returns the body as a readable stream resource.
+     *
+     * Note that the stream may not be rewindable, and therefore may only be
+     * read once.
+     *
+     * @return resource
+     */
+    function getBodyAsStream()
+    {
+        throw new \Exception('not used');
+    }
+
+    /**
+     * Returns the body as a string.
+     *
+     * Note that because the underlying data may be based on a stream, this
+     * method could only work correctly the first time.
+     *
+     * @return string
+     */
+    function getBodyAsString(): string
+    {
+        throw new \Exception('not used');
+    }
+
+    /**
+     * Returns the message body, as it's internal representation.
+     *
+     * This could be either a string, a stream or a callback writing the body to php://output
+     *
+     * @return resource|string|callable
+     */
+    function getBody()
+    {
+//        return $this->response->getBody()->getContents();
+        throw new \Exception('not used');
+    }
+
+    /**
+     * Updates the body resource with a new stream.
+     *
+     * @param resource|string|callable $body
+     * @return void
+     */
+    function setBody($body)
+    {
+        if (is_callable($body)) {
+            throw new \Exception('not used');
+        }
+        $this->response = $this->response->withBody(stream_for($body));
+
+    }
+
+    /**
+     * Returns all the HTTP headers as an array.
+     *
+     * Every header is returned as an array, with one or more values.
+     */
+    function getHeaders(): array
+    {
+        throw new \Exception('not used');
+    }
+
+    /**
+     * Will return true or false, depending on if a HTTP header exists.
+     */
+    function hasHeader(string $name): bool
+    {
+        throw new \Exception('not used');
+    }
+
+    /**
+     * Returns a specific HTTP header, based on it's name.
+     *
+     * The name must be treated as case-insensitive.
+     * If the header does not exist, this method must return null.
+     *
+     * If a header appeared more than once in a HTTP request, this method will
+     * concatenate all the values with a comma.
+     *
+     * Note that this not make sense for all headers. Some, such as
+     * `Set-Cookie` cannot be logically combined with a comma. In those cases
+     * you *should* use getHeaderAsArray().
+     *
+     * @return string|null
+     */
+    function getHeader(string $name)
+    {
+        return $this->response->getHeaderLine($name);
+    }
+
+    /**
+     * Returns a HTTP header as an array.
+     *
+     * For every time the HTTP header appeared in the request or response, an
+     * item will appear in the array.
+     *
+     * If the header did not exists, this method will return an empty array.
+     *
+     * @return string[]
+     */
+    function getHeaderAsArray(string $name): array
+    {
+        throw new \Exception('not used');
+    }
+
+    /**
+     * Updates a HTTP header.
+     *
+     * The case-sensitity of the name value must be retained as-is.
+     *
+     * If the header already existed, it will be overwritten.
+     *
+     * @param string|string[] $value
+     * @return void
+     */
+    function setHeader(string $name, $value)
+    {
+        $this->response = $this->response->withHeader($name, $value);
+    }
+
+    /**
+     * Sets a new set of HTTP headers.
+     *
+     * The headers array should contain headernames for keys, and their value
+     * should be specified as either a string or an array.
+     *
+     * Any header that already existed will be overwritten.
+     *
+     * @return void
+     */
+    function setHeaders(array $headers)
+    {
+        foreach($headers as $name => $value) {
+            $this->response = $this->response->withHeader($name, $value);
+        }
+    }
+
+    /**
+     * Adds a HTTP header.
+     *
+     * This method will not overwrite any existing HTTP header, but instead add
+     * another value. Individual values can be retrieved with
+     * getHeadersAsArray.
+     *
+     * @param scalar $value
+     * @return void
+     */
+    function addHeader(string $name, $value)
+    {
+        $this->response = $this->response->withAddedHeader($name, $value);
+    }
+
+    /**
+     * Adds a new set of HTTP headers.
+     *
+     * Any existing headers will not be overwritten.
+     *
+     * @return void
+     */
+    function addHeaders(array $headers)
+    {
+        foreach($headers as $name => $value) {
+            $this->response = $this->response->withAddedHeader($name, $value);
+        }
+    }
+
+    /**
+     * Removes a HTTP header.
+     *
+     * The specified header name must be treated as case-insenstive.
+     * This method should return true if the header was successfully deleted,
+     * and false if the header did not exist.
+     */
+    function removeHeader(string $name): bool
+    {
+        throw new \Exception('not used');
+    }
+
+    /**
+     * Sets the HTTP version.
+     *
+     * Should be 1.0, 1.1 or 2.0.
+     *
+     * @return void
+     */
+    function setHttpVersion(string $version)
+    {
+        $this->response = $this->response->withProtocolVersion($version);
+    }
+
+    /**
+     * Returns the HTTP version.
+     */
+    function getHttpVersion(): string
+    {
+        throw new \Exception('not used');
+    }
+
+    /**
+     * Returns the current HTTP status code.
+     */
+    function getStatus(): int
+    {
+        return $this->response->getStatusCode();
+    }
+
+    /**
+     * Returns the human-readable status string.
+     *
+     * In the case of a 200, this may for example be 'OK'.
+     */
+    function getStatusText(): string
+    {
+        throw new \Exception('not used');
+    }
+
+    /**
+     * Sets the HTTP status code.
+     *
+     * This can be either the full HTTP status code with human readable string,
+     * for example: "403 I can't let you do that, Dave".
+     *
+     * Or just the code, in which case the appropriate default message will be
+     * added.
+     *
+     * @param string|int $status
+     * @throws \InvalidArgumentException
+     * @return void
+     */
+    function setStatus($status)
+    {
+        if (is_string($status)) {
+            $reason = substr($status, 3);
+            $status = substr($status, 0, 3);
+            $this->response = $this->response->withStatus($status, $reason);
+        } else {
+            $this->response = $this->response->withStatus($status);
+        }
+    }
+
+    public function getResponse(): \Psr\Http\Message\ResponseInterface
+    {
+        return $this->response;
+    }
+
+}

--- a/lib/DAV/Server.php
+++ b/lib/DAV/Server.php
@@ -4,6 +4,7 @@ namespace Sabre\DAV;
 
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Psr7\ServerRequest;
+use function Http\Response\send;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use Psr\Log\LoggerAwareInterface;
@@ -71,13 +72,6 @@ class Server implements
      * @var Psr7RequestWrapper
      */
     private $httpRequest;
-
-    /**
-     * PHP HTTP Sapi
-     *
-     * @var HTTP\Sapi
-     */
-    private $sapi;
 
     /**
      * The list of plugins
@@ -194,6 +188,10 @@ class Server implements
     static $exposeVersion = true;
 
     /**
+     * @var callable Callable that sends a PSR7 response object.
+     */
+    private $responseSender;
+    /**
      * Sets up the server
      *
      * If a Sabre\DAV\Tree object is passed as an argument, it will
@@ -208,8 +206,14 @@ class Server implements
      *
      * @param Tree|INode|array|null $treeOrNode The tree object
      * @param \Closure A response factory
+     * @param ServerRequestInterface Example request; needed for some getters during tests. [TEMPORARY]
      */
-    function __construct($treeOrNode = null, \Closure $responseFactory = null) {
+    public function __construct(
+        $treeOrNode = null,
+        \Closure $responseFactory = null,
+        ServerRequestInterface $request = null,
+        callable $responseSender = null
+    ) {
 
         if ($treeOrNode instanceof Tree) {
             $this->tree = $treeOrNode;
@@ -228,7 +232,6 @@ class Server implements
         }
 
         $this->xml = new Xml\Service();
-        $this->sapi = new HTTP\Sapi();
 
         if (!isset($responseFactory) && class_exists(Response::class)) {
             $responseFactory = function () {
@@ -239,8 +242,24 @@ class Server implements
         if (!isset($responseFactory)) {
             throw new Exception('No response factory given and guzzle is not available');
         }
+
+        if (!isset($request) && class_exists(ServerRequest::class)) {
+            $request = new ServerRequest('GET', '');
+        }
+
+        if (!isset($responseFactory)) {
+            throw new Exception('No request was given and guzzle is not available');
+        }
+
+        if (!isset($responseSender)) {
+            $responseSender = function(\Psr\Http\Message\ResponseInterface $response) {
+                send($response);
+            };
+        }
+
         $this->httpResponse = new Psr7ResponseWrapper($responseFactory);
-        $this->httpRequest = new Psr7RequestWrapper(new ServerRequest('GET', ''));
+        $this->httpRequest = new Psr7RequestWrapper($request);
+        $this->responseSender = $responseSender;
         $this->addPlugin(new CorePlugin());
     }
 
@@ -259,8 +278,9 @@ class Server implements
      * Starts the DAV Server
      *
      * @return void
+     * @deprecated
      */
-    function start() {
+    public function start() {
 
         try {
 
@@ -276,71 +296,13 @@ class Server implements
             $this->httpRequest->setBaseUrl($this->getBaseUri());
             $this->invokeMethod($this->httpRequest, $this->httpResponse);
         } catch (\Throwable $e) {
-
             try {
                 $this->emit('exception', [$e]);
             } catch (\Exception $ignore) {
             }
-            $DOM = new \DOMDocument('1.0', 'utf-8');
-            $DOM->formatOutput = true;
-
-            $error = $DOM->createElementNS('DAV:', 'd:error');
-            $error->setAttribute('xmlns:s', self::NS_SABREDAV);
-            $DOM->appendChild($error);
-
-            $h = function($v) {
-
-                return htmlspecialchars((string)$v, ENT_NOQUOTES, 'UTF-8');
-
-            };
-
-            if (self::$exposeVersion) {
-                $error->appendChild($DOM->createElement('s:sabredav-version', $h(Version::VERSION)));
-            }
-
-            $error->appendChild($DOM->createElement('s:exception', $h(get_class($e))));
-            $error->appendChild($DOM->createElement('s:message', $h($e->getMessage())));
-            if ($this->debugExceptions) {
-                $error->appendChild($DOM->createElement('s:file', $h($e->getFile())));
-                $error->appendChild($DOM->createElement('s:line', $h($e->getLine())));
-                $error->appendChild($DOM->createElement('s:code', $h($e->getCode())));
-                $error->appendChild($DOM->createElement('s:stacktrace', $h($e->getTraceAsString())));
-            }
-
-            if ($this->debugExceptions) {
-                $previous = $e;
-                while ($previous = $previous->getPrevious()) {
-                    $xPrevious = $DOM->createElement('s:previous-exception');
-                    $xPrevious->appendChild($DOM->createElement('s:exception', $h(get_class($previous))));
-                    $xPrevious->appendChild($DOM->createElement('s:message', $h($previous->getMessage())));
-                    $xPrevious->appendChild($DOM->createElement('s:file', $h($previous->getFile())));
-                    $xPrevious->appendChild($DOM->createElement('s:line', $h($previous->getLine())));
-                    $xPrevious->appendChild($DOM->createElement('s:code', $h($previous->getCode())));
-                    $xPrevious->appendChild($DOM->createElement('s:stacktrace', $h($previous->getTraceAsString())));
-                    $error->appendChild($xPrevious);
-                }
-            }
-
-
-            if ($e instanceof Exception) {
-
-                $httpCode = $e->getHTTPCode();
-                $e->serialize($this, $error);
-                $headers = $e->getHTTPHeaders($this);
-
-            } else {
-
-                $httpCode = 500;
-                $headers = [];
-
-            }
-            $headers['Content-Type'] = 'application/xml; charset=utf-8';
-
-            $this->httpResponse->setStatus($httpCode);
-            $this->httpResponse->setHeaders($headers);
-            $this->httpResponse->setBody($DOM->saveXML());
+            $this->renderError($e);
         }
-
+        $this->sendResponse($this->httpResponse->getResponse());
     }
 
     /**
@@ -481,20 +443,16 @@ class Server implements
      * @param bool $sendResponse Whether to send the HTTP response to the DAV client.
      * @return void
      */
-    function invokeMethod(RequestInterface $request, ResponseInterface $response, $sendResponse = true) {
+    function invokeMethod(RequestInterface $request, Psr7ResponseWrapper $response, $sendResponse = true) {
 
         $method = $request->getMethod();
 
         if (!$this->emit('beforeMethod:' . $method, [$request, $response])) return;
 
-        if (self::$exposeVersion) {
-            $response->setHeader('X-Sabre-Version', Version::VERSION);
-        }
-
         $this->transactionType = strtolower($method);
 
         if (!$this->checkPreconditions($request, $response)) {
-            $this->sendResponse($response);
+            $this->sendResponse($response->getResponse());
             return;
         }
 
@@ -511,7 +469,7 @@ class Server implements
         if (!$this->emit('afterMethod:' . $method, [$request, $response])) return;
 
         if ($sendResponse) {
-            $this->sendResponse($response);
+            $this->sendResponse($response->getResponse());
             $this->emit('afterResponse', [$request, $response]);
         }
 
@@ -1707,16 +1665,93 @@ class Server implements
     {
         $this->httpRequest = new Psr7RequestWrapper($request);
         $this->httpResponse->reset();
-        $this->start();
+        $this->httpResponse->setHttpVersion($request->getProtocolVersion());
+        try {
+            // Setting the base url
+            $this->httpRequest->setBaseUrl($this->getBaseUri());
+            $this->invokeMethod($this->httpRequest, $this->httpResponse);
+        } catch (\Throwable $e) {
+            try {
+                $this->emit('exception', [$e]);
+            } catch (\Exception $ignore) {
+            }
+            $this->renderError($e);
+        }
         return $this->httpResponse->getResponse();
     }
 
     /**
      * Temporary function; replaces ->sapi->sendResponse().
      */
-    private function sendResponse(HTTP\ResponseInterface $response)
+    private function sendResponse(\Psr\Http\Message\ResponseInterface $response)
     {
-        // Do something here.
+        return call_user_func($this->responseSender, $response);
+    }
 
+    protected function renderError(\Throwable $e)
+    {
+        $DOM = new \DOMDocument('1.0', 'utf-8');
+        $DOM->formatOutput = true;
+
+        $error = $DOM->createElementNS('DAV:', 'd:error');
+        $error->setAttribute('xmlns:s', self::NS_SABREDAV);
+        $DOM->appendChild($error);
+
+        $h = function($v) {
+
+            return htmlspecialchars((string)$v, ENT_NOQUOTES, 'UTF-8');
+
+        };
+
+        if (self::$exposeVersion) {
+            $error->appendChild($DOM->createElement('s:sabredav-version', $h(Version::VERSION)));
+        }
+
+        $error->appendChild($DOM->createElement('s:exception', $h(get_class($e))));
+        $error->appendChild($DOM->createElement('s:message', $h($e->getMessage())));
+        if ($this->debugExceptions) {
+            $error->appendChild($DOM->createElement('s:file', $h($e->getFile())));
+            $error->appendChild($DOM->createElement('s:line', $h($e->getLine())));
+            $error->appendChild($DOM->createElement('s:code', $h($e->getCode())));
+            $error->appendChild($DOM->createElement('s:stacktrace', $h($e->getTraceAsString())));
+        }
+
+        if ($this->debugExceptions) {
+            $previous = $e;
+            while ($previous = $previous->getPrevious()) {
+                $xPrevious = $DOM->createElement('s:previous-exception');
+                $xPrevious->appendChild($DOM->createElement('s:exception', $h(get_class($previous))));
+                $xPrevious->appendChild($DOM->createElement('s:message', $h($previous->getMessage())));
+                $xPrevious->appendChild($DOM->createElement('s:file', $h($previous->getFile())));
+                $xPrevious->appendChild($DOM->createElement('s:line', $h($previous->getLine())));
+                $xPrevious->appendChild($DOM->createElement('s:code', $h($previous->getCode())));
+                $xPrevious->appendChild($DOM->createElement('s:stacktrace', $h($previous->getTraceAsString())));
+                $error->appendChild($xPrevious);
+            }
+        }
+
+
+        if ($e instanceof Exception) {
+
+            $httpCode = $e->getHTTPCode();
+            $e->serialize($this, $error);
+            $headers = $e->getHTTPHeaders($this);
+
+        } else {
+
+            $httpCode = 500;
+            $headers = [];
+
+        }
+        $headers['Content-Type'] = 'application/xml; charset=utf-8';
+        // Some headers are expected to be retained.
+        if (!empty($this->httpResponse->getResponse()->getHeader('X-Sabre-Temp'))) {
+            $headers['X-Sabre-Temp'] = $this->httpResponse->getResponse()->getHeader('X-Sabre-Temp');
+        }
+
+        $this->httpResponse->reset();
+        $this->httpResponse->setStatus($httpCode);
+        $this->httpResponse->setHeaders($headers);
+        $this->httpResponse->setBody($DOM->saveXML());
     }
 }

--- a/lib/DAV/Server.php
+++ b/lib/DAV/Server.php
@@ -376,17 +376,17 @@ class Server implements
      * Only the PATH_INFO variable is considered.
      *
      * If this variable is not set, the root (/) is assumed.
-     *
+     * @param ServerRequestInterface $request
      * @return string
      */
-    public function guessBaseUri(HTTP\RequestInterface $request) {
+    public function guessBaseUri(ServerRequestInterface $request) {
+        $params = $request->getServerParams();
 
-        $pathInfo = $request->getRawServerValue('PATH_INFO');
-        $uri = $request->getRawServerValue('REQUEST_URI');
 
         // If PATH_INFO is found, we can assume it's accurate.
-        if (!empty($pathInfo)) {
-
+        if (!empty($params['PATH_INFO'])) {
+            $pathInfo = $params['PATH_INFO'];
+            $uri = $params['REQUEST_URI'];
             // We need to make sure we ignore the QUERY_STRING part
             if ($pos = strpos($uri, '?'))
                 $uri = substr($uri, 0, $pos);

--- a/tests/Sabre/CalDAV/Backend/AbstractPDOTest.php
+++ b/tests/Sabre/CalDAV/Backend/AbstractPDOTest.php
@@ -1342,7 +1342,7 @@ abstract class AbstractPDOTest extends \PHPUnit_Framework_TestCase {
                 ],
             ])
         ];
-        $this->assertEquals($expected, $result, null, 0.0, 10, true); // Last argument is $canonicalize = true, which allows us to compare, ignoring the order, because it's different between MySQL and Sqlite.
+        $this->assertEquals($expected, $result, '', 0.0, 10, true); // Last argument is $canonicalize = true, which allows us to compare, ignoring the order, because it's different between MySQL and Sqlite.
 
     }
 

--- a/tests/Sabre/CalDAV/Backend/AbstractPDOTest.php
+++ b/tests/Sabre/CalDAV/Backend/AbstractPDOTest.php
@@ -320,7 +320,7 @@ abstract class AbstractPDOTest extends \PHPUnit_Framework_TestCase {
     }
 
     /**
-     * @expectedException Sabre\DAV\Exception\BadRequest
+     * @expectedException \Sabre\DAV\Exception\BadRequest
      * @depends testCreateCalendarObject
      */
     function testCreateCalendarObjectNoComponent() {

--- a/tests/Sabre/CalDAV/CalendarHomeTest.php
+++ b/tests/Sabre/CalDAV/CalendarHomeTest.php
@@ -8,7 +8,7 @@ use Sabre\DAV\MkCol;
 class CalendarHomeTest extends \PHPUnit_Framework_TestCase {
 
     /**
-     * @var Sabre\CalDAV\CalendarHome
+     * @var \Sabre\CalDAV\CalendarHome
      */
     protected $usercalendars;
 
@@ -33,7 +33,7 @@ class CalendarHomeTest extends \PHPUnit_Framework_TestCase {
     }
 
     /**
-     * @expectedException Sabre\DAV\Exception\NotFound
+     * @expectedException \Sabre\DAV\Exception\NotFound
      * @depends testSimple
      */
     function testGetChildNotFound() {
@@ -144,7 +144,7 @@ class CalendarHomeTest extends \PHPUnit_Framework_TestCase {
 
 
     /**
-     * @expectedException Sabre\DAV\Exception\MethodNotAllowed
+     * @expectedException \Sabre\DAV\Exception\MethodNotAllowed
      * @depends testSimple
      */
     function testCreateDirectory() {
@@ -170,7 +170,7 @@ class CalendarHomeTest extends \PHPUnit_Framework_TestCase {
     }
 
     /**
-     * @expectedException Sabre\DAV\Exception\InvalidResourceType
+     * @expectedException \Sabre\DAV\Exception\InvalidResourceType
      * @depends testSimple
      */
     function testCreateExtendedCollectionBadResourceType() {
@@ -184,7 +184,7 @@ class CalendarHomeTest extends \PHPUnit_Framework_TestCase {
     }
 
     /**
-     * @expectedException Sabre\DAV\Exception\InvalidResourceType
+     * @expectedException \Sabre\DAV\Exception\InvalidResourceType
      * @depends testSimple
      */
     function testCreateExtendedCollectionNotACalendar() {
@@ -204,7 +204,7 @@ class CalendarHomeTest extends \PHPUnit_Framework_TestCase {
     }
 
     /**
-     * @expectedException Sabre\DAV\Exception\NotImplemented
+     * @expectedException \Sabre\DAV\Exception\NotImplemented
      */
     function testShareReplyFail() {
 

--- a/tests/Sabre/CalDAV/CalendarObjectTest.php
+++ b/tests/Sabre/CalDAV/CalendarObjectTest.php
@@ -7,11 +7,11 @@ require_once 'Sabre/CalDAV/TestUtil.php';
 class CalendarObjectTest extends \PHPUnit_Framework_TestCase {
 
     /**
-     * @var Sabre\CalDAV\Backend_PDO
+     * @var \Sabre\CalDAV\Backend_PDO
      */
     protected $backend;
     /**
-     * @var Sabre\CalDAV\Calendar
+     * @var \Sabre\CalDAV\Calendar
      */
     protected $calendar;
     protected $principalBackend;

--- a/tests/Sabre/CalDAV/CalendarTest.php
+++ b/tests/Sabre/CalDAV/CalendarTest.php
@@ -9,12 +9,12 @@ require_once 'Sabre/CalDAV/TestUtil.php';
 class CalendarTest extends \PHPUnit_Framework_TestCase {
 
     /**
-     * @var Sabre\CalDAV\Backend\PDO
+     * @var \Sabre\CalDAV\Backend\PDO
      */
     protected $backend;
     protected $principalBackend;
     /**
-     * @var Sabre\CalDAV\Calendar
+     * @var \Sabre\CalDAV\Calendar
      */
     protected $calendar;
     /**
@@ -82,7 +82,7 @@ class CalendarTest extends \PHPUnit_Framework_TestCase {
     }
 
     /**
-     * @expectedException Sabre\DAV\Exception\NotFound
+     * @expectedException \Sabre\DAV\Exception\NotFound
      * @depends testSimple
      */
     function testGetChildNotFound() {
@@ -117,7 +117,7 @@ class CalendarTest extends \PHPUnit_Framework_TestCase {
 
 
     /**
-     * @expectedException Sabre\DAV\Exception\MethodNotAllowed
+     * @expectedException \Sabre\DAV\Exception\MethodNotAllowed
      */
     function testCreateDirectory() {
 
@@ -126,7 +126,7 @@ class CalendarTest extends \PHPUnit_Framework_TestCase {
     }
 
     /**
-     * @expectedException Sabre\DAV\Exception\MethodNotAllowed
+     * @expectedException \Sabre\DAV\Exception\MethodNotAllowed
      */
     function testSetName() {
 

--- a/tests/Sabre/CalDAV/ExpandEventsDTSTARTandDTENDTest.php
+++ b/tests/Sabre/CalDAV/ExpandEventsDTSTARTandDTENDTest.php
@@ -2,7 +2,7 @@
 
 namespace Sabre\CalDAV;
 
-use Sabre\HTTP;
+use GuzzleHttp\Psr7\ServerRequest;
 use Sabre\VObject;
 
 /**
@@ -54,14 +54,10 @@ END:VCALENDAR
 
     function testExpand() {
 
-        $request = HTTP\Sapi::createFromServerArray([
-            'REQUEST_METHOD'    => 'REPORT',
-            'HTTP_CONTENT_TYPE' => 'application/xml',
-            'REQUEST_URI'       => '/calendars/user1/calendar1',
-            'HTTP_DEPTH'        => '1',
-        ]);
-
-        $request->setBody('<?xml version="1.0" encoding="utf-8" ?>
+        $request = new ServerRequest('REPORT', '/calendars/user1/calendar1', [
+            'Content-Type' => 'application/xml',
+            'Depth'        => '1',
+        ],'<?xml version="1.0" encoding="utf-8" ?>
 <C:calendar-query xmlns:D="DAV:" xmlns:C="urn:ietf:params:xml:ns:caldav">
     <D:prop>
         <C:calendar-data>

--- a/tests/Sabre/CalDAV/ExpandEventsDTSTARTandDTENDTest.php
+++ b/tests/Sabre/CalDAV/ExpandEventsDTSTARTandDTENDTest.php
@@ -80,25 +80,26 @@ END:VCALENDAR
 
         $response = $this->request($request);
 
+        $responseBody = $response->getBody()->getContents();
         // Everts super awesome xml parser.
         $body = substr(
-            $response->body,
-            $start = strpos($response->body, 'BEGIN:VCALENDAR'),
-            strpos($response->body, 'END:VCALENDAR') - $start + 13
+            $responseBody,
+            $start = strpos($responseBody, 'BEGIN:VCALENDAR'),
+            strpos($responseBody, 'END:VCALENDAR') - $start + 13
         );
         $body = str_replace('&#13;', '', $body);
 
         try {
             $vObject = VObject\Reader::read($body);
         } catch (VObject\ParseException $e) {
-            $this->fail('Could not parse object. Error:' . $e->getMessage() . ' full object: ' . $response->getBodyAsString());
+            $this->fail('Could not parse object. Error:' . $e->getMessage() . ' full object: ' . $responseBody);
         }
 
         // check if DTSTARTs and DTENDs are correct
         foreach ($vObject->VEVENT as $vevent) {
-            /** @var $vevent Sabre\VObject\Component\VEvent */
+            /** @var $vevent VObject\Component\VEvent */
             foreach ($vevent->children() as $child) {
-                /** @var $child Sabre\VObject\Property */
+                /** @var $child VObject\Property */
                 if ($child->name == 'DTSTART') {
                     // DTSTART has to be one of three valid values
                     $this->assertContains($child->getValue(), ['20120207T171500Z', '20120208T171500Z', '20120209T171500Z'], 'DTSTART is not a valid value: ' . $child->getValue());

--- a/tests/Sabre/CalDAV/ExpandEventsDTSTARTandDTENDbyDayTest.php
+++ b/tests/Sabre/CalDAV/ExpandEventsDTSTARTandDTENDbyDayTest.php
@@ -2,7 +2,7 @@
 
 namespace Sabre\CalDAV;
 
-use Sabre\HTTP;
+use GuzzleHttp\Psr7\ServerRequest;
 use Sabre\VObject;
 
 /**
@@ -45,14 +45,10 @@ END:VCALENDAR
 
     function testExpandRecurringByDayEvent() {
 
-        $request = HTTP\Sapi::createFromServerArray([
-            'REQUEST_METHOD'    => 'REPORT',
-            'HTTP_CONTENT_TYPE' => 'application/xml',
-            'REQUEST_URI'       => '/calendars/user1/calendar1',
-            'HTTP_DEPTH'        => '1',
-        ]);
-
-        $request->setBody('<?xml version="1.0" encoding="utf-8" ?>
+        $request = new ServerRequest('REPORT', '/calendars/user1/calendar1', [
+            'Content-Type' => 'application/xml',
+            'Depth' => '1',
+        ], '<?xml version="1.0" encoding="utf-8" ?>
 <C:calendar-query xmlns:D="DAV:" xmlns:C="urn:ietf:params:xml:ns:caldav">
     <D:prop>
         <C:calendar-data>

--- a/tests/Sabre/CalDAV/ExpandEventsDTSTARTandDTENDbyDayTest.php
+++ b/tests/Sabre/CalDAV/ExpandEventsDTSTARTandDTENDbyDayTest.php
@@ -6,7 +6,7 @@ use Sabre\HTTP;
 use Sabre\VObject;
 
 /**
- * This unittests is created to find out why recurring events have wrong DTSTART value
+ * This unit test was created to find out why recurring events have wrong DTSTART value
  *
  * @copyright Copyright (C) fruux GmbH (https://fruux.com/)
  * @author Evert Pot (http://evertpot.com/)
@@ -71,11 +71,12 @@ END:VCALENDAR
 
         $response = $this->request($request);
 
+        $responseBody = $response->getBody()->getContents();
         // Everts super awesome xml parser.
         $body = substr(
-            $response->body,
-            $start = strpos($response->body, 'BEGIN:VCALENDAR'),
-            strpos($response->body, 'END:VCALENDAR') - $start + 13
+            $responseBody,
+            $start = strpos($responseBody, 'BEGIN:VCALENDAR'),
+            strpos($responseBody, 'END:VCALENDAR') - $start + 13
         );
         $body = str_replace('&#13;', '', $body);
 
@@ -85,9 +86,9 @@ END:VCALENDAR
 
         // check if DTSTARTs and DTENDs are correct
         foreach ($vObject->VEVENT as $vevent) {
-            /** @var $vevent Sabre\VObject\Component\VEvent */
+            /** @var $vevent VObject\Component\VEvent */
             foreach ($vevent->children() as $child) {
-                /** @var $child Sabre\VObject\Property */
+                /** @var $child VObject\Property */
                 if ($child->name == 'DTSTART') {
                     // DTSTART has to be one of two valid values
                     $this->assertContains($child->getValue(), ['20120214T171500Z', '20120216T171500Z'], 'DTSTART is not a valid value: ' . $child->getValue());

--- a/tests/Sabre/CalDAV/ExpandEventsDoubleEventsTest.php
+++ b/tests/Sabre/CalDAV/ExpandEventsDoubleEventsTest.php
@@ -81,12 +81,14 @@ END:VCALENDAR
 </C:calendar-query>');
 
         $response = $this->request($request);
+        $responseBody = $response->getBody()->getContents();
+
 
         // Everts super awesome xml parser.
         $body = substr(
-            $response->body,
-            $start = strpos($response->body, 'BEGIN:VCALENDAR'),
-            strpos($response->body, 'END:VCALENDAR') - $start + 13
+            $responseBody,
+            $start = strpos($responseBody, 'BEGIN:VCALENDAR'),
+            strpos($responseBody, 'END:VCALENDAR') - $start + 13
         );
         $body = str_replace('&#13;', '', $body);
 

--- a/tests/Sabre/CalDAV/ExpandEventsDoubleEventsTest.php
+++ b/tests/Sabre/CalDAV/ExpandEventsDoubleEventsTest.php
@@ -2,7 +2,7 @@
 
 namespace Sabre\CalDAV;
 
-use Sabre\HTTP;
+use GuzzleHttp\Psr7\ServerRequest;
 use Sabre\VObject;
 
 /**
@@ -56,14 +56,14 @@ END:VCALENDAR
 
     function testExpand() {
 
-        $request = HTTP\Sapi::createFromServerArray([
-            'REQUEST_METHOD'    => 'REPORT',
-            'HTTP_CONTENT_TYPE' => 'application/xml',
-            'REQUEST_URI'       => '/calendars/user1/calendar1',
-            'HTTP_DEPTH'        => '1',
-        ]);
-
-        $request->setBody('<?xml version="1.0" encoding="utf-8" ?>
+        $request = new ServerRequest(
+            'REPORT',
+            '/calendars/user1/calendar1',
+            [
+                'Content-Type' => 'application/xml',
+                'Depth' => '1',
+            ],
+            '<?xml version="1.0" encoding="utf-8" ?>
 <C:calendar-query xmlns:D="DAV:" xmlns:C="urn:ietf:params:xml:ns:caldav">
     <D:prop>
         <C:calendar-data>
@@ -78,7 +78,8 @@ END:VCALENDAR
             </C:comp-filter>
         </C:comp-filter>
     </C:filter>
-</C:calendar-query>');
+</C:calendar-query>'
+        );
 
         $response = $this->request($request);
         $responseBody = $response->getBody()->getContents();

--- a/tests/Sabre/CalDAV/ExpandEventsFloatingTimeTest.php
+++ b/tests/Sabre/CalDAV/ExpandEventsFloatingTimeTest.php
@@ -2,7 +2,7 @@
 
 namespace Sabre\CalDAV;
 
-use Sabre\HTTP;
+use GuzzleHttp\Psr7\ServerRequest;
 use Sabre\VObject;
 
 /**
@@ -69,12 +69,10 @@ END:VCALENDAR
 
     function testExpandCalendarQuery() {
 
-        $request = new HTTP\Request('REPORT', '/calendars/user1/calendar1', [
+        $request = new ServerRequest('REPORT', '/calendars/user1/calendar1', [
             'Depth'        => 1,
             'Content-Type' => 'application/xml',
-        ]);
-
-        $request->setBody('<?xml version="1.0" encoding="utf-8" ?>
+        ],'<?xml version="1.0" encoding="utf-8" ?>
 <C:calendar-query xmlns:D="DAV:" xmlns:C="urn:ietf:params:xml:ns:caldav">
     <D:prop>
         <C:calendar-data>
@@ -121,12 +119,10 @@ END:VCALENDAR
 
     function testExpandMultiGet() {
 
-        $request = new HTTP\Request('REPORT', '/calendars/user1/calendar1', [
+        $request = new ServerRequest('REPORT', '/calendars/user1/calendar1', [
             'Depth'        => 1,
             'Content-Type' => 'application/xml',
-        ]);
-
-        $request->setBody('<?xml version="1.0" encoding="utf-8" ?>
+        ],'<?xml version="1.0" encoding="utf-8" ?>
 <C:calendar-multiget xmlns:D="DAV:" xmlns:C="urn:ietf:params:xml:ns:caldav">
     <D:prop>
         <C:calendar-data>
@@ -170,9 +166,14 @@ END:VCALENDAR
 
     function testExpandExport() {
 
-        $request = new HTTP\Request('GET', '/calendars/user1/calendar1?export&start=1&end=2000000000&expand=1', [
+        $request = (new ServerRequest('GET', '/calendars/user1/calendar1?export&start=1&end=2000000000&expand=1', [
             'Depth'        => 1,
             'Content-Type' => 'application/xml',
+        ]))->withQueryParams([
+            'export' => '',
+            'start' => '1',
+            'end' => '2000000000',
+            'expand' => '1'
         ]);
 
         $response = $this->request($request, 200);

--- a/tests/Sabre/CalDAV/ExpandEventsFloatingTimeTest.php
+++ b/tests/Sabre/CalDAV/ExpandEventsFloatingTimeTest.php
@@ -92,12 +92,12 @@ END:VCALENDAR
 </C:calendar-query>');
 
         $response = $this->request($request);
-
+        $responseBody = $response->getBody()->getContents();
         // Everts super awesome xml parser.
         $body = substr(
-            $response->body,
-            $start = strpos($response->body, 'BEGIN:VCALENDAR'),
-            strpos($response->body, 'END:VCALENDAR') - $start + 13
+            $responseBody,
+            $start = strpos($responseBody, 'BEGIN:VCALENDAR'),
+            strpos($responseBody, 'END:VCALENDAR') - $start + 13
         );
         $body = str_replace('&#13;', '', $body);
 
@@ -105,9 +105,9 @@ END:VCALENDAR
 
         // check if DTSTARTs and DTENDs are correct
         foreach ($vObject->VEVENT as $vevent) {
-            /** @var $vevent Sabre\VObject\Component\VEvent */
+            /** @var $vevent VObject\Component\VEvent */
             foreach ($vevent->children() as $child) {
-                /** @var $child Sabre\VObject\Property */
+                /** @var $child VObject\Property */
                 if ($child->name == 'DTSTART') {
                     // DTSTART should be the UTC equivalent of given floating time
                     $this->assertEquals('20141108T043000Z', $child->getValue());
@@ -139,13 +139,14 @@ END:VCALENDAR
 
         $response = $this->request($request);
 
-        $this->assertEquals(207, $response->getStatus());
+        $this->assertEquals(207, $response->getStatusCode());
 
+        $responseBody = $response->getBody()->getContents();
         // Everts super awesome xml parser.
         $body = substr(
-            $response->body,
-            $start = strpos($response->body, 'BEGIN:VCALENDAR'),
-            strpos($response->body, 'END:VCALENDAR') - $start + 13
+            $responseBody,
+            $start = strpos($responseBody, 'BEGIN:VCALENDAR'),
+            strpos($responseBody, 'END:VCALENDAR') - $start + 13
         );
         $body = str_replace('&#13;', '', $body);
 
@@ -174,15 +175,14 @@ END:VCALENDAR
             'Content-Type' => 'application/xml',
         ]);
 
-        $response = $this->request($request);
+        $response = $this->request($request, 200);
 
-        $this->assertEquals(200, $response->getStatus());
-
+        $responseBody = $response->getBody()->getContents();
         // Everts super awesome xml parser.
         $body = substr(
-            $response->body,
-            $start = strpos($response->body, 'BEGIN:VCALENDAR'),
-            strpos($response->body, 'END:VCALENDAR') - $start + 13
+            $responseBody,
+            $start = strpos($responseBody, 'BEGIN:VCALENDAR'),
+            strpos($responseBody, 'END:VCALENDAR') - $start + 13
         );
         $body = str_replace('&#13;', '', $body);
 
@@ -190,9 +190,9 @@ END:VCALENDAR
 
         // check if DTSTARTs and DTENDs are correct
         foreach ($vObject->VEVENT as $vevent) {
-            /** @var $vevent Sabre\VObject\Component\VEvent */
+            /** @var $vevent VObject\Component\VEvent */
             foreach ($vevent->children() as $child) {
-                /** @var $child Sabre\VObject\Property */
+                /** @var $child VObject\Property */
                 if ($child->name == 'DTSTART') {
                     // DTSTART should be the UTC equivalent of given floating time
                     $this->assertEquals('20141108T043000Z', $child->getValue());

--- a/tests/Sabre/CalDAV/FreeBusyReportTest.php
+++ b/tests/Sabre/CalDAV/FreeBusyReportTest.php
@@ -78,7 +78,7 @@ ics;
             '{' . Plugin::NS_CALDAV . '}calendar-timezone' => "BEGIN:VCALENDAR\r\nBEGIN:VTIMEZONE\r\nTZID:Europe/Berlin\r\nEND:VTIMEZONE\r\nEND:VCALENDAR",
         ]);
 
-        $this->server = new DAV\Server([$calendar]);
+        $this->server = new DAV\Server([$calendar], null, null, function(){});
 
         $request = new ServerRequest('GET', '/calendar');
 
@@ -153,7 +153,7 @@ XML;
      */
     function testFreeBusyReportNoACLPlugin() {
 
-        $server = new DAV\Server();
+        $server = new DAV\Server(null, null, null, function(){});
         $plugin = new Plugin();
         $server->addPlugin($plugin);
 

--- a/tests/Sabre/CalDAV/FreeBusyReportTest.php
+++ b/tests/Sabre/CalDAV/FreeBusyReportTest.php
@@ -82,8 +82,6 @@ ics;
 
         $request = new HTTP\Request('GET', '/calendar');
         $this->server->httpRequest = $request;
-        $this->server->httpResponse = new HTTP\ResponseMock();
-
         $this->plugin = new Plugin();
         $this->server->addPlugin($this->plugin);
 
@@ -101,16 +99,18 @@ XML;
         $report = $this->server->xml->parse($reportXML, null, $rootElem);
         $this->plugin->report($rootElem, $report, null);
 
-        $this->assertEquals(200, $this->server->httpResponse->status);
-        $this->assertEquals('text/calendar', $this->server->httpResponse->getHeader('Content-Type'));
-        $this->assertTrue(strpos($this->server->httpResponse->body, 'BEGIN:VFREEBUSY') !== false);
-        $this->assertTrue(strpos($this->server->httpResponse->body, '20111005T120000Z/20111005T130000Z') !== false);
-        $this->assertTrue(strpos($this->server->httpResponse->body, '20111006T100000Z/20111006T110000Z') !== false);
+        $response = $this->server->httpResponse->getResponse();
+        $responseBody = $response->getBody()->getContents();
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('text/calendar', $response->getHeaderLine('Content-Type'));
+        $this->assertTrue(strpos($responseBody, 'BEGIN:VFREEBUSY') !== false);
+        $this->assertTrue(strpos($responseBody, '20111005T120000Z/20111005T130000Z') !== false);
+        $this->assertTrue(strpos($responseBody, '20111006T100000Z/20111006T110000Z') !== false);
 
     }
 
     /**
-     * @expectedException Sabre\DAV\Exception\BadRequest
+     * @expectedException \Sabre\DAV\Exception\BadRequest
      */
     function testFreeBusyReportNoTimeRange() {
 
@@ -125,7 +125,7 @@ XML;
     }
 
     /**
-     * @expectedException Sabre\DAV\Exception\NotImplemented
+     * @expectedException \Sabre\DAV\Exception\NotImplemented
      */
     function testFreeBusyReportWrongNode() {
 
@@ -145,7 +145,7 @@ XML;
     }
 
     /**
-     * @expectedException Sabre\DAV\Exception
+     * @expectedException \Sabre\DAV\Exception
      */
     function testFreeBusyReportNoACLPlugin() {
 

--- a/tests/Sabre/CalDAV/FreeBusyReportTest.php
+++ b/tests/Sabre/CalDAV/FreeBusyReportTest.php
@@ -3,7 +3,7 @@
 namespace Sabre\CalDAV;
 
 use Sabre\DAV;
-use Sabre\HTTP;
+use GuzzleHttp\Psr7\ServerRequest;
 
 class FreeBusyReportTest extends \PHPUnit_Framework_TestCase {
 
@@ -80,10 +80,12 @@ ics;
 
         $this->server = new DAV\Server([$calendar]);
 
-        $request = new HTTP\Request('GET', '/calendar');
-        $this->server->httpRequest = $request;
+        $request = new ServerRequest('GET', '/calendar');
+
+
         $this->plugin = new Plugin();
         $this->server->addPlugin($this->plugin);
+        $this->server->handle($request);
 
     }
 
@@ -129,8 +131,10 @@ XML;
      */
     function testFreeBusyReportWrongNode() {
 
-        $request = new HTTP\Request('REPORT', '/');
-        $this->server->httpRequest = $request;
+        $request = new ServerRequest('REPORT', '/');
+
+        $this->server->handle($request);
+
 
         $reportXML = <<<XML
 <?xml version="1.0"?>
@@ -149,10 +153,9 @@ XML;
      */
     function testFreeBusyReportNoACLPlugin() {
 
-        $this->server = new DAV\Server();
-        $this->server->httpRequest = new HTTP\Request('REPORT', '/');
-        $this->plugin = new Plugin();
-        $this->server->addPlugin($this->plugin);
+        $server = new DAV\Server();
+        $plugin = new Plugin();
+        $server->addPlugin($plugin);
 
         $reportXML = <<<XML
 <?xml version="1.0"?>
@@ -161,8 +164,8 @@ XML;
 </c:free-busy-query>
 XML;
 
-        $report = $this->server->xml->parse($reportXML, null, $rootElem);
-        $this->plugin->report($rootElem, $report, null);
+        $report = $server->xml->parse($reportXML, null, $rootElem);
+        $plugin->report($rootElem, $report, null);
 
     }
 }

--- a/tests/Sabre/CalDAV/GetEventsByTimerangeTest.php
+++ b/tests/Sabre/CalDAV/GetEventsByTimerangeTest.php
@@ -75,7 +75,7 @@ END:VCALENDAR
 
         $response = $this->request($request);
 
-        $this->assertTrue(strpos($response->body, 'BEGIN:VCALENDAR') !== false);
+        $this->assertTrue(strpos($response->getBody()->getContents(), 'BEGIN:VCALENDAR') !== false);
 
     }
 

--- a/tests/Sabre/CalDAV/GetEventsByTimerangeTest.php
+++ b/tests/Sabre/CalDAV/GetEventsByTimerangeTest.php
@@ -2,7 +2,7 @@
 
 namespace Sabre\CalDAV;
 
-use Sabre\HTTP;
+use GuzzleHttp\Psr7\ServerRequest;
 
 /**
  * This unittest is created to check if queries for time-range include the start timestamp or not
@@ -47,16 +47,14 @@ END:VCALENDAR
 
     function testQueryTimerange() {
 
-        $request = new HTTP\Request(
+        $request = new ServerRequest(
             'REPORT',
             '/calendars/user1/calendar1',
             [
                 'Content-Type' => 'application/xml',
                 'Depth'        => '1',
-            ]
-        );
-
-        $request->setBody('<?xml version="1.0" encoding="utf-8" ?>
+            ],
+            '<?xml version="1.0" encoding="utf-8" ?>
 <C:calendar-query xmlns:D="DAV:" xmlns:C="urn:ietf:params:xml:ns:caldav">
     <D:prop>
         <C:calendar-data>

--- a/tests/Sabre/CalDAV/ICSExportPluginTest.php
+++ b/tests/Sabre/CalDAV/ICSExportPluginTest.php
@@ -82,8 +82,10 @@ ICS
             'export' => ''
         ]);
 
+        $old = DAV\Server::$exposeVersion;
+        DAV\Server::$exposeVersion = true;
         $response = $this->request($request, 200);
-
+        DAV\Server::$exposeVersion = $old;
         $this->assertEquals('text/calendar', $response->getHeaderLine('Content-Type'));
 
         $obj = VObject\Reader::read($response->getBody()->getContents());
@@ -105,9 +107,7 @@ ICS
             'GET',
             '/calendars/admin/UUID-123467?export'
         ))->withQueryParams(['export' => '1']);
-        DAV\Server::$exposeVersion = false;
         $response = $this->request($request);
-        DAV\Server::$exposeVersion = true;
 
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertEquals('text/calendar', $response->getHeaderLine('Content-Type'));
@@ -172,7 +172,11 @@ ICS
             'export' => ''
         ]);
 
+        $old = DAV\Server::$exposeVersion;
+        DAV\Server::$exposeVersion = true;
         $response = $this->request($request, 200);
+        DAV\Server::$exposeVersion = $old;
+
         $this->assertEquals('text/calendar', $response->getHeaderLine('Content-Type'));
 
         $obj = VObject\Reader::read($response->getBody()->getContents());
@@ -181,6 +185,7 @@ ICS
         $this->assertEquals(1, count($obj->VERSION));
         $this->assertEquals(1, count($obj->CALSCALE));
         $this->assertEquals(1, count($obj->PRODID));
+
         $this->assertTrue(strpos((string)$obj->PRODID, DAV\Version::VERSION) !== false);
         $this->assertEquals(1, count($obj->VTIMEZONE));
         $this->assertEquals(1, count($obj->VEVENT));

--- a/tests/Sabre/CalDAV/ICSExportPluginTest.php
+++ b/tests/Sabre/CalDAV/ICSExportPluginTest.php
@@ -80,10 +80,10 @@ ICS
 
         $response = $this->request($request);
 
-        $this->assertEquals(200, $response->getStatus());
-        $this->assertEquals('text/calendar', $response->getHeader('Content-Type'));
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('text/calendar', $response->getHeaderLine('Content-Type'));
 
-        $obj = VObject\Reader::read($response->body);
+        $obj = VObject\Reader::read($response->getBody()->getContents());
 
         $this->assertEquals(8, count($obj->children()));
         $this->assertEquals(1, count($obj->VERSION));
@@ -106,10 +106,10 @@ ICS
         $response = $this->request($request);
         DAV\Server::$exposeVersion = true;
 
-        $this->assertEquals(200, $response->getStatus());
-        $this->assertEquals('text/calendar', $response->getHeader('Content-Type'));
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('text/calendar', $response->getHeaderLine('Content-Type'));
 
-        $obj = VObject\Reader::read($response->body);
+        $obj = VObject\Reader::read($response->getBody()->getContents());
 
         $this->assertEquals(8, count($obj->children()));
         $this->assertEquals(1, count($obj->VERSION));
@@ -168,9 +168,9 @@ ICS
         );
 
         $response = $this->request($request, 200);
-        $this->assertEquals('text/calendar', $response->getHeader('Content-Type'));
+        $this->assertEquals('text/calendar', $response->getHeaderLine('Content-Type'));
 
-        $obj = VObject\Reader::read($response->body);
+        $obj = VObject\Reader::read($response->getBody()->getContents());
 
         $this->assertEquals(8, count($obj->children()));
         $this->assertEquals(1, count($obj->VERSION));
@@ -210,7 +210,7 @@ ICS
         );
         $response = $this->request($request, 200);
 
-        $obj = VObject\Reader::read($response->getBody());
+        $obj = VObject\Reader::read($response->getBody()->getContents());
 
         $this->assertNull($obj->VTIMEZONE);
         $this->assertNull($obj->VEVENT);
@@ -235,7 +235,7 @@ ICS
         );
         $response = $this->request($request, 200);
 
-        $obj = VObject\Reader::read($response->getBody());
+        $obj = VObject\Reader::read($response->getBody()->getContents());
 
         $this->assertNull($obj->VTIMEZONE);
         $this->assertEquals(1, count($obj->VEVENT));
@@ -251,7 +251,7 @@ ICS
         );
 
         $response = $this->request($request, 200);
-        $this->assertEquals('application/calendar+json', $response->getHeader('Content-Type'));
+        $this->assertEquals('application/calendar+json', $response->getHeaderLine('Content-Type'));
 
     }
 
@@ -263,7 +263,7 @@ ICS
         );
 
         $response = $this->request($request, 200);
-        $this->assertEquals('application/calendar+json', $response->getHeader('Content-Type'));
+        $this->assertEquals('application/calendar+json', $response->getHeaderLine('Content-Type'));
 
     }
 
@@ -276,7 +276,7 @@ ICS
         );
 
         $response = $this->request($request, 200);
-        $this->assertEquals('text/calendar', $response->getHeader('Content-Type'));
+        $this->assertEquals('text/calendar', $response->getHeaderLine('Content-Type'));
 
     }
 
@@ -289,7 +289,7 @@ ICS
 
         $response = $this->request($request, 200);
 
-        $obj = VObject\Reader::read($response->body);
+        $obj = VObject\Reader::read($response->getBody()->getContents());
         $this->assertEquals(1, count($obj->VTIMEZONE));
         $this->assertEquals(1, count($obj->VEVENT));
         $this->assertNull($obj->VTODO);
@@ -305,7 +305,7 @@ ICS
 
         $response = $this->request($request, 200);
 
-        $obj = VObject\Reader::read($response->body);
+        $obj = VObject\Reader::read($response->getBody()->getContents());
 
         $this->assertNull($obj->VTIMEZONE);
         $this->assertNull($obj->VEVENT);
@@ -332,10 +332,10 @@ ICS
         );
 
         $response = $this->request($request, 200);
-        $this->assertEquals('text/calendar', $response->getHeader('Content-Type'));
+        $this->assertEquals('text/calendar', $response->getHeaderLine('Content-Type'));
         $this->assertEquals(
             'attachment; filename="UUID-123467-' . date('Y-m-d') . '.ics"',
-            $response->getHeader('Content-Disposition')
+            $response->getHeaderLine('Content-Disposition')
         );
 
     }
@@ -349,10 +349,10 @@ ICS
         );
 
         $response = $this->request($request, 200);
-        $this->assertEquals('application/calendar+json', $response->getHeader('Content-Type'));
+        $this->assertEquals('application/calendar+json', $response->getHeaderLine('Content-Type'));
         $this->assertEquals(
             'attachment; filename="UUID-123467-' . date('Y-m-d') . '.json"',
-            $response->getHeader('Content-Disposition')
+            $response->getHeaderLine('Content-Disposition')
         );
 
     }
@@ -375,10 +375,10 @@ ICS
         );
 
         $response = $this->request($request, 200);
-        $this->assertEquals('application/calendar+json', $response->getHeader('Content-Type'));
+        $this->assertEquals('application/calendar+json', $response->getHeaderLine('Content-Type'));
         $this->assertEquals(
             'attachment; filename="UUID-b_adchars-' . date('Y-m-d') . '.json"',
-            $response->getHeader('Content-Disposition')
+            $response->getHeaderLine('Content-Disposition')
         );
 
     }

--- a/tests/Sabre/CalDAV/ICSExportPluginTest.php
+++ b/tests/Sabre/CalDAV/ICSExportPluginTest.php
@@ -2,15 +2,17 @@
 
 namespace Sabre\CalDAV;
 
+use GuzzleHttp\Psr7\Response;
 use Sabre\DAV;
 use Sabre\DAVACL;
-use Sabre\HTTP;
+use GuzzleHttp\Psr7\ServerRequest;
 use Sabre\VObject;
 
 class ICSExportPluginTest extends \Sabre\DAVServerTest {
 
     protected $setupCalDAV = true;
 
+    /** @var ICSExportPlugin */
     protected $icsExportPlugin;
 
     function setUp() {
@@ -73,14 +75,15 @@ ICS
 
     function testBeforeMethod() {
 
-        $request = new HTTP\Request(
+        $request = (new ServerRequest(
             'GET',
             '/calendars/admin/UUID-123467?export'
-        );
+        ))->withQueryParams([
+            'export' => ''
+        ]);
 
-        $response = $this->request($request);
+        $response = $this->request($request, 200);
 
-        $this->assertEquals(200, $response->getStatusCode());
         $this->assertEquals('text/calendar', $response->getHeaderLine('Content-Type'));
 
         $obj = VObject\Reader::read($response->getBody()->getContents());
@@ -98,10 +101,10 @@ ICS
     }
     function testBeforeMethodNoVersion() {
 
-        $request = new HTTP\Request(
+        $request = (new ServerRequest(
             'GET',
             '/calendars/admin/UUID-123467?export'
-        );
+        ))->withQueryParams(['export' => '1']);
         DAV\Server::$exposeVersion = false;
         $response = $this->request($request);
         DAV\Server::$exposeVersion = true;
@@ -123,12 +126,12 @@ ICS
 
     function testBeforeMethodNoExport() {
 
-        $request = new HTTP\Request(
+        $request = new ServerRequest(
             'GET',
             '/calendars/admin/UUID-123467'
         );
-        $response = new HTTP\Response();
-        $this->assertNull($this->icsExportPlugin->httpGet($request, $response));
+        $response = new DAV\Psr7ResponseWrapper(function() { return new Response(500); });
+        $this->assertNull($this->icsExportPlugin->httpGet(new DAV\Psr7RequestWrapper($request), $response));
 
     }
 
@@ -140,7 +143,7 @@ ICS
             $aclPlugin
         );
 
-        $request = new HTTP\Request(
+        $request = new ServerRequest(
             'GET',
             '/calendars/admin/UUID-123467?export'
         );
@@ -162,10 +165,12 @@ ICS
 
         $this->autoLogin('admin');
 
-        $request = new HTTP\Request(
+        $request = (new ServerRequest(
             'GET',
             '/calendars/admin/UUID-123467?export'
-        );
+        ))->withQueryParams([
+            'export' => ''
+        ]);
 
         $response = $this->request($request, 200);
         $this->assertEquals('text/calendar', $response->getHeaderLine('Content-Type'));
@@ -184,30 +189,40 @@ ICS
 
     function testBadStartParam() {
 
-        $request = new HTTP\Request(
+        $request = (new ServerRequest(
             'GET',
             '/calendars/admin/UUID-123467?export&start=foo'
-        );
+        ))->withQueryParams([
+            'export' => '',
+            'start' => 'foo'
+        ]);
         $this->request($request, 400);
 
     }
 
     function testBadEndParam() {
 
-        $request = new HTTP\Request(
+        $request = (new ServerRequest(
             'GET',
             '/calendars/admin/UUID-123467?export&end=foo'
-        );
+        ))->withQueryParams([
+            'export' => '',
+            'end' => 'foo'
+        ]);
         $this->request($request, 400);
 
     }
 
     function testFilterStartEnd() {
 
-        $request = new HTTP\Request(
+        $request = (new ServerRequest(
             'GET',
             '/calendars/admin/UUID-123467?export&start=1&end=2'
-        );
+        ))->withQueryParams([
+            'export' => '',
+            'start' => '1',
+            'end' => '2'
+        ]);
         $response = $this->request($request, 200);
 
         $obj = VObject\Reader::read($response->getBody()->getContents());
@@ -219,20 +234,29 @@ ICS
 
     function testExpandNoStart() {
 
-        $request = new HTTP\Request(
+        $request = (new ServerRequest(
             'GET',
             '/calendars/admin/UUID-123467?export&expand=1&end=2'
-        );
+        ))->withQueryParams([
+            'export' => '',
+            'expand' => '1',
+            'end' => '2'
+        ]);
         $this->request($request, 400);
 
     }
 
     function testExpand() {
 
-        $request = new HTTP\Request(
+        $request = (new ServerRequest(
             'GET',
             '/calendars/admin/UUID-123467?export&start=1&end=2000000000&expand=1'
-        );
+        ))->withQueryParams([
+            'export' => '',
+            'start' => '1',
+            'end' => '2000000000',
+            'expand' => '1'
+        ]);
         $response = $this->request($request, 200);
 
         $obj = VObject\Reader::read($response->getBody()->getContents());
@@ -244,23 +268,29 @@ ICS
 
     function testJCal() {
 
-        $request = new HTTP\Request(
+        $request = (new ServerRequest(
             'GET',
             '/calendars/admin/UUID-123467?export',
             ['Accept' => 'application/calendar+json']
-        );
+        ))->withQueryParams([
+            'export' => ''
+        ]);
 
         $response = $this->request($request, 200);
+
         $this->assertEquals('application/calendar+json', $response->getHeaderLine('Content-Type'));
 
     }
 
     function testJCalInUrl() {
 
-        $request = new HTTP\Request(
+        $request = (new ServerRequest(
             'GET',
             '/calendars/admin/UUID-123467?export&accept=jcal'
-        );
+        ))->withQueryParams([
+            'export' => '',
+            'accept' => 'jcal'
+        ]);
 
         $response = $this->request($request, 200);
         $this->assertEquals('application/calendar+json', $response->getHeaderLine('Content-Type'));
@@ -269,11 +299,13 @@ ICS
 
     function testNegotiateDefault() {
 
-        $request = new HTTP\Request(
+        $request = (new ServerRequest(
             'GET',
             '/calendars/admin/UUID-123467?export',
             ['Accept' => 'text/plain']
-        );
+        ))->withQueryParams([
+            'export' => ''
+        ]);
 
         $response = $this->request($request, 200);
         $this->assertEquals('text/calendar', $response->getHeaderLine('Content-Type'));
@@ -282,10 +314,13 @@ ICS
 
     function testFilterComponentVEVENT() {
 
-        $request = new HTTP\Request(
+        $request = (new ServerRequest(
             'GET',
             '/calendars/admin/UUID-123467?export&componentType=VEVENT'
-        );
+        ))->withQueryParams([
+            'export' => '',
+            'componentType' => 'VEVENT'
+        ]);
 
         $response = $this->request($request, 200);
 
@@ -298,10 +333,13 @@ ICS
 
     function testFilterComponentVTODO() {
 
-        $request = new HTTP\Request(
+        $request = (new ServerRequest(
             'GET',
             '/calendars/admin/UUID-123467?export&componentType=VTODO'
-        );
+        ))->withQueryParams([
+            'export' => '',
+            'componentType' => 'VTODO'
+        ]);
 
         $response = $this->request($request, 200);
 
@@ -315,10 +353,13 @@ ICS
 
     function testFilterComponentBadComponent() {
 
-        $request = new HTTP\Request(
+        $request = (new ServerRequest(
             'GET',
             '/calendars/admin/UUID-123467?export&componentType=VVOODOO'
-        );
+        ))->withQueryParams([
+            'export'=> '',
+            'componentType' => 'VVOODOO'
+        ]);
 
         $response = $this->request($request, 400);
 
@@ -326,10 +367,10 @@ ICS
 
     function testContentDisposition() {
 
-        $request = new HTTP\Request(
+        $request = (new ServerRequest(
             'GET',
             '/calendars/admin/UUID-123467?export'
-        );
+        ))->withQueryParams(['export' => '']);
 
         $response = $this->request($request, 200);
         $this->assertEquals('text/calendar', $response->getHeaderLine('Content-Type'));
@@ -342,11 +383,11 @@ ICS
 
     function testContentDispositionJson() {
 
-        $request = new HTTP\Request(
+        $request = (new ServerRequest(
             'GET',
             '/calendars/admin/UUID-123467?export',
             ['Accept' => 'application/calendar+json']
-        );
+        ))->withQueryParams(['export' => '']);
 
         $response = $this->request($request, 200);
         $this->assertEquals('application/calendar+json', $response->getHeaderLine('Content-Type'));
@@ -368,11 +409,11 @@ ICS
             ]
         );
 
-        $request = new HTTP\Request(
+        $request = (new ServerRequest(
             'GET',
             '/calendars/admin/UUID-b_ad"(ch)ars?export',
             ['Accept' => 'application/calendar+json']
-        );
+        ))->withQueryParams(['export' => '']);
 
         $response = $this->request($request, 200);
         $this->assertEquals('application/calendar+json', $response->getHeaderLine('Content-Type'));

--- a/tests/Sabre/CalDAV/Issue203Test.php
+++ b/tests/Sabre/CalDAV/Issue203Test.php
@@ -84,11 +84,13 @@ END:VCALENDAR
 
         $response = $this->request($request);
 
+        $responseBody = $response->getBody()->getContents();
+
         // Everts super awesome xml parser.
         $body = substr(
-            $response->body,
-            $start = strpos($response->body, 'BEGIN:VCALENDAR'),
-            strpos($response->body, 'END:VCALENDAR') - $start + 13
+            $responseBody,
+            $start = strpos($responseBody, 'BEGIN:VCALENDAR'),
+            strpos($responseBody, 'END:VCALENDAR') - $start + 13
         );
         $body = str_replace('&#13;', '', $body);
 

--- a/tests/Sabre/CalDAV/Issue203Test.php
+++ b/tests/Sabre/CalDAV/Issue203Test.php
@@ -2,7 +2,7 @@
 
 namespace Sabre\CalDAV;
 
-use Sabre\HTTP;
+use GuzzleHttp\Psr7\ServerRequest;
 use Sabre\VObject;
 
 /**
@@ -58,14 +58,14 @@ END:VCALENDAR
 
     function testIssue203() {
 
-        $request = HTTP\Sapi::createFromServerArray([
-            'REQUEST_METHOD'    => 'REPORT',
-            'HTTP_CONTENT_TYPE' => 'application/xml',
-            'REQUEST_URI'       => '/calendars/user1/calendar1',
-            'HTTP_DEPTH'        => '1',
-        ]);
-
-        $request->setBody('<?xml version="1.0" encoding="utf-8" ?>
+        $request = new ServerRequest(
+            'REPORT',
+            '/calendars/user1/calendar1',
+            [
+                'Content-Type' => 'application/xml',
+                'Depth'        => '1',
+            ],
+            '<?xml version="1.0" encoding="utf-8" ?>
 <C:calendar-query xmlns:D="DAV:" xmlns:C="urn:ietf:params:xml:ns:caldav">
     <D:prop>
         <C:calendar-data>

--- a/tests/Sabre/CalDAV/Issue205Test.php
+++ b/tests/Sabre/CalDAV/Issue205Test.php
@@ -2,7 +2,7 @@
 
 namespace Sabre\CalDAV;
 
-use Sabre\HTTP;
+use GuzzleHttp\Psr7\ServerRequest;
 use Sabre\VObject;
 
 /**
@@ -51,14 +51,14 @@ END:VCALENDAR
 
     function testIssue205() {
 
-        $request = HTTP\Sapi::createFromServerArray([
-            'REQUEST_METHOD'    => 'REPORT',
-            'HTTP_CONTENT_TYPE' => 'application/xml',
-            'REQUEST_URI'       => '/calendars/user1/calendar1',
-            'HTTP_DEPTH'        => '1',
-        ]);
+        $request = new ServerRequest(
+             'REPORT',
 
-        $request->setBody('<?xml version="1.0" encoding="utf-8" ?>
+            '/calendars/user1/calendar1',
+            [
+                'Content-Type' => 'application/xml',
+            'Depth'        => '1',
+        ], '<?xml version="1.0" encoding="utf-8" ?>
 <C:calendar-query xmlns:D="DAV:" xmlns:C="urn:ietf:params:xml:ns:caldav">
     <D:prop>
         <C:calendar-data>

--- a/tests/Sabre/CalDAV/Issue205Test.php
+++ b/tests/Sabre/CalDAV/Issue205Test.php
@@ -79,14 +79,15 @@ END:VCALENDAR
 
         $response = $this->request($request);
 
-        $this->assertFalse(strpos($response->body, '<s:exception>Exception</s:exception>'), 'Exception occurred: ' . $response->body);
-        $this->assertFalse(strpos($response->body, 'Unknown or bad format'), 'DateTime unknown format Exception: ' . $response->body);
+        $body = $response->getBody()->getContents();
+        $this->assertFalse(strpos($body, '<s:exception>Exception</s:exception>'), 'Exception occurred: ' . $body);
+        $this->assertFalse(strpos($body, 'Unknown or bad format'), 'DateTime unknown format Exception: ' . $body);
 
         // Everts super awesome xml parser.
         $body = substr(
-            $response->body,
-            $start = strpos($response->body, 'BEGIN:VCALENDAR'),
-            strpos($response->body, 'END:VCALENDAR') - $start + 13
+            $body,
+            $start = strpos($body, 'BEGIN:VCALENDAR'),
+            strpos($body, 'END:VCALENDAR') - $start + 13
         );
         $body = str_replace('&#13;', '', $body);
 

--- a/tests/Sabre/CalDAV/Issue211Test.php
+++ b/tests/Sabre/CalDAV/Issue211Test.php
@@ -2,7 +2,7 @@
 
 namespace Sabre\CalDAV;
 
-use Sabre\HTTP;
+use GuzzleHttp\Psr7\ServerRequest;
 
 /**
  * This unittest is created to check for an endless loop in Sabre\CalDAV\CalendarQueryValidator
@@ -55,14 +55,13 @@ END:VCALENDAR
 
     function testIssue211() {
 
-        $request = HTTP\Sapi::createFromServerArray([
-            'REQUEST_METHOD'    => 'REPORT',
-            'HTTP_CONTENT_TYPE' => 'application/xml',
-            'REQUEST_URI'       => '/calendars/user1/calendar1',
-            'HTTP_DEPTH'        => '1',
-        ]);
+        $request = new ServerRequest(
+             'REPORT',
+            '/calendars/user1/calendar1', [
+            'Content-Type' => 'application/xml',
 
-        $request->setBody('<?xml version="1.0" encoding="utf-8" ?>
+            'Depth'        => '1',
+        ],'<?xml version="1.0" encoding="utf-8" ?>
 <C:calendar-query xmlns:D="DAV:" xmlns:C="urn:ietf:params:xml:ns:caldav">
     <D:prop>
         <C:calendar-data/>

--- a/tests/Sabre/CalDAV/Issue211Test.php
+++ b/tests/Sabre/CalDAV/Issue211Test.php
@@ -83,7 +83,7 @@ END:VCALENDAR
 
         // if this assert is reached, the endless loop is gone
         // There should be no matching events
-        $this->assertFalse(strpos('BEGIN:VEVENT', $response->body));
+        $this->assertFalse(strpos('BEGIN:VEVENT', $response->getBody()->getContents()));
 
     }
 }

--- a/tests/Sabre/CalDAV/Issue220Test.php
+++ b/tests/Sabre/CalDAV/Issue220Test.php
@@ -90,10 +90,10 @@ END:VCALENDAR
 </C:calendar-query>');
 
         $response = $this->request($request);
+        $responseBody = $response->getBody()->getContents();
+        $this->assertFalse(strpos($responseBody, '<s:exception>PHPUnit_Framework_Error_Warning</s:exception>'), 'Error Warning occurred: ' . $responseBody);
+        $this->assertFalse(strpos($responseBody, 'Invalid argument supplied for foreach()'), 'Invalid argument supplied for foreach(): ' . $responseBody);
 
-        $this->assertFalse(strpos($response->body, '<s:exception>PHPUnit_Framework_Error_Warning</s:exception>'), 'Error Warning occurred: ' . $response->body);
-        $this->assertFalse(strpos($response->body, 'Invalid argument supplied for foreach()'), 'Invalid argument supplied for foreach(): ' . $response->body);
-
-        $this->assertEquals(207, $response->status);
+        $this->assertEquals(207, $response->getStatusCode());
     }
 }

--- a/tests/Sabre/CalDAV/Issue220Test.php
+++ b/tests/Sabre/CalDAV/Issue220Test.php
@@ -2,7 +2,7 @@
 
 namespace Sabre\CalDAV;
 
-use Sabre\HTTP;
+use GuzzleHttp\Psr7\ServerRequest;
 
 /**
  * This unittest is created to check for an endless loop in CalendarQueryValidator
@@ -65,14 +65,14 @@ END:VCALENDAR
 
     function testIssue220() {
 
-        $request = HTTP\Sapi::createFromServerArray([
-            'REQUEST_METHOD'    => 'REPORT',
-            'HTTP_CONTENT_TYPE' => 'application/xml',
-            'REQUEST_URI'       => '/calendars/user1/calendar1',
-            'HTTP_DEPTH'        => '1',
-        ]);
-
-        $request->setBody('<?xml version="1.0" encoding="utf-8" ?>
+        $request = new ServerRequest(
+             'REPORT',
+            '/calendars/user1/calendar1',
+            [
+                'Content-Type' => 'application/xml',
+                'Depth'        => '1',
+            ],
+             '<?xml version="1.0" encoding="utf-8" ?>
 <C:calendar-query xmlns:D="DAV:" xmlns:C="urn:ietf:params:xml:ns:caldav">
     <D:prop>
         <C:calendar-data/>

--- a/tests/Sabre/CalDAV/Issue228Test.php
+++ b/tests/Sabre/CalDAV/Issue228Test.php
@@ -2,7 +2,7 @@
 
 namespace Sabre\CalDAV;
 
-use Sabre\HTTP;
+use GuzzleHttp\Psr7\ServerRequest;
 
 /**
  * This unittest is created to check if the time-range filter is working correctly with all-day-events
@@ -45,14 +45,13 @@ END:VCALENDAR
 
     function testIssue228() {
 
-        $request = HTTP\Sapi::createFromServerArray([
-            'REQUEST_METHOD'    => 'REPORT',
-            'HTTP_CONTENT_TYPE' => 'application/xml',
-            'REQUEST_URI'       => '/calendars/user1/calendar1',
-            'HTTP_DEPTH'        => '1',
-        ]);
-
-        $request->setBody('<?xml version="1.0" encoding="utf-8" ?>
+        $request = new ServerRequest(
+             'REPORT',
+            '/calendars/user1/calendar1',
+            [
+            'Content-Type' => 'application/xml',
+            'Depth'        => '1',
+        ],'<?xml version="1.0" encoding="utf-8" ?>
 <C:calendar-query xmlns:D="DAV:" xmlns:C="urn:ietf:params:xml:ns:caldav">
   <D:prop>
     <C:calendar-data>

--- a/tests/Sabre/CalDAV/Issue228Test.php
+++ b/tests/Sabre/CalDAV/Issue228Test.php
@@ -73,7 +73,7 @@ END:VCALENDAR
         $response = $this->request($request);
 
         // We must check if absolutely nothing was returned from this query.
-        $this->assertFalse(strpos($response->body, 'BEGIN:VCALENDAR'));
+        $this->assertFalse(strpos($response->getBody()->getContents(), 'BEGIN:VCALENDAR'));
 
     }
 }

--- a/tests/Sabre/CalDAV/JCalTransformTest.php
+++ b/tests/Sabre/CalDAV/JCalTransformTest.php
@@ -37,8 +37,8 @@ class JCalTransformTest extends \Sabre\DAVServerTest {
 
         $response = $this->request($request);
 
-        $body = $response->getBodyAsString();
-        $this->assertEquals(200, $response->getStatus(), "Incorrect status code: " . $body);
+        $body = $response->getBody()->getContents();
+        $this->assertEquals(200, $response->getStatusCode(), "Incorrect status code: " . $body);
 
         $response = json_decode($body, true);
         if (json_last_error() !== JSON_ERROR_NONE) {
@@ -77,12 +77,10 @@ XML;
         $request = new Request('REPORT', '/calendars/user1/foo', $headers, $xml);
 
         $response = $this->request($request);
+        $responseBody = $response->getBody()->getContents();
+        $this->assertEquals(207, $response->getStatusCode(), 'Full rsponse: ' . $responseBody);
 
-        $this->assertEquals(207, $response->getStatus(), 'Full rsponse: ' . $response->getBodyAsString());
-
-        $multiStatus = $this->server->xml->parse(
-            $response->getBodyAsString()
-        );
+        $multiStatus = $this->server->xml->parse($responseBody);
 
         $responses = $multiStatus->getResponses();
         $this->assertEquals(1, count($responses));
@@ -91,7 +89,7 @@ XML;
 
         $jresponse = json_decode($response, true);
         if (json_last_error()) {
-            $this->fail('Json decoding error: ' . json_last_error_msg() . '. Full response: ' . $response);
+            $this->fail('Json decoding error: ' . json_last_error_msg() . '. Full response: ' . $responseBody);
         }
         $this->assertEquals(
             [
@@ -131,11 +129,10 @@ XML;
 
         $response = $this->request($request);
 
-        $this->assertEquals(207, $response->getStatus(), "Invalid response code. Full body: " . $response->getBodyAsString());
+        $responseBody = $response->getBody()->getContents();
+        $this->assertEquals(207, $response->getStatusCode(), "Invalid response code. Full body: " . $responseBody);
 
-        $multiStatus = $this->server->xml->parse(
-            $response->getBodyAsString()
-        );
+        $multiStatus = $this->server->xml->parse($responseBody);
 
         $responses = $multiStatus->getResponses();
 
@@ -183,12 +180,11 @@ XML;
         $request = new Request('REPORT', '/calendars/user1/foo/bar.ics', $headers, $xml);
 
         $response = $this->request($request);
+        $responseBody = $response->getBody()->getContents();
 
-        $this->assertEquals(207, $response->getStatus(), "Invalid response code. Full body: " . $response->getBodyAsString());
+        $this->assertEquals(207, $response->getStatusCode(), "Invalid response code. Full body: " . $responseBody);
 
-        $multiStatus = $this->server->xml->parse(
-            $response->getBodyAsString()
-        );
+        $multiStatus = $this->server->xml->parse($responseBody);
 
         $responses = $multiStatus->getResponses();
 

--- a/tests/Sabre/CalDAV/JCalTransformTest.php
+++ b/tests/Sabre/CalDAV/JCalTransformTest.php
@@ -2,6 +2,7 @@
 
 namespace Sabre\CalDAV;
 
+use GuzzleHttp\Psr7\ServerRequest;
 use Sabre\HTTP\Request;
 use Sabre\VObject;
 
@@ -33,7 +34,7 @@ class JCalTransformTest extends \Sabre\DAVServerTest {
         $headers = [
             'Accept' => 'application/calendar+json',
         ];
-        $request = new Request('GET', '/calendars/user1/foo/bar.ics', $headers);
+        $request = new ServerRequest('GET', '/calendars/user1/foo/bar.ics', $headers);
 
         $response = $this->request($request);
 
@@ -74,7 +75,7 @@ class JCalTransformTest extends \Sabre\DAVServerTest {
 XML;
 
         $headers = [];
-        $request = new Request('REPORT', '/calendars/user1/foo', $headers, $xml);
+        $request = new ServerRequest('REPORT', '/calendars/user1/foo', $headers, $xml);
 
         $response = $this->request($request);
         $responseBody = $response->getBody()->getContents();
@@ -125,7 +126,7 @@ XML;
         $headers = [
             'Depth' => '1',
         ];
-        $request = new Request('REPORT', '/calendars/user1/foo', $headers, $xml);
+        $request = new ServerRequest('REPORT', '/calendars/user1/foo', $headers, $xml);
 
         $response = $this->request($request);
 
@@ -177,7 +178,7 @@ XML;
         $headers = [
             'Depth' => '0',
         ];
-        $request = new Request('REPORT', '/calendars/user1/foo/bar.ics', $headers, $xml);
+        $request = new ServerRequest('REPORT', '/calendars/user1/foo/bar.ics', $headers, $xml);
 
         $response = $this->request($request);
         $responseBody = $response->getBody()->getContents();

--- a/tests/Sabre/CalDAV/Notifications/PluginTest.php
+++ b/tests/Sabre/CalDAV/Notifications/PluginTest.php
@@ -36,7 +36,7 @@ class PluginTest extends \PHPUnit_Framework_TestCase {
         $root->addChild($calendars);
         $root->addChild($principals);
 
-        $this->server = new DAV\Server($root);
+        $this->server = new DAV\Server($root, null, null, function(){});
 
         $this->server->debugExceptions = true;
         $this->server->setBaseUri('/');
@@ -121,7 +121,7 @@ class PluginTest extends \PHPUnit_Framework_TestCase {
             new SystemStatus('foo', '"1"')
         );
 
-        $server = new DAV\Server([$notification]);
+        $server = new DAV\Server([$notification], null, null, function(){});
         $caldav = new Plugin();
         $server->addPlugin($caldav);
         $request = new ServerRequest('GET', '/foo.xml');
@@ -149,7 +149,7 @@ class PluginTest extends \PHPUnit_Framework_TestCase {
 
     function testGETPassthrough() {
 
-        $server = new DAV\Server();
+        $server = new DAV\Server(null, null, null, function(){});
         $caldav = new Plugin();
 
         $server->addPlugin($caldav);

--- a/tests/Sabre/CalDAV/Notifications/PluginTest.php
+++ b/tests/Sabre/CalDAV/Notifications/PluginTest.php
@@ -59,8 +59,7 @@ class PluginTest extends \PHPUnit_Framework_TestCase {
         // This forces a login
         $authPlugin->beforeMethod(new HTTP\Request('GET', '/'), new HTTP\Response());
 
-        $this->response = new HTTP\ResponseMock();
-        $this->server->httpResponse = $this->response;
+        $this->response = $this->server->httpResponse;
 
     }
 
@@ -126,18 +125,17 @@ class PluginTest extends \PHPUnit_Framework_TestCase {
         $caldav = new Plugin();
 
         $server->httpRequest = new Request('GET', '/foo.xml');
-        $httpResponse = new HTTP\ResponseMock();
-        $server->httpResponse = $httpResponse;
-
         $server->addPlugin($caldav);
 
         $caldav->httpGet($server->httpRequest, $server->httpResponse);
 
-        $this->assertEquals(200, $httpResponse->status);
+        $response = $server->httpResponse->getResponse();
+
+        $this->assertEquals(200, $response->getStatusCode());
         $this->assertEquals([
             'Content-Type' => ['application/xml'],
             'ETag'         => ['"1"'],
-        ], $httpResponse->getHeaders());
+        ], $response->getHeaders());
 
         $expected =
 '<?xml version="1.0" encoding="UTF-8"?>
@@ -146,7 +144,7 @@ class PluginTest extends \PHPUnit_Framework_TestCase {
 </cs:notification>
 ';
 
-        $this->assertXmlStringEqualsXmlString($expected, $httpResponse->getBodyAsString());
+        $this->assertXmlStringEqualsXmlString($expected, $response->getBody()->getContents());
 
     }
 
@@ -154,9 +152,6 @@ class PluginTest extends \PHPUnit_Framework_TestCase {
 
         $server = new DAV\Server();
         $caldav = new Plugin();
-
-        $httpResponse = new HTTP\ResponseMock();
-        $server->httpResponse = $httpResponse;
 
         $server->addPlugin($caldav);
 

--- a/tests/Sabre/CalDAV/PluginTest.php
+++ b/tests/Sabre/CalDAV/PluginTest.php
@@ -6,13 +6,14 @@ use DateTime;
 use DateTimeZone;
 use GuzzleHttp\Psr7\ServerRequest;
 use Sabre\DAV;
+use Sabre\DAV\Server;
 use Sabre\DAVACL;
 use Sabre\HTTP\Response;
 
 class PluginTest extends \PHPUnit_Framework_TestCase {
 
     /**
-     * @var DAV\Server
+     * @var Server
      */
     protected $server;
     /**
@@ -74,7 +75,7 @@ class PluginTest extends \PHPUnit_Framework_TestCase {
         $root->addChild($calendars);
         $root->addChild($principals);
 
-        $this->server = new DAV\Server($root);
+        $this->server = new Server($root, null, null, function(){});
 
         $this->server->debugExceptions = true;
         $this->server->setBaseUri('/');

--- a/tests/Sabre/CalDAV/PluginTest.php
+++ b/tests/Sabre/CalDAV/PluginTest.php
@@ -94,10 +94,6 @@ class PluginTest extends \PHPUnit_Framework_TestCase {
 
         // This forces a login
         $authPlugin->beforeMethod(new HTTP\Request('GET', '/'), new HTTP\Response());
-
-        $this->response = new HTTP\ResponseMock();
-        $this->server->httpResponse = $this->response;
-
     }
 
     function testSimple() {
@@ -116,9 +112,9 @@ class PluginTest extends \PHPUnit_Framework_TestCase {
         $request = new HTTP\Request('MKBREAKFAST', '/');
 
         $this->server->httpRequest = $request;
-        $this->server->exec();
+        $this->server->start();
 
-        $this->assertEquals(501, $this->response->status, 'Incorrect status returned. Full response body:' . $this->response->body);
+        $this->assertEquals(501, $this->server->httpResponse->getResponse()->getStatusCode(), 'Incorrect status returned. Full response body:' . $this->server->httpResponse->getResponse()->getBody()->getContents());
 
     }
 
@@ -128,9 +124,9 @@ class PluginTest extends \PHPUnit_Framework_TestCase {
         $request->setBody('<?xml version="1.0"?><s:somereport xmlns:s="http://www.rooftopsolutions.nl/NS/example" />');
 
         $this->server->httpRequest = $request;
-        $this->server->exec();
+        $this->server->start();
 
-        $this->assertEquals(415, $this->response->status);
+        $this->assertEquals(415, $this->server->httpResponse->getResponse()->getStatusCode());
 
     }
 
@@ -178,9 +174,9 @@ class PluginTest extends \PHPUnit_Framework_TestCase {
 
         $request->setBody($body);
         $this->server->httpRequest = $request;
-        $this->server->exec();
+        $this->server->start();
 
-        $this->assertEquals(403, $this->response->status);
+        $this->assertEquals(403, $this->server->httpResponse->getResponse()->getStatusCode());
 
     }
 
@@ -228,9 +224,9 @@ class PluginTest extends \PHPUnit_Framework_TestCase {
 
         $request->setBody($body);
         $this->server->httpRequest = $request;
-        $this->server->exec();
+        $this->server->start();
 
-        $this->assertEquals(409, $this->response->status);
+        $this->assertEquals(409, $this->server->httpResponse->getResponse()->getStatusCode());
 
     }
 
@@ -281,9 +277,9 @@ class PluginTest extends \PHPUnit_Framework_TestCase {
 
         $request->setBody($body);
         $this->server->httpRequest = $request;
-        $this->server->exec();
+        $this->server->start();
 
-        $this->assertEquals(405, $this->response->status);
+        $this->assertEquals(405, $this->server->httpResponse->getResponse()->getStatusCode());
 
     }
 
@@ -332,9 +328,9 @@ END:VCALENDAR';
 
         $request->setBody($body);
         $this->server->httpRequest = $request;
-        $this->server->exec();
+        $this->server->start();
 
-        $this->assertEquals(201, $this->response->status, 'Invalid response code received. Full response body: ' . $this->response->body);
+        $this->assertEquals(201, $this->server->httpResponse->getResponse()->getStatusCode(), 'Invalid response code received. Full response body: ' . $this->server->httpResponse->getResponse()->getBody()->getContents());
 
         $calendars = $this->caldavBackend->getCalendarsForUser('principals/user1');
         $this->assertEquals(3, count($calendars));
@@ -378,9 +374,9 @@ END:VCALENDAR';
 
         $request->setBody('');
         $this->server->httpRequest = $request;
-        $this->server->exec();
+        $this->server->start();
 
-        $this->assertEquals(201, $this->response->status, 'Invalid response code received. Full response body: ' . $this->response->body);
+        $this->assertEquals(201, $this->server->httpResponse->getResponse()->getStatusCode(), 'Invalid response code received. Full response body: ' . $this->server->httpResponse->getResponse()->getBody()->getContents());
 
         $calendars = $this->caldavBackend->getCalendarsForUser('principals/user1');
         $this->assertEquals(3, count($calendars));
@@ -422,9 +418,9 @@ END:VCALENDAR';
 
         $request->setBody($body);
         $this->server->httpRequest = $request;
-        $this->server->exec();
+        $this->server->start();
 
-        $this->assertEquals(400, $this->response->status);
+        $this->assertEquals(400, $this->server->httpResponse->getResponse()->getStatusCode());
 
     }
 
@@ -564,9 +560,9 @@ END:VCALENDAR';
         $request->setBody($body);
 
         $this->server->httpRequest = $request;
-        $this->server->exec();
+        $this->server->start();
 
-        $this->assertEquals(207, $this->response->status, 'Invalid HTTP status received. Full response body');
+        $this->assertEquals(207, $this->server->httpResponse->getResponse()->getStatusCode(), 'Invalid HTTP status received. Full response body');
 
         $expectedIcal = TestUtil::getTestCalendarData();
 
@@ -586,7 +582,7 @@ END:VCALENDAR';
 </d:multistatus>
 XML;
 
-        $this->assertXmlStringEqualsXmlString($expected, $this->response->getBodyAsString());
+        $this->assertXmlStringEqualsXmlString($expected, $this->server->httpResponse->getResponse()->getBody()->getContents());
 
     }
 
@@ -611,9 +607,12 @@ XML;
         $request->setBody($body);
 
         $this->server->httpRequest = $request;
-        $this->server->exec();
+        $this->server->start();
 
-        $this->assertEquals(207, $this->response->status, 'Invalid HTTP status received. Full response body: ' . $this->response->body);
+        $response = $this->server->httpResponse->getResponse();
+        $responseBody = $response->getBody()->getContents();
+
+        $this->assertEquals(207, $response->getStatusCode(), 'Invalid HTTP status received. Full response body: ' . $responseBody);
 
         $expectedIcal = TestUtil::getTestCalendarData();
         $expectedIcal = \Sabre\VObject\Reader::read($expectedIcal);
@@ -639,7 +638,8 @@ XML;
 </d:multistatus>
 XML;
 
-        $this->assertXmlStringEqualsXmlString($expected, $this->response->getBodyAsString());
+
+        $this->assertXmlStringEqualsXmlString($expected, $responseBody);
 
     }
 
@@ -669,9 +669,10 @@ XML;
         $request->setBody($body);
 
         $this->server->httpRequest = $request;
-        $this->server->exec();
+        $this->server->start();
+        $responseBody = $this->server->httpResponse->getResponse()->getBody()->getContents();
 
-        $this->assertEquals(207, $this->response->status, 'Received an unexpected status. Full response body: ' . $this->response->body);
+        $this->assertEquals(207, $this->server->httpResponse->getResponse()->getStatusCode(), 'Received an unexpected status. Full response body: ' . $responseBody);
 
         $expectedIcal = TestUtil::getTestCalendarData();
         $expectedIcal = \Sabre\VObject\Reader::read($expectedIcal);
@@ -697,7 +698,7 @@ XML;
 </d:multistatus>
 XML;
 
-        $this->assertXmlStringEqualsXmlString($expected, $this->response->getBodyAsString());
+        $this->assertXmlStringEqualsXmlString($expected, $responseBody);
 
     }
 
@@ -731,9 +732,10 @@ XML;
         $request->setBody($body);
 
         $this->server->httpRequest = $request;
-        $this->server->exec();
+        $this->server->start();
+        $responseBody = $this->server->httpResponse->getResponse()->getBody()->getContents();
 
-        $this->assertEquals(207, $this->response->status, 'Received an unexpected status. Full response body: ' . $this->response->body);
+        $this->assertEquals(207, $this->server->httpResponse->getResponse()->getStatusCode(), 'Received an unexpected status. Full response body: ' . $responseBody);
 
         $expectedIcal = TestUtil::getTestCalendarData();
         $expectedIcal = \Sabre\VObject\Reader::read($expectedIcal);
@@ -759,7 +761,7 @@ XML;
 </d:multistatus>
 XML;
 
-        $this->assertXmlStringEqualsXmlString($expected, $this->response->getBodyAsString());
+        $this->assertXmlStringEqualsXmlString($expected, $responseBody);
 
     }
 
@@ -791,9 +793,9 @@ XML;
         $request->setBody($body);
 
         $this->server->httpRequest = $request;
-        $this->server->exec();
+        $this->server->start();
 
-        $this->assertEquals(400, $this->response->status, 'Received an unexpected status. Full response body: ' . $this->response->body);
+        $this->assertEquals(400, $this->server->httpResponse->getResponse()->getStatusCode(), 'Received an unexpected status. Full response body: ' . $this->server->httpResponse->getResponse()->getBody()->getContents());
 
     }
 
@@ -821,9 +823,11 @@ XML;
         $request->setBody($body);
 
         $this->server->httpRequest = $request;
-        $this->server->exec();
+        $this->server->start();
 
-        $this->assertEquals(207, $this->response->status, 'Received an unexpected status. Full response body: ' . $this->response->body);
+        $response = $this->server->httpResponse->getResponse();
+        $responseBody = $response->getBody()->getContents();
+        $this->assertEquals(207, $response->getStatusCode(), 'Received an unexpected status. Full response body: ' . $responseBody);
 
         $expected = <<<XML
 <?xml version="1.0"?>
@@ -840,7 +844,7 @@ XML;
 </d:multistatus>
 XML;
 
-        $this->assertXmlStringEqualsXmlString($expected, $this->response->getBodyAsString());
+        $this->assertXmlStringEqualsXmlString($expected, $responseBody);
 
     }
 
@@ -862,9 +866,9 @@ XML;
         $request->setBody($body);
 
         $this->server->httpRequest = $request;
-        $this->server->exec();
+        $this->server->start();
 
-        $this->assertEquals(400, $this->response->status, 'Received an unexpected status. Full response body: ' . $this->response->body);
+        $this->assertEquals(400, $this->server->httpResponse->getResponse()->getStatusCode(), 'Received an unexpected status. Full response body: ' . $this->server->httpResponse->getResponse()->getBody()->getContents());
 
     }
 
@@ -894,9 +898,11 @@ XML;
         $request->setBody($body);
 
         $this->server->httpRequest = $request;
-        $this->server->exec();
+        $this->server->start();
+        $response = $this->server->httpResponse->getResponse();
+        $responseBody = $response->getBody()->getContents();
 
-        $this->assertEquals(207, $this->response->status, 'Received an unexpected status. Full response body: ' . $this->response->body);
+        $this->assertEquals(207, $response->getStatusCode(), 'Received an unexpected status. Full response body: ' . $responseBody);
 
         $expectedIcal = TestUtil::getTestCalendarData();
         $expectedIcal = \Sabre\VObject\Reader::read($expectedIcal);
@@ -922,7 +928,7 @@ XML;
 </d:multistatus>
 XML;
 
-        $this->assertXmlStringEqualsXmlString($expected, $this->response->getBodyAsString());
+        $this->assertXmlStringEqualsXmlString($expected, $responseBody);
 
     }
 
@@ -949,9 +955,11 @@ XML;
         $request->setBody($body);
 
         $this->server->httpRequest = $request;
-        $this->server->exec();
+        $this->server->start();
+        $response = $this->server->httpResponse->getResponse();
+        $responseBody = $response->getBody()->getContents();
 
-        $this->assertEquals(207, $this->response->status, 'Received an unexpected status. Full response body: ' . $this->response->body);
+        $this->assertEquals(207, $response->getStatusCode(), 'Received an unexpected status. Full response body: ' . $responseBody);
 
         $expected = <<<XML
 <?xml version="1.0"?>
@@ -968,7 +976,7 @@ XML;
 </d:multistatus>
 XML;
 
-        $this->assertXmlStringEqualsXmlString($expected, $this->response->getBodyAsString());
+        $this->assertXmlStringEqualsXmlString($expected, $responseBody);
 
     }
 
@@ -1003,9 +1011,9 @@ XML;
         $request->setBody($body);
 
         $this->server->httpRequest = $request;
-        $this->server->exec();
+        $this->server->start();
 
-        $this->assertEquals(400, $this->response->status, 'Invalid HTTP status received. Full response body: ' . $this->response->body);
+        $this->assertEquals(400, $this->server->httpResponse->getResponse()->getStatusCode(), 'Invalid HTTP status received. Full response body: ' . $this->server->httpResponse->getResponse()->getBody()->getContents());
 
     }
 
@@ -1030,9 +1038,9 @@ XML;
         $request->setBody($body);
 
         $this->server->httpRequest = $request;
-        $this->server->exec();
+        $this->server->start();
 
-        $this->assertEquals(400, $this->response->status, 'Invalid HTTP status received. Full response body: ' . $this->response->body);
+        $this->assertEquals(400, $this->server->httpResponse->getResponse()->getStatusCode(), 'Invalid HTTP status received. Full response body: ' . $this->server->httpResponse->getResponse()->getBody()->getContents());
 
     }
 
@@ -1057,9 +1065,9 @@ XML;
         $request->setBody($body);
 
         $this->server->httpRequest = $request;
-        $this->server->exec();
+        $this->server->start();
 
-        $this->assertEquals(400, $this->response->status, 'Invalid HTTP status received. Full response body: ' . $this->response->body);
+        $this->assertEquals(400, $this->server->httpResponse->getResponse()->getStatusCode(), 'Invalid HTTP status received. Full response body: ' . $this->server->httpResponse->getResponse()->getBody()->getContents());
 
     }
 

--- a/tests/Sabre/CalDAV/Principal/ProxyReadTest.php
+++ b/tests/Sabre/CalDAV/Principal/ProxyReadTest.php
@@ -40,7 +40,7 @@ class ProxyReadTest extends \PHPUnit_Framework_TestCase {
     }
 
     /**
-     * @expectedException Sabre\DAV\Exception\Forbidden
+     * @expectedException \Sabre\DAV\Exception\Forbidden
      */
     function testDelete() {
 
@@ -50,7 +50,7 @@ class ProxyReadTest extends \PHPUnit_Framework_TestCase {
     }
 
     /**
-     * @expectedException Sabre\DAV\Exception\Forbidden
+     * @expectedException \Sabre\DAV\Exception\Forbidden
      */
     function testSetName() {
 

--- a/tests/Sabre/CalDAV/Principal/UserTest.php
+++ b/tests/Sabre/CalDAV/Principal/UserTest.php
@@ -25,7 +25,7 @@ class UserTest extends \PHPUnit_Framework_TestCase {
     }
 
     /**
-     * @expectedException Sabre\DAV\Exception\Forbidden
+     * @expectedException \Sabre\DAV\Exception\Forbidden
      */
     function testCreateFile() {
 
@@ -35,7 +35,7 @@ class UserTest extends \PHPUnit_Framework_TestCase {
     }
 
     /**
-     * @expectedException Sabre\DAV\Exception\Forbidden
+     * @expectedException \Sabre\DAV\Exception\Forbidden
      */
     function testCreateDirectory() {
 
@@ -61,7 +61,7 @@ class UserTest extends \PHPUnit_Framework_TestCase {
     }
 
     /**
-     * @expectedException Sabre\DAV\Exception\NotFound
+     * @expectedException \Sabre\DAV\Exception\NotFound
      */
     function testGetChildNotFound() {
 
@@ -71,7 +71,7 @@ class UserTest extends \PHPUnit_Framework_TestCase {
     }
 
     /**
-     * @expectedException Sabre\DAV\Exception\NotFound
+     * @expectedException \Sabre\DAV\Exception\NotFound
      */
     function testGetChildNotFound2() {
 

--- a/tests/Sabre/CalDAV/Schedule/DeliverNewEventTest.php
+++ b/tests/Sabre/CalDAV/Schedule/DeliverNewEventTest.php
@@ -65,9 +65,10 @@ ICS
 
         $response = $this->request($request);
 
-        $this->assertEquals(201, $response->getStatus(), 'Incorrect status code received. Response body:' . $response->getBodyAsString());
+        $responseBody = $response->getBody()->getContents();
+        $this->assertEquals(201, $response->getStatusCode(), 'Incorrect status code received. Response body:' . $responseBody);
 
-        $result = $this->request(new Request('GET', '/calendars/user1/default/foo.ics'))->getBody();
+        $result = $this->request(new Request('GET', '/calendars/user1/default/foo.ics'))->getBody()->getContents();
         $resultVObj = VObject\Reader::read($result);
 
         $this->assertEquals(

--- a/tests/Sabre/CalDAV/Schedule/DeliverNewEventTest.php
+++ b/tests/Sabre/CalDAV/Schedule/DeliverNewEventTest.php
@@ -2,7 +2,7 @@
 
 namespace Sabre\CalDAV\Schedule;
 
-use Sabre\HTTP\Request;
+use GuzzleHttp\Psr7\ServerRequest;
 use Sabre\VObject;
 
 class DeliverNewEventTest extends \Sabre\DAVServerTest {
@@ -34,8 +34,7 @@ class DeliverNewEventTest extends \Sabre\DAVServerTest {
 
     function testDelivery() {
 
-        $request = new Request('PUT', '/calendars/user1/default/foo.ics');
-        $request->setBody(<<<ICS
+        $request = new ServerRequest('PUT', '/calendars/user1/default/foo.ics', [], <<<ICS
 BEGIN:VCALENDAR
 VERSION:2.0
 PRODID:-//Apple Inc.//Mac OS X 10.9.1//EN
@@ -68,7 +67,7 @@ ICS
         $responseBody = $response->getBody()->getContents();
         $this->assertEquals(201, $response->getStatusCode(), 'Incorrect status code received. Response body:' . $responseBody);
 
-        $result = $this->request(new Request('GET', '/calendars/user1/default/foo.ics'))->getBody()->getContents();
+        $result = $this->request(new ServerRequest('GET', '/calendars/user1/default/foo.ics'))->getBody()->getContents();
         $resultVObj = VObject\Reader::read($result);
 
         $this->assertEquals(

--- a/tests/Sabre/CalDAV/Schedule/FreeBusyRequestTest.php
+++ b/tests/Sabre/CalDAV/Schedule/FreeBusyRequestTest.php
@@ -76,7 +76,7 @@ END:VCALENDAR',
             'Content-Type' => 'text/calendar',
         ]);
 
-        $this->server = new DAV\Server($tree);
+        $this->server = new DAV\Server($tree, null, null, function(){});
 
         $this->aclPlugin = new DAVACL\Plugin();
         $this->aclPlugin->allowUnauthenticatedAccess = false;
@@ -306,7 +306,7 @@ ICS;
         $this->assertEquals(200, $response->getStatusCode(), $responseBody);
         $this->assertEquals([
             'Content-Type' => ['application/xml'],
-            'X-Sabre-Version' => [DAV\Version::VERSION]
+
         ], $response->getHeaders());
 
         $strings = [
@@ -380,7 +380,7 @@ ICS;
         $this->assertEquals(200, $response->getStatusCode(), $responseBody);
         $this->assertEquals([
             'Content-Type' => ['application/xml'],
-            'X-Sabre-Version' => [DAV\Version::VERSION]
+
         ], $response->getHeaders());
 
         $strings = [
@@ -446,7 +446,7 @@ ICS;
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertEquals([
             'Content-Type' => ['application/xml'],
-            'X-Sabre-Version' => [DAV\Version::VERSION]
+
         ], $response->getHeaders());
 
         $strings = [
@@ -511,7 +511,7 @@ ICS;
         $this->assertEquals(200, $response->getStatusCode(), $responseBody);
         $this->assertEquals([
             'Content-Type' => ['application/xml'],
-            'X-Sabre-Version' => [DAV\Version::VERSION]
+
         ], $response->getHeaders());
 
         $strings = [
@@ -591,7 +591,6 @@ ICS;
         $this->assertEquals(200, $response->getStatusCode(), $responseBody);
         $this->assertEquals([
             'Content-Type' => ['application/xml'],
-            'X-Sabre-Version' => [\Sabre\DAV\Version::VERSION],
         ], $response->getHeaders());
 
         $strings = [

--- a/tests/Sabre/CalDAV/Schedule/IMipPluginTest.php
+++ b/tests/Sabre/CalDAV/Schedule/IMipPluginTest.php
@@ -51,7 +51,6 @@ ICS;
                     'Reply-To: Sender <sender@example.org>',
                     'From: system@example.org',
                     'Content-Type: text/calendar; charset=UTF-8; method=REPLY',
-                    'X-Sabre-Version: ' . \Sabre\DAV\Version::VERSION,
                 ],
             ]
         ];
@@ -123,7 +122,6 @@ ICS;
                     'Reply-To: Sender <sender@example.org>',
                     'From: system@example.org',
                     'Content-Type: text/calendar; charset=UTF-8; method=REQUEST',
-                    'X-Sabre-Version: ' . \Sabre\DAV\Version::VERSION,
                 ],
             ]
         ];
@@ -165,7 +163,6 @@ ICS;
                     'Reply-To: Sender <sender@example.org>',
                     'From: system@example.org',
                     'Content-Type: text/calendar; charset=UTF-8; method=CANCEL',
-                    'X-Sabre-Version: ' . \Sabre\DAV\Version::VERSION,
                 ],
             ]
         ];
@@ -179,7 +176,7 @@ ICS;
 
         $plugin = new IMip\MockPlugin('system@example.org');
 
-        $server = new Server();
+        $server = new Server(null, null, null, function(){});
         $server->addPlugin($plugin);
         $server->emit('schedule', [$message]);
 

--- a/tests/Sabre/CalDAV/Schedule/SchedulingObjectTest.php
+++ b/tests/Sabre/CalDAV/Schedule/SchedulingObjectTest.php
@@ -7,11 +7,11 @@ use Sabre\CalDAV\Backend;
 class SchedulingObjectTest extends \PHPUnit_Framework_TestCase {
 
     /**
-     * @var Sabre\CalDAV\Backend_PDO
+     * @var \Sabre\CalDAV\Backend_PDO
      */
     protected $backend;
     /**
-     * @var Sabre\CalDAV\Calendar
+     * @var \Sabre\CalDAV\Calendar
      */
     protected $calendar;
     protected $principalBackend;

--- a/tests/Sabre/CalDAV/SharingPluginTest.php
+++ b/tests/Sabre/CalDAV/SharingPluginTest.php
@@ -57,7 +57,7 @@ class SharingPluginTest extends \Sabre\DAVServerTest {
      */
     function testSetupWithoutCoreSharingPlugin() {
 
-        $server = new DAV\Server();
+        $server = new DAV\Server(null, null, null, function(){});
         $server->addPlugin(
             new SharingPlugin()
         );

--- a/tests/Sabre/CalDAV/SharingPluginTest.php
+++ b/tests/Sabre/CalDAV/SharingPluginTest.php
@@ -137,7 +137,7 @@ class SharingPluginTest extends \Sabre\DAVServerTest {
 
         $response = $this->request($request);
 
-        $this->assertEquals(501, $response->status, $response->body);
+        $this->assertEquals(501, $response->getStatusCode(), $response->getBody()->getContents());
 
     }
 
@@ -151,7 +151,7 @@ class SharingPluginTest extends \Sabre\DAVServerTest {
 
         $response = $this->request($request);
 
-        $this->assertEquals(501, $response->status, $response->body);
+        $this->assertEquals(501, $response->getStatusCode(), $response->getBody()->getContents());
 
     }
 
@@ -165,7 +165,7 @@ class SharingPluginTest extends \Sabre\DAVServerTest {
 
         $response = $this->request($request);
 
-        $this->assertEquals(501, $response->status, $response->body);
+        $this->assertEquals(501, $response->getStatusCode(), $response->getBody()->getContents());
 
     }
 
@@ -261,7 +261,7 @@ RRR;
 
         $request->setBody($xml);
         $response = $this->request($request);
-        $this->assertEquals(200, $response->status, $response->body);
+        $this->assertEquals(200, $response->getStatusCode(), $response->getBody()->getContents());
 
     }
 
@@ -279,7 +279,7 @@ RRR;
 ';
         $request->setBody($xml);
         $response = $this->request($request);
-        $this->assertEquals(400, $response->status, $response->body);
+        $this->assertEquals(400, $response->getStatusCode(), $response->getBody()->getContents());
 
     }
 
@@ -298,7 +298,7 @@ RRR;
 ';
         $request->setBody($xml);
         $response = $this->request($request);
-        $this->assertEquals(501, $response->status, $response->body);
+        $this->assertEquals(501, $response->getStatusCode(), $response->getBody()->getContents());
 
         // If the plugin did not handle this request, it must ensure that the
         // body is still accessible by other plugins.
@@ -317,7 +317,7 @@ RRR;
         $request->setBody($xml);
 
         $response = $this->request($request);
-        $this->assertEquals(202, $response->status, $response->body);
+        $this->assertEquals(202, $response->getStatusCode(), $response->getBody()->getContents());
 
     }
 
@@ -337,7 +337,7 @@ RRR;
         $request->setBody($xml);
 
         $response = $this->request($request);
-        $this->assertEquals(200, $response->status, $response->body);
+        $this->assertEquals(200, $response->getStatusCode(), $response->getBody()->getContents());
 
     }
 
@@ -390,7 +390,7 @@ RRR;
         $request->setBody($xml);
 
         $response = $this->request($request);
-        $this->assertEquals(501, $response->status, $response->body);
+        $this->assertEquals(501, $response->getStatusCode(), $response->getBody()->getContents());
 
     }
 }

--- a/tests/Sabre/CalDAV/Subscriptions/CreateSubscriptionTest.php
+++ b/tests/Sabre/CalDAV/Subscriptions/CreateSubscriptionTest.php
@@ -45,7 +45,7 @@ XML;
         $request = new Request('MKCOL', '/calendars/user1/subscription1', $headers, $body);
 
         $response = $this->request($request);
-        $this->assertEquals(201, $response->getStatus());
+        $this->assertEquals(201, $response->getStatusCode());
         $subscriptions = $this->caldavBackend->getSubscriptionsForUser('principals/user1');
         $this->assertSubscription($subscriptions[0]);
 
@@ -89,7 +89,7 @@ XML;
         $request = new Request('MKCALENDAR', '/calendars/user1/subscription1', $headers, $body);
 
         $response = $this->request($request);
-        $this->assertEquals(201, $response->getStatus());
+        $this->assertEquals(201, $response->getStatusCode());
         $subscriptions = $this->caldavBackend->getSubscriptionsForUser('principals/user1');
         $this->assertSubscription($subscriptions[0]);
 

--- a/tests/Sabre/CalDAV/Subscriptions/CreateSubscriptionTest.php
+++ b/tests/Sabre/CalDAV/Subscriptions/CreateSubscriptionTest.php
@@ -2,6 +2,7 @@
 
 namespace Sabre\CalDAV\Subscriptions;
 
+use GuzzleHttp\Psr7\ServerRequest;
 use Sabre\CalDAV;
 use Sabre\HTTP\Request;
 
@@ -42,7 +43,7 @@ XML;
         $headers = [
             'Content-Type' => 'application/xml',
         ];
-        $request = new Request('MKCOL', '/calendars/user1/subscription1', $headers, $body);
+        $request = new ServerRequest('MKCOL', '/calendars/user1/subscription1', $headers, $body);
 
         $response = $this->request($request);
         $this->assertEquals(201, $response->getStatusCode());
@@ -86,7 +87,7 @@ XML;
         $headers = [
             'Content-Type' => 'application/xml',
         ];
-        $request = new Request('MKCALENDAR', '/calendars/user1/subscription1', $headers, $body);
+        $request = new ServerRequest('MKCALENDAR', '/calendars/user1/subscription1', $headers, $body);
 
         $response = $this->request($request);
         $this->assertEquals(201, $response->getStatusCode());

--- a/tests/Sabre/CalDAV/Subscriptions/PluginTest.php
+++ b/tests/Sabre/CalDAV/Subscriptions/PluginTest.php
@@ -3,12 +3,13 @@
 namespace Sabre\CalDAV\Subscriptions;
 
 use Sabre\DAV\PropFind;
+use Sabre\DAV\Server;
 
 class PluginTest extends \PHPUnit_Framework_TestCase {
 
     function testInit() {
 
-        $server = new \Sabre\DAV\Server();
+        $server = new Server(null, null, null, function(){});
         $plugin = new Plugin();
 
         $server->addPlugin($plugin);

--- a/tests/Sabre/CalDAV/ValidateICalTest.php
+++ b/tests/Sabre/CalDAV/ValidateICalTest.php
@@ -42,7 +42,7 @@ class ValidateICalTest extends \PHPUnit_Framework_TestCase {
             new CalendarRoot($principalBackend, $this->calBackend),
         ];
 
-        $this->server = new DAV\Server($tree);
+        $this->server = new DAV\Server($tree, null, null, function(){});
         $this->server->debugExceptions = true;
 
         $plugin = new Plugin();
@@ -89,7 +89,7 @@ ICS;
         $responseBody = $response->getBody()->getContents();
         $this->assertEquals(201, $response->getStatusCode(), 'Incorrect status returned! Full response body: ' . $responseBody);
         $this->assertEquals([
-            'X-Sabre-Version' => [DAV\Version::VERSION],
+
             'Content-Length'  => ['0'],
             'ETag'            => ['"' . md5($ics) . '"'],
         ], $response->getHeaders());
@@ -157,7 +157,6 @@ ICS;
 
         $this->assertEquals(201, $response->getStatusCode(), 'Incorrect status returned! Full response body: ' . $response->getBody()->getContents());
         $this->assertEquals([
-            'X-Sabre-Version'  => [DAV\Version::VERSION],
             'Content-Length'   => ['0'],
             'X-Sabre-Ew-Gross' => ['iCalendar validation warning: VERSION MUST appear exactly once in a VCALENDAR component'],
         ], $response->getHeaders());

--- a/tests/Sabre/CalDAV/ValidateICalTest.php
+++ b/tests/Sabre/CalDAV/ValidateICalTest.php
@@ -2,6 +2,7 @@
 
 namespace Sabre\CalDAV;
 
+use Psr\Http\Message\ResponseInterface;
 use Sabre\DAV;
 use Sabre\DAVACL;
 use Sabre\HTTP;
@@ -11,11 +12,11 @@ require_once 'Sabre/HTTP/ResponseMock.php';
 class ValidateICalTest extends \PHPUnit_Framework_TestCase {
 
     /**
-     * @var Sabre\DAV\Server
+     * @var DAV\Server
      */
     protected $server;
     /**
-     * @var Sabre\CalDAV\Backend\Mock
+     * @var CalDAV\Backend\Mock
      */
     protected $calBackend;
 
@@ -50,17 +51,14 @@ class ValidateICalTest extends \PHPUnit_Framework_TestCase {
         $plugin = new Plugin();
         $this->server->addPlugin($plugin);
 
-        $response = new HTTP\ResponseMock();
-        $this->server->httpResponse = $response;
-
     }
 
-    function request(HTTP\Request $request) {
+    function request(HTTP\Request $request): ResponseInterface {
 
         $this->server->httpRequest = $request;
-        $this->server->exec();
+        $this->server->start();
 
-        return $this->server->httpResponse;
+        return $this->server->httpResponse->getResponse();
 
     }
 
@@ -73,7 +71,7 @@ class ValidateICalTest extends \PHPUnit_Framework_TestCase {
 
         $response = $this->request($request);
 
-        $this->assertEquals(415, $response->status);
+        $this->assertEquals(415, $response->getStatusCode());
 
     }
 
@@ -101,7 +99,8 @@ ICS;
 
         $response = $this->request($request);
 
-        $this->assertEquals(201, $response->status, 'Incorrect status returned! Full response body: ' . $response->body);
+        $responseBody = $response->getBody()->getContents();
+        $this->assertEquals(201, $response->getStatusCode(), 'Incorrect status returned! Full response body: ' . $responseBody);
         $this->assertEquals([
             'X-Sabre-Version' => [DAV\Version::VERSION],
             'Content-Length'  => ['0'],
@@ -142,7 +141,7 @@ ICS;
 
         $response = $this->request($request);
 
-        $this->assertEquals(415, $response->status, 'Incorrect status returned! Full response body: ' . $response->body);
+        $this->assertEquals(415, $response->getStatusCode(), 'Incorrect status returned! Full response body: ' . $response->getBody()->getContents());
 
     }
 
@@ -169,7 +168,7 @@ ICS;
 
         $response = $this->request($request);
 
-        $this->assertEquals(201, $response->status, 'Incorrect status returned! Full response body: ' . $response->body);
+        $this->assertEquals(201, $response->getStatusCode(), 'Incorrect status returned! Full response body: ' . $response->getBody()->getContents());
         $this->assertEquals([
             'X-Sabre-Version'  => [DAV\Version::VERSION],
             'Content-Length'   => ['0'],
@@ -217,7 +216,7 @@ ICS;
         $request->setBody($ics);
 
         $response = $this->request($request);
-        $this->assertEquals(403, $response->status, 'Incorrect status returned! Full response body: ' . $response->body);
+        $this->assertEquals(403, $response->getStatusCode(), 'Incorrect status returned! Full response body: ' . $response->getBody()->getContents());
 
     }
 
@@ -231,7 +230,7 @@ ICS;
 
         $response = $this->request($request);
 
-        $this->assertEquals(415, $response->status, 'Incorrect status returned! Full response body: ' . $response->body);
+        $this->assertEquals(415, $response->getStatusCode(), 'Incorrect status returned! Full response body: ' . $response->getBody()->getContents());
 
     }
 
@@ -245,7 +244,7 @@ ICS;
 
         $response = $this->request($request);
 
-        $this->assertEquals(415, $response->status, 'Incorrect status returned! Full response body: ' . $response->body);
+        $this->assertEquals(415, $response->getStatusCode(), 'Incorrect status returned! Full response body: ' . $response->getBody()->getContents());
 
     }
 
@@ -259,7 +258,7 @@ ICS;
 
         $response = $this->request($request);
 
-        $this->assertEquals(415, $response->status, 'Incorrect status returned! Full response body: ' . $response->body);
+        $this->assertEquals(415, $response->getStatusCode(), 'Incorrect status returned! Full response body: ' . $response->getBody()->getContents());
 
     }
 
@@ -273,7 +272,7 @@ ICS;
 
         $response = $this->request($request);
 
-        $this->assertEquals(415, $response->status, 'Incorrect status returned! Full response body: ' . $response->body);
+        $this->assertEquals(415, $response->getStatusCode(), 'Incorrect status returned! Full response body: ' . $response->getBody()->getContents());
 
     }
 
@@ -287,7 +286,7 @@ ICS;
 
         $response = $this->request($request);
 
-        $this->assertEquals(403, $response->status, 'Incorrect status returned! Full response body: ' . $response->body);
+        $this->assertEquals(403, $response->getStatusCode(), 'Incorrect status returned! Full response body: ' . $response->getBody()->getContents());
 
     }
 
@@ -301,7 +300,7 @@ ICS;
 
         $response = $this->request($request);
 
-        $this->assertEquals(415, $response->status);
+        $this->assertEquals(415, $response->getStatusCode());
 
     }
 
@@ -327,7 +326,7 @@ ICS;
         $request->setBody($ics);
         $response = $this->request($request);
 
-        $this->assertEquals(204, $response->status);
+        $this->assertEquals(204, $response->getStatusCode());
 
         $expected = [
             'uri'          => 'blabla.ics',
@@ -350,7 +349,7 @@ ICS;
 
         $response = $this->request($request);
 
-        $this->assertEquals(403, $response->status, 'Incorrect status returned! Full response body: ' . $response->body);
+        $this->assertEquals(403, $response->getStatusCode(), 'Incorrect status returned! Full response body: ' . $response->getBody()->getContents());
 
     }
 
@@ -365,7 +364,7 @@ ICS;
 
         $response = $this->request($request);
 
-        $this->assertEquals(403, $response->status, 'Incorrect status returned! Full response body: ' . $response->body);
+        $this->assertEquals(403, $response->getStatusCode(), 'Incorrect status returned! Full response body: ' . $response->getBody()->getContents());
 
     }
 
@@ -399,8 +398,8 @@ ICS;
 
         $response = $this->request($request);
 
-        $this->assertEquals(201, $response->status, 'Incorrect status returned! Full response body: ' . $response->body);
-        $this->assertNull($response->getHeader('ETag'));
+        $this->assertEquals(201, $response->getStatusCode(), 'Incorrect status returned! Full response body: ' . $response->getBody()->getContents());
+        $this->assertEmpty($response->getHeader('ETag'));
 
     }
 }

--- a/tests/Sabre/CalDAV/Xml/Request/CalendarQueryReportTest.php
+++ b/tests/Sabre/CalDAV/Xml/Request/CalendarQueryReportTest.php
@@ -47,7 +47,7 @@ XML;
     }
 
     /**
-     * @expectedException Sabre\DAV\Exception\BadRequest
+     * @expectedException \Sabre\DAV\Exception\BadRequest
      */
     function testDeserializeNoFilter() {
 

--- a/tests/Sabre/CardDAV/AbstractPluginTest.php
+++ b/tests/Sabre/CardDAV/AbstractPluginTest.php
@@ -33,7 +33,7 @@ abstract class AbstractPluginTest extends \PHPUnit_Framework_TestCase {
 
         $this->plugin = new Plugin();
         $this->plugin->directories = ['directory'];
-        $this->server = new DAV\Server($tree);
+        $this->server = new DAV\Server($tree, null, null, function(){});
 
         $this->server->addPlugin($this->plugin);
         $this->server->debugExceptions = true;

--- a/tests/Sabre/CardDAV/AbstractPluginTest.php
+++ b/tests/Sabre/CardDAV/AbstractPluginTest.php
@@ -13,7 +13,7 @@ abstract class AbstractPluginTest extends \PHPUnit_Framework_TestCase {
      */
     protected $plugin;
     /**
-     * @var Sabre\DAV\Server
+     * @var DAV\Server
      */
     protected $server;
     /**

--- a/tests/Sabre/CardDAV/AbstractPluginTest.php
+++ b/tests/Sabre/CardDAV/AbstractPluginTest.php
@@ -9,7 +9,7 @@ use Sabre\HTTP;
 abstract class AbstractPluginTest extends \PHPUnit_Framework_TestCase {
 
     /**
-     * @var Sabre\CardDAV\Plugin
+     * @var \Sabre\CardDAV\Plugin
      */
     protected $plugin;
     /**
@@ -17,7 +17,7 @@ abstract class AbstractPluginTest extends \PHPUnit_Framework_TestCase {
      */
     protected $server;
     /**
-     * @var Sabre\CardDAV\Backend\Mock;
+     * @var \Sabre\CardDAV\Backend\Mock;
      */
     protected $backend;
 
@@ -34,7 +34,7 @@ abstract class AbstractPluginTest extends \PHPUnit_Framework_TestCase {
         $this->plugin = new Plugin();
         $this->plugin->directories = ['directory'];
         $this->server = new DAV\Server($tree);
-        $this->server->sapi = new HTTP\SapiMock();
+
         $this->server->addPlugin($this->plugin);
         $this->server->debugExceptions = true;
 

--- a/tests/Sabre/CardDAV/AddressBookHomeTest.php
+++ b/tests/Sabre/CardDAV/AddressBookHomeTest.php
@@ -7,7 +7,7 @@ use Sabre\DAV\MkCol;
 class AddressBookHomeTest extends \PHPUnit_Framework_TestCase {
 
     /**
-     * @var Sabre\CardDAV\AddressBookHome
+     * @var \Sabre\CardDAV\AddressBookHome
      */
     protected $s;
     protected $backend;
@@ -29,7 +29,7 @@ class AddressBookHomeTest extends \PHPUnit_Framework_TestCase {
     }
 
     /**
-     * @expectedException Sabre\DAV\Exception\MethodNotAllowed
+     * @expectedException \Sabre\DAV\Exception\MethodNotAllowed
      */
     function testSetName() {
 
@@ -38,7 +38,7 @@ class AddressBookHomeTest extends \PHPUnit_Framework_TestCase {
     }
 
     /**
-     * @expectedException Sabre\DAV\Exception\MethodNotAllowed
+     * @expectedException \Sabre\DAV\Exception\MethodNotAllowed
      */
     function testDelete() {
 
@@ -53,7 +53,7 @@ class AddressBookHomeTest extends \PHPUnit_Framework_TestCase {
     }
 
     /**
-     * @expectedException Sabre\DAV\Exception\MethodNotAllowed
+     * @expectedException \Sabre\DAV\Exception\MethodNotAllowed
      */
     function testCreateFile() {
 
@@ -62,7 +62,7 @@ class AddressBookHomeTest extends \PHPUnit_Framework_TestCase {
     }
 
     /**
-     * @expectedException Sabre\DAV\Exception\MethodNotAllowed
+     * @expectedException \Sabre\DAV\Exception\MethodNotAllowed
      */
     function testCreateDirectory() {
 
@@ -79,7 +79,7 @@ class AddressBookHomeTest extends \PHPUnit_Framework_TestCase {
     }
 
     /**
-     * @expectedException Sabre\DAV\Exception\NotFound
+     * @expectedException \Sabre\DAV\Exception\NotFound
      */
     function testGetChild404() {
 
@@ -114,7 +114,7 @@ class AddressBookHomeTest extends \PHPUnit_Framework_TestCase {
     }
 
     /**
-     * @expectedException Sabre\DAV\Exception\InvalidResourceType
+     * @expectedException \Sabre\DAV\Exception\InvalidResourceType
      */
     function testCreateExtendedCollectionInvalid() {
 
@@ -141,7 +141,7 @@ class AddressBookHomeTest extends \PHPUnit_Framework_TestCase {
     }
 
     /**
-     * @expectedException Sabre\DAV\Exception\Forbidden
+     * @expectedException \Sabre\DAV\Exception\Forbidden
      */
     function testSetACL() {
 

--- a/tests/Sabre/CardDAV/AddressBookQueryTest.php
+++ b/tests/Sabre/CardDAV/AddressBookQueryTest.php
@@ -2,6 +2,7 @@
 
 namespace Sabre\CardDAV;
 
+use GuzzleHttp\Psr7\ServerRequest;
 use Sabre\DAV;
 use Sabre\HTTP;
 
@@ -12,13 +13,10 @@ class AddressBookQueryTest extends AbstractPluginTest {
 
     function testQuery() {
 
-        $request = new HTTP\Request(
+        $request = new ServerRequest(
             'REPORT',
             '/addressbooks/user1/book1',
-            ['Depth' => '1']
-        );
-
-        $request->setBody(
+            ['Depth' => '1'],
 '<?xml version="1.0"?>
 <c:addressbook-query xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:carddav">
     <d:prop>
@@ -30,11 +28,11 @@ class AddressBookQueryTest extends AbstractPluginTest {
 </c:addressbook-query>'
             );
 
-        $this->server->httpRequest = $request;
 
-        $this->server->start();
 
-        $response = $this->server->httpResponse->getResponse();
+
+
+        $response = $this->server->handle($request);
         $responseBody = $response->getBody()->getContents();
 
         $this->assertEquals(207, $response->getStatusCode(), 'Incorrect status code. Full response body:' . $responseBody);
@@ -62,13 +60,10 @@ class AddressBookQueryTest extends AbstractPluginTest {
 
     function testQueryDepth0() {
 
-        $request = new HTTP\Request(
+        $request = new ServerRequest(
             'REPORT',
             '/addressbooks/user1/book1/card1',
-            ['Depth' => '0']
-        );
-
-        $request->setBody(
+            ['Depth' => '0'],
 '<?xml version="1.0"?>
 <c:addressbook-query xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:carddav">
     <d:prop>
@@ -80,10 +75,10 @@ class AddressBookQueryTest extends AbstractPluginTest {
 </c:addressbook-query>'
             );
 
-        $this->server->httpRequest = $request;
 
-        $this->server->start();
-        $response = $this->server->httpResponse->getResponse();
+
+
+        $response = $this->server->handle($request);
         $responseBody = $response->getBody()->getContents();
 
         $this->assertEquals(207, $response->getStatusCode(), 'Incorrect status code. Full response body:' . $responseBody);
@@ -106,13 +101,10 @@ class AddressBookQueryTest extends AbstractPluginTest {
 
     function testQueryNoMatch() {
 
-        $request = new HTTP\Request(
+        $request = new ServerRequest(
             'REPORT',
             '/addressbooks/user1/book1',
-            ['Depth' => '1']
-        );
-
-        $request->setBody(
+            ['Depth' => '1'],
 '<?xml version="1.0"?>
 <c:addressbook-query xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:carddav">
     <d:prop>
@@ -124,11 +116,11 @@ class AddressBookQueryTest extends AbstractPluginTest {
 </c:addressbook-query>'
             );
 
-        $this->server->httpRequest = $request;
 
-        $this->server->start();
 
-        $response = $this->server->httpResponse->getResponse();
+
+
+        $response = $this->server->handle($request);
         $responseBody = $response->getBody()->getContents();
 
         $this->assertEquals(207, $response->getStatusCode(), 'Incorrect status code. Full response body:' . $responseBody);
@@ -144,13 +136,10 @@ class AddressBookQueryTest extends AbstractPluginTest {
 
     function testQueryLimit() {
 
-        $request = HTTP\Sapi::createFromServerArray([
-            'REQUEST_METHOD' => 'REPORT',
-            'REQUEST_URI'    => '/addressbooks/user1/book1',
-            'HTTP_DEPTH'     => '1',
-        ]);
-
-        $request->setBody(
+        $request = new ServerRequest(
+            'REPORT',
+            '/addressbooks/user1/book1',
+            ['Depth'     => '1'],
 '<?xml version="1.0"?>
 <c:addressbook-query xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:carddav">
     <d:prop>
@@ -163,10 +152,10 @@ class AddressBookQueryTest extends AbstractPluginTest {
 </c:addressbook-query>'
             );
 
-        $this->server->httpRequest = $request;
 
-        $this->server->start();
-        $response = $this->server->httpResponse->getResponse();
+
+
+        $response = $this->server->handle($request);
         $responseBody = $response->getBody()->getContents();
 
         $this->assertEquals(207, $response->getStatusCode(), 'Incorrect status code. Full response body:' . $responseBody);
@@ -189,13 +178,10 @@ class AddressBookQueryTest extends AbstractPluginTest {
 
     function testJson() {
 
-        $request = new HTTP\Request(
+        $request = new ServerRequest(
             'REPORT',
             '/addressbooks/user1/book1/card1',
-            ['Depth' => '0']
-        );
-
-        $request->setBody(
+            ['Depth' => '0'],
 '<?xml version="1.0"?>
 <c:addressbook-query xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:carddav">
     <d:prop>
@@ -205,10 +191,10 @@ class AddressBookQueryTest extends AbstractPluginTest {
 </c:addressbook-query>'
             );
 
-        $this->server->httpRequest = $request;
 
-        $this->server->start();
-        $response = $this->server->httpResponse->getResponse();
+
+
+        $response = $this->server->handle($request);
         $responseBody = $response->getBody()->getContents();
         $this->assertEquals(207, $response->getStatusCode(), 'Incorrect status code. Full response body:' . $responseBody);
 
@@ -232,13 +218,10 @@ class AddressBookQueryTest extends AbstractPluginTest {
 
     function testVCard4() {
 
-        $request = new HTTP\Request(
+        $request = new ServerRequest(
             'REPORT',
             '/addressbooks/user1/book1/card1',
-            ['Depth' => '0']
-        );
-
-        $request->setBody(
+            ['Depth' => '0'],
 '<?xml version="1.0"?>
 <c:addressbook-query xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:carddav">
     <d:prop>
@@ -248,10 +231,10 @@ class AddressBookQueryTest extends AbstractPluginTest {
 </c:addressbook-query>'
             );
 
-        $this->server->httpRequest = $request;
 
-        $this->server->start();
-        $response = $this->server->httpResponse->getResponse();
+
+
+        $response = $this->server->handle($request);
         $responseBody = $response->getBody()->getContents();
 
         $this->assertEquals(207, $response->getStatusCode(), 'Incorrect status code. Full response body:' . $responseBody);
@@ -276,13 +259,10 @@ class AddressBookQueryTest extends AbstractPluginTest {
 
     function testAddressBookDepth0() {
 
-        $request = new HTTP\Request(
+        $request = new ServerRequest(
             'REPORT',
             '/addressbooks/user1/book1',
-            ['Depth' => '0']
-        );
-
-        $request->setBody(
+            ['Depth' => '0'],
             '<?xml version="1.0"?>
 <c:addressbook-query xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:carddav">
     <d:prop>
@@ -292,9 +272,9 @@ class AddressBookQueryTest extends AbstractPluginTest {
 </c:addressbook-query>'
         );
 
-        $this->server->httpRequest = $request;
-        $this->server->start();
-        $response = $this->server->httpResponse->getResponse();
+
+
+        $response = $this->server->handle($request);
         $responseBody = $response->getBody()->getContents();
 
 
@@ -304,13 +284,10 @@ class AddressBookQueryTest extends AbstractPluginTest {
 
     function testAddressBookProperties() {
 
-        $request = new HTTP\Request(
+        $request = new ServerRequest(
             'REPORT',
             '/addressbooks/user1/book3',
-            ['Depth' => '1']
-        );
-
-        $request->setBody(
+            ['Depth' => '1'],
             '<?xml version="1.0"?>
 <c:addressbook-query xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:carddav">
     <d:prop>
@@ -323,10 +300,10 @@ class AddressBookQueryTest extends AbstractPluginTest {
 </c:addressbook-query>'
         );
 
-        $this->server->httpRequest = $request;
 
-        $this->server->start();
-        $response = $this->server->httpResponse->getResponse();
+
+
+        $response = $this->server->handle($request);
         $responseBody = $response->getBody()->getContents();
         $this->assertEquals(207, $response->getStatusCode(), 'Incorrect status code. Full response body:' . $responseBody);
 

--- a/tests/Sabre/CardDAV/AddressBookQueryTest.php
+++ b/tests/Sabre/CardDAV/AddressBookQueryTest.php
@@ -30,19 +30,19 @@ class AddressBookQueryTest extends AbstractPluginTest {
 </c:addressbook-query>'
             );
 
-        $response = new HTTP\ResponseMock();
-
         $this->server->httpRequest = $request;
-        $this->server->httpResponse = $response;
 
-        $this->server->exec();
+        $this->server->start();
 
-        $this->assertEquals(207, $response->status, 'Incorrect status code. Full response body:' . $response->body);
+        $response = $this->server->httpResponse->getResponse();
+        $responseBody = $response->getBody()->getContents();
+
+        $this->assertEquals(207, $response->getStatusCode(), 'Incorrect status code. Full response body:' . $responseBody);
 
         // using the client for parsing
         $client = new DAV\Client(['baseUri' => '/']);
 
-        $result = $client->parseMultiStatus($response->body);
+        $result = $client->parseMultiStatus($responseBody);
 
         $this->assertEquals([
             '/addressbooks/user1/book1/card1' => [
@@ -80,19 +80,18 @@ class AddressBookQueryTest extends AbstractPluginTest {
 </c:addressbook-query>'
             );
 
-        $response = new HTTP\ResponseMock();
-
         $this->server->httpRequest = $request;
-        $this->server->httpResponse = $response;
 
-        $this->server->exec();
+        $this->server->start();
+        $response = $this->server->httpResponse->getResponse();
+        $responseBody = $response->getBody()->getContents();
 
-        $this->assertEquals(207, $response->status, 'Incorrect status code. Full response body:' . $response->body);
+        $this->assertEquals(207, $response->getStatusCode(), 'Incorrect status code. Full response body:' . $responseBody);
 
         // using the client for parsing
         $client = new DAV\Client(['baseUri' => '/']);
 
-        $result = $client->parseMultiStatus($response->body);
+        $result = $client->parseMultiStatus($responseBody);
 
         $this->assertEquals([
             '/addressbooks/user1/book1/card1' => [
@@ -125,19 +124,19 @@ class AddressBookQueryTest extends AbstractPluginTest {
 </c:addressbook-query>'
             );
 
-        $response = new HTTP\ResponseMock();
-
         $this->server->httpRequest = $request;
-        $this->server->httpResponse = $response;
 
-        $this->server->exec();
+        $this->server->start();
 
-        $this->assertEquals(207, $response->status, 'Incorrect status code. Full response body:' . $response->body);
+        $response = $this->server->httpResponse->getResponse();
+        $responseBody = $response->getBody()->getContents();
+
+        $this->assertEquals(207, $response->getStatusCode(), 'Incorrect status code. Full response body:' . $responseBody);
 
         // using the client for parsing
         $client = new DAV\Client(['baseUri' => '/']);
 
-        $result = $client->parseMultiStatus($response->body);
+        $result = $client->parseMultiStatus($responseBody);
 
         $this->assertEquals([], $result);
 
@@ -164,19 +163,18 @@ class AddressBookQueryTest extends AbstractPluginTest {
 </c:addressbook-query>'
             );
 
-        $response = new HTTP\ResponseMock();
-
         $this->server->httpRequest = $request;
-        $this->server->httpResponse = $response;
 
-        $this->server->exec();
+        $this->server->start();
+        $response = $this->server->httpResponse->getResponse();
+        $responseBody = $response->getBody()->getContents();
 
-        $this->assertEquals(207, $response->status, 'Incorrect status code. Full response body:' . $response->body);
+        $this->assertEquals(207, $response->getStatusCode(), 'Incorrect status code. Full response body:' . $responseBody);
 
         // using the client for parsing
         $client = new DAV\Client(['baseUri' => '/']);
 
-        $result = $client->parseMultiStatus($response->body);
+        $result = $client->parseMultiStatus($responseBody);
 
         $this->assertEquals([
             '/addressbooks/user1/book1/card1' => [
@@ -207,19 +205,17 @@ class AddressBookQueryTest extends AbstractPluginTest {
 </c:addressbook-query>'
             );
 
-        $response = new HTTP\ResponseMock();
-
         $this->server->httpRequest = $request;
-        $this->server->httpResponse = $response;
 
-        $this->server->exec();
-
-        $this->assertEquals(207, $response->status, 'Incorrect status code. Full response body:' . $response->body);
+        $this->server->start();
+        $response = $this->server->httpResponse->getResponse();
+        $responseBody = $response->getBody()->getContents();
+        $this->assertEquals(207, $response->getStatusCode(), 'Incorrect status code. Full response body:' . $responseBody);
 
         // using the client for parsing
         $client = new DAV\Client(['baseUri' => '/']);
 
-        $result = $client->parseMultiStatus($response->body);
+        $result = $client->parseMultiStatus($responseBody);
 
         $vobjVersion = \Sabre\VObject\Version::VERSION;
 
@@ -252,19 +248,18 @@ class AddressBookQueryTest extends AbstractPluginTest {
 </c:addressbook-query>'
             );
 
-        $response = new HTTP\ResponseMock();
-
         $this->server->httpRequest = $request;
-        $this->server->httpResponse = $response;
 
-        $this->server->exec();
+        $this->server->start();
+        $response = $this->server->httpResponse->getResponse();
+        $responseBody = $response->getBody()->getContents();
 
-        $this->assertEquals(207, $response->status, 'Incorrect status code. Full response body:' . $response->body);
+        $this->assertEquals(207, $response->getStatusCode(), 'Incorrect status code. Full response body:' . $responseBody);
 
         // using the client for parsing
         $client = new DAV\Client(['baseUri' => '/']);
 
-        $result = $client->parseMultiStatus($response->body);
+        $result = $client->parseMultiStatus($responseBody);
 
         $vobjVersion = \Sabre\VObject\Version::VERSION;
 
@@ -297,14 +292,14 @@ class AddressBookQueryTest extends AbstractPluginTest {
 </c:addressbook-query>'
         );
 
-        $response = new HTTP\ResponseMock();
-
         $this->server->httpRequest = $request;
-        $this->server->httpResponse = $response;
+        $this->server->start();
+        $response = $this->server->httpResponse->getResponse();
+        $responseBody = $response->getBody()->getContents();
 
-        $this->server->exec();
 
-        $this->assertEquals(415, $response->status, 'Incorrect status code. Full response body:' . $response->body);
+
+        $this->assertEquals(415, $response->getStatusCode(), 'Incorrect status code. Full response body:' . $responseBody);
     }
 
     function testAddressBookProperties() {
@@ -328,19 +323,17 @@ class AddressBookQueryTest extends AbstractPluginTest {
 </c:addressbook-query>'
         );
 
-        $response = new HTTP\ResponseMock();
-
         $this->server->httpRequest = $request;
-        $this->server->httpResponse = $response;
 
-        $this->server->exec();
-
-        $this->assertEquals(207, $response->status, 'Incorrect status code. Full response body:' . $response->body);
+        $this->server->start();
+        $response = $this->server->httpResponse->getResponse();
+        $responseBody = $response->getBody()->getContents();
+        $this->assertEquals(207, $response->getStatusCode(), 'Incorrect status code. Full response body:' . $responseBody);
 
         // using the client for parsing
         $client = new DAV\Client(['baseUri' => '/']);
 
-        $result = $client->parseMultiStatus($response->body);
+        $result = $client->parseMultiStatus($responseBody);
 
         $this->assertEquals([
             '/addressbooks/user1/book3/card3' => [

--- a/tests/Sabre/CardDAV/AddressBookTest.php
+++ b/tests/Sabre/CardDAV/AddressBookTest.php
@@ -9,7 +9,7 @@ class AddressBookTest extends \PHPUnit_Framework_TestCase {
     use \Sabre\DAV\DbTestHelperTrait;
 
     /**
-     * @var Sabre\CardDAV\AddressBook
+     * @var \Sabre\CardDAV\AddressBook
      */
     protected $ab;
     protected $backend;
@@ -44,7 +44,7 @@ class AddressBookTest extends \PHPUnit_Framework_TestCase {
     }
 
     /**
-     * @expectedException Sabre\DAV\Exception\NotFound
+     * @expectedException \Sabre\DAV\Exception\NotFound
      */
     function testGetChildNotFound() {
 
@@ -63,7 +63,7 @@ class AddressBookTest extends \PHPUnit_Framework_TestCase {
     }
 
     /**
-     * @expectedException Sabre\DAV\Exception\MethodNotAllowed
+     * @expectedException \Sabre\DAV\Exception\MethodNotAllowed
      */
     function testCreateDirectory() {
 
@@ -90,7 +90,7 @@ class AddressBookTest extends \PHPUnit_Framework_TestCase {
     }
 
     /**
-     * @expectedException Sabre\DAV\Exception\MethodNotAllowed
+     * @expectedException \Sabre\DAV\Exception\MethodNotAllowed
      */
     function testSetName() {
 
@@ -140,7 +140,7 @@ class AddressBookTest extends \PHPUnit_Framework_TestCase {
     }
 
     /**
-     * @expectedException Sabre\DAV\Exception\Forbidden
+     * @expectedException \Sabre\DAV\Exception\Forbidden
      */
     function testSetACL() {
 

--- a/tests/Sabre/CardDAV/Backend/AbstractPDOTest.php
+++ b/tests/Sabre/CardDAV/Backend/AbstractPDOTest.php
@@ -149,7 +149,7 @@ abstract class AbstractPDOTest extends \PHPUnit_Framework_TestCase {
     }
 
     /**
-     * @expectedException Sabre\DAV\Exception\BadRequest
+     * @expectedException \Sabre\DAV\Exception\BadRequest
      */
     function testCreateAddressBookUnsupportedProp() {
 

--- a/tests/Sabre/CardDAV/CardTest.php
+++ b/tests/Sabre/CardDAV/CardTest.php
@@ -5,11 +5,11 @@ namespace Sabre\CardDAV;
 class CardTest extends \PHPUnit_Framework_TestCase {
 
     /**
-     * @var Sabre\CardDAV\Card
+     * @var \Sabre\CardDAV\Card
      */
     protected $card;
     /**
-     * @var Sabre\CardDAV\MockBackend
+     * @var \Sabre\CardDAV\MockBackend
      */
     protected $backend;
 
@@ -191,7 +191,7 @@ class CardTest extends \PHPUnit_Framework_TestCase {
     }
 
     /**
-     * @expectedException Sabre\DAV\Exception\Forbidden
+     * @expectedException \Sabre\DAV\Exception\Forbidden
      */
     function testSetACL() {
 

--- a/tests/Sabre/CardDAV/IDirectoryTest.php
+++ b/tests/Sabre/CardDAV/IDirectoryTest.php
@@ -12,7 +12,7 @@ class IDirectoryTest extends \PHPUnit_Framework_TestCase {
             new DirectoryMock('directory')
         ];
 
-        $server = new DAV\Server($tree);
+        $server = new DAV\Server($tree, null, null, function(){});
         $plugin = new Plugin();
         $server->addPlugin($plugin);
 

--- a/tests/Sabre/CardDAV/MultiGetTest.php
+++ b/tests/Sabre/CardDAV/MultiGetTest.php
@@ -27,19 +27,18 @@ class MultiGetTest extends AbstractPluginTest {
 </c:addressbook-multiget>'
             );
 
-        $response = new HTTP\ResponseMock();
-
         $this->server->httpRequest = $request;
-        $this->server->httpResponse = $response;
 
-        $this->server->exec();
 
-        $this->assertEquals(207, $response->status, 'Incorrect status code. Full response body:' . $response->body);
+        $this->server->start();
+        $response = $this->server->httpResponse->getResponse();
+        $responseBody = $response->getBody()->getContents();
+        $this->assertEquals(207, $response->getStatusCode(), 'Incorrect status code. Full response body:' . $responseBody);
 
         // using the client for parsing
         $client = new DAV\Client(['baseUri' => '/']);
 
-        $result = $client->parseMultiStatus($response->body);
+        $result = $client->parseMultiStatus($responseBody);
 
         $this->assertEquals([
             '/addressbooks/user1/book1/card1' => [
@@ -70,19 +69,17 @@ class MultiGetTest extends AbstractPluginTest {
 </c:addressbook-multiget>'
             );
 
-        $response = new HTTP\ResponseMock();
-
         $this->server->httpRequest = $request;
-        $this->server->httpResponse = $response;
 
-        $this->server->exec();
-
-        $this->assertEquals(207, $response->status, 'Incorrect status code. Full response body:' . $response->body);
+        $this->server->start();
+        $response = $this->server->httpResponse->getResponse();
+        $responseBody = $response->getBody()->getContents();
+        $this->assertEquals(207, $response->getStatusCode(), 'Incorrect status code. Full response body:' . $responseBody);
 
         // using the client for parsing
         $client = new DAV\Client(['baseUri' => '/']);
 
-        $result = $client->parseMultiStatus($response->body);
+        $result = $client->parseMultiStatus($responseBody);
 
         $prodId = "PRODID:-//Sabre//Sabre VObject " . \Sabre\VObject\Version::VERSION . "//EN";
 

--- a/tests/Sabre/CardDAV/MultiGetTest.php
+++ b/tests/Sabre/CardDAV/MultiGetTest.php
@@ -2,6 +2,7 @@
 
 namespace Sabre\CardDAV;
 
+use GuzzleHttp\Psr7\ServerRequest;
 use Sabre\DAV;
 use Sabre\HTTP;
 
@@ -11,13 +12,7 @@ class MultiGetTest extends AbstractPluginTest {
 
     function testMultiGet() {
 
-        $request = HTTP\Sapi::createFromServerArray([
-            'REQUEST_METHOD' => 'REPORT',
-            'REQUEST_URI'    => '/addressbooks/user1/book1',
-        ]);
-
-        $request->setBody(
-'<?xml version="1.0"?>
+        $request = new ServerRequest('REPORT', '/addressbooks/user1/book1', [], '<?xml version="1.0"?>
 <c:addressbook-multiget xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:carddav">
     <d:prop>
       <d:getetag />
@@ -25,13 +20,13 @@ class MultiGetTest extends AbstractPluginTest {
     </d:prop>
     <d:href>/addressbooks/user1/book1/card1</d:href>
 </c:addressbook-multiget>'
-            );
-
-        $this->server->httpRequest = $request;
+        );
 
 
-        $this->server->start();
-        $response = $this->server->httpResponse->getResponse();
+
+
+
+        $response = $this->server->handle($request);
         $responseBody = $response->getBody()->getContents();
         $this->assertEquals(207, $response->getStatusCode(), 'Incorrect status code. Full response body:' . $responseBody);
 
@@ -53,12 +48,7 @@ class MultiGetTest extends AbstractPluginTest {
 
     function testMultiGetVCard4() {
 
-        $request = HTTP\Sapi::createFromServerArray([
-            'REQUEST_METHOD' => 'REPORT',
-            'REQUEST_URI'    => '/addressbooks/user1/book1',
-        ]);
-
-        $request->setBody(
+        $request = new ServerRequest('REPORT', '/addressbooks/user1/book1', [],
 '<?xml version="1.0"?>
 <c:addressbook-multiget xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:carddav">
     <d:prop>
@@ -67,12 +57,12 @@ class MultiGetTest extends AbstractPluginTest {
     </d:prop>
     <d:href>/addressbooks/user1/book1/card1</d:href>
 </c:addressbook-multiget>'
-            );
+        );
 
-        $this->server->httpRequest = $request;
 
-        $this->server->start();
-        $response = $this->server->httpResponse->getResponse();
+
+
+        $response = $this->server->handle($request);
         $responseBody = $response->getBody()->getContents();
         $this->assertEquals(207, $response->getStatusCode(), 'Incorrect status code. Full response body:' . $responseBody);
 

--- a/tests/Sabre/CardDAV/PluginTest.php
+++ b/tests/Sabre/CardDAV/PluginTest.php
@@ -3,6 +3,7 @@
 namespace Sabre\CardDAV;
 
 use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Psr7\ServerRequest;
 use Sabre\DAV;
 use Sabre\DAV\Psr7ResponseWrapper;
 
@@ -93,11 +94,10 @@ class PluginTest extends AbstractPluginTest {
 
     function testGetTransform() {
 
-        $request = new \Sabre\HTTP\Request('GET', '/addressbooks/user1/book1/card1', ['Accept' => 'application/vcard+json']);
-        $response = new Psr7ResponseWrapper(function() { return new Response(); });
-        $this->server->invokeMethod($request, $response);
+        $request = new ServerRequest('GET', '/addressbooks/user1/book1/card1', ['Accept' => 'application/vcard+json']);
+        $response = $this->server->handle($request);
 
-        $this->assertEquals(200, $response->getResponse()->getStatusCode());
+        $this->assertEquals(200, $response->getStatusCode());
 
     }
 

--- a/tests/Sabre/CardDAV/PluginTest.php
+++ b/tests/Sabre/CardDAV/PluginTest.php
@@ -2,7 +2,9 @@
 
 namespace Sabre\CardDAV;
 
+use GuzzleHttp\Psr7\Response;
 use Sabre\DAV;
+use Sabre\DAV\Psr7ResponseWrapper;
 
 class PluginTest extends AbstractPluginTest {
 
@@ -92,10 +94,10 @@ class PluginTest extends AbstractPluginTest {
     function testGetTransform() {
 
         $request = new \Sabre\HTTP\Request('GET', '/addressbooks/user1/book1/card1', ['Accept' => 'application/vcard+json']);
-        $response = new \Sabre\HTTP\ResponseMock();
+        $response = new Psr7ResponseWrapper(function() { return new Response(); });
         $this->server->invokeMethod($request, $response);
 
-        $this->assertEquals(200, $response->getStatus());
+        $this->assertEquals(200, $response->getResponse()->getStatusCode());
 
     }
 

--- a/tests/Sabre/CardDAV/SogoStripContentTypeTest.php
+++ b/tests/Sabre/CardDAV/SogoStripContentTypeTest.php
@@ -2,6 +2,7 @@
 
 namespace Sabre\CardDAV;
 
+use GuzzleHttp\Psr7\ServerRequest;
 use Sabre\DAV\PropFind;
 use Sabre\HTTP;
 
@@ -31,9 +32,10 @@ class SogoStripContentTypeTest extends \Sabre\DAVServerTest {
     }
     function testStrip() {
 
-        $this->server->httpRequest = new HTTP\Request('GET', '/', [
+        $request = new ServerRequest('GET', '/', [
             'User-Agent' => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.6; rv:10.0.2) Gecko/20120216 Thunderbird/10.0.2 Lightning/1.2.1',
         ]);
+        $this->server->handle($request);
         $result = $this->server->getProperties('addressbooks/user1/book1/card1.vcf', ['{DAV:}getcontenttype']);
         $this->assertEquals([
             '{DAV:}getcontenttype' => 'text/x-vcard'
@@ -42,10 +44,10 @@ class SogoStripContentTypeTest extends \Sabre\DAVServerTest {
     }
     function testDontTouchOtherMimeTypes() {
 
-        $this->server->httpRequest = new HTTP\Request('GET', '/addressbooks/user1/book1/card1.vcf', [
+        $request = new ServerRequest('GET', '/addressbooks/user1/book1/card1.vcf', [
             'User-Agent' => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.6; rv:10.0.2) Gecko/20120216 Thunderbird/10.0.2 Lightning/1.2.1',
         ]);
-
+        $this->server->handle($request);
         $propFind = new PropFind('hello', ['{DAV:}getcontenttype']);
         $propFind->set('{DAV:}getcontenttype', 'text/plain');
         $this->carddavPlugin->propFindLate($propFind, new \Sabre\DAV\SimpleCollection('foo'));

--- a/tests/Sabre/CardDAV/VCFExportTest.php
+++ b/tests/Sabre/CardDAV/VCFExportTest.php
@@ -2,6 +2,7 @@
 
 namespace Sabre\CardDAV;
 
+use GuzzleHttp\Psr7\ServerRequest;
 use Sabre\HTTP;
 
 class VCFExportTest extends \Sabre\DAVServerTest {
@@ -50,12 +51,10 @@ class VCFExportTest extends \Sabre\DAVServerTest {
 
     function testExport() {
 
-        $request = HTTP\Sapi::createFromServerArray([
-            'REQUEST_URI'    => '/addressbooks/user1/book1?export',
-            'QUERY_STRING'   => 'export',
-            'REQUEST_METHOD' => 'GET',
-        ]);
-
+        $request = (new ServerRequest('GET', '/addressbooks/user1/book1?export'))
+            ->withQueryParams([
+                'export' => ''
+            ]);
         $response = $this->request($request);
         $responseBody = $response->getBody()->getContents();
         $this->assertEquals(200, $response->getStatusCode(), $responseBody);
@@ -92,10 +91,10 @@ END:VCARD
 
     function testContentDisposition() {
 
-        $request = new HTTP\Request(
+        $request = (new ServerRequest(
             'GET',
             '/addressbooks/user1/book1?export'
-        );
+        ))->withQueryParams(['export' => '']);
 
         $response = $this->request($request, 200);
         $this->assertEquals('text/directory', $response->getHeaderLine('Content-Type'));
@@ -119,10 +118,10 @@ END:VCARD
             "BEGIN:VCARD\r\nFN:Person1\r\nEND:VCARD\r\n"
         );
 
-        $request = new HTTP\Request(
+        $request = (new ServerRequest(
             'GET',
             '/addressbooks/user1/book-b_ad"(ch)ars?export'
-        );
+        ))->withQueryParams(['export' => '']);
 
         $response = $this->request($request, 200);
         $this->assertEquals('text/directory', $response->getHeaderLine('Content-Type'));

--- a/tests/Sabre/CardDAV/VCFExportTest.php
+++ b/tests/Sabre/CardDAV/VCFExportTest.php
@@ -57,7 +57,8 @@ class VCFExportTest extends \Sabre\DAVServerTest {
         ]);
 
         $response = $this->request($request);
-        $this->assertEquals(200, $response->status, $response->body);
+        $responseBody = $response->getBody()->getContents();
+        $this->assertEquals(200, $response->getStatusCode(), $responseBody);
 
         $expected = "BEGIN:VCARD
 FN:Person1
@@ -75,7 +76,7 @@ END:VCARD
         // We actually expected windows line endings
         $expected = str_replace("\n", "\r\n", $expected);
 
-        $this->assertEquals($expected, $response->body);
+        $this->assertEquals($expected, $responseBody);
 
     }
 
@@ -97,10 +98,10 @@ END:VCARD
         );
 
         $response = $this->request($request, 200);
-        $this->assertEquals('text/directory', $response->getHeader('Content-Type'));
+        $this->assertEquals('text/directory', $response->getHeaderLine('Content-Type'));
         $this->assertEquals(
             'attachment; filename="book1-' . date('Y-m-d') . '.vcf"',
-            $response->getHeader('Content-Disposition')
+            $response->getHeaderLine('Content-Disposition')
         );
 
     }
@@ -124,10 +125,10 @@ END:VCARD
         );
 
         $response = $this->request($request, 200);
-        $this->assertEquals('text/directory', $response->getHeader('Content-Type'));
+        $this->assertEquals('text/directory', $response->getHeaderLine('Content-Type'));
         $this->assertEquals(
             'attachment; filename="book-b_adchars-' . date('Y-m-d') . '.vcf"',
-            $response->getHeader('Content-Disposition')
+            $response->getHeaderLine('Content-Disposition')
         );
 
     }

--- a/tests/Sabre/CardDAV/ValidateFilterTest.php
+++ b/tests/Sabre/CardDAV/ValidateFilterTest.php
@@ -14,7 +14,7 @@ class ValidateFilterTest extends AbstractPluginTest {
      * @param string|null $message
      * @dataProvider data
      */
-    function testFilter($input, $filters, $test, $result, $message = null) {
+    function testFilter($input, $filters, $test, $result, string $message = '') {
 
         if ($result) {
             $this->assertTrue($this->plugin->validateFilters($input, $filters, $test), $message);

--- a/tests/Sabre/CardDAV/ValidateVCardTest.php
+++ b/tests/Sabre/CardDAV/ValidateVCardTest.php
@@ -33,7 +33,7 @@ class ValidateVCardTest extends \PHPUnit_Framework_TestCase {
             new AddressBookRoot($principalBackend, $this->cardBackend),
         ];
 
-        $this->server = new DAV\Server($tree);
+        $this->server = new DAV\Server($tree, null, null, function(){});
 
         $this->server->debugExceptions = true;
 

--- a/tests/Sabre/DAV/AbstractServer.php
+++ b/tests/Sabre/DAV/AbstractServer.php
@@ -2,6 +2,7 @@
 
 namespace Sabre\DAV;
 
+use GuzzleHttp\Psr7\ServerRequest;
 use Psr\Http\Message\ResponseInterface;
 use Sabre\HTTP;
 
@@ -16,7 +17,12 @@ abstract class AbstractServer extends \PHPUnit_Framework_TestCase {
 
     function setUp() {
 
-        $this->server = new Server($this->getRootNode());
+        $this->server = new Server(
+            $this->getRootNode(),
+            function() { return new \GuzzleHttp\Psr7\Response(); },
+            new ServerRequest('GET', ''),
+            function(ResponseInterface $response) { }
+        );
 
         $this->server->debugExceptions = true;
         $this->deleteTree(SABRE_TEMPDIR, false);

--- a/tests/Sabre/DAV/AbstractServer.php
+++ b/tests/Sabre/DAV/AbstractServer.php
@@ -2,27 +2,27 @@
 
 namespace Sabre\DAV;
 
+use Psr\Http\Message\ResponseInterface;
 use Sabre\HTTP;
 
 abstract class AbstractServer extends \PHPUnit_Framework_TestCase {
 
-    /**
-     * @var Sabre\HTTP\ResponseMock
-     */
-    protected $response;
     protected $request;
     /**
-     * @var Sabre\DAV\Server
+     * @var Server
      */
     protected $server;
     protected $tempDir = SABRE_TEMPDIR;
 
+    protected function getResponse(): ResponseInterface
+    {
+        return $this->server->httpResponse->getResponse();
+    }
+
     function setUp() {
 
-        $this->response = new HTTP\ResponseMock();
         $this->server = new Server($this->getRootNode());
         $this->server->sapi = new HTTP\SapiMock();
-        $this->server->httpResponse = $this->response;
         $this->server->debugExceptions = true;
         $this->deleteTree(SABRE_TEMPDIR, false);
         file_put_contents(SABRE_TEMPDIR . '/test.txt', 'Test contents');

--- a/tests/Sabre/DAV/AbstractServer.php
+++ b/tests/Sabre/DAV/AbstractServer.php
@@ -14,15 +14,10 @@ abstract class AbstractServer extends \PHPUnit_Framework_TestCase {
     protected $server;
     protected $tempDir = SABRE_TEMPDIR;
 
-    protected function getResponse(): ResponseInterface
-    {
-        return $this->server->httpResponse->getResponse();
-    }
-
     function setUp() {
 
         $this->server = new Server($this->getRootNode());
-        $this->server->sapi = new HTTP\SapiMock();
+
         $this->server->debugExceptions = true;
         $this->deleteTree(SABRE_TEMPDIR, false);
         file_put_contents(SABRE_TEMPDIR . '/test.txt', 'Test contents');

--- a/tests/Sabre/DAV/Auth/Backend/AbstractBasicTest.php
+++ b/tests/Sabre/DAV/Auth/Backend/AbstractBasicTest.php
@@ -2,6 +2,8 @@
 
 namespace Sabre\DAV\Auth\Backend;
 
+use GuzzleHttp\Psr7\Response;
+use Sabre\DAV\Psr7ResponseWrapper;
 use Sabre\HTTP;
 
 class AbstractBasicTest extends \PHPUnit_Framework_TestCase {
@@ -58,7 +60,7 @@ class AbstractBasicTest extends \PHPUnit_Framework_TestCase {
     function testRequireAuth() {
 
         $request = new HTTP\Request('GET', '/');
-        $response = new HTTP\Response();
+        $response = new Psr7ResponseWrapper(function() { return new Response(); });
 
         $backend = new AbstractBasicMock();
         $backend->setRealm('writing unittests on a saturday night');
@@ -66,7 +68,7 @@ class AbstractBasicTest extends \PHPUnit_Framework_TestCase {
 
         $this->assertEquals(
             'Basic realm="writing unittests on a saturday night", charset="UTF-8"',
-            $response->getHeader('WWW-Authenticate')
+            $response->getResponse()->getHeaderLine('WWW-Authenticate')
         );
 
     }

--- a/tests/Sabre/DAV/Auth/Backend/AbstractBearerTest.php
+++ b/tests/Sabre/DAV/Auth/Backend/AbstractBearerTest.php
@@ -3,6 +3,8 @@
 namespace Sabre\DAV\Auth\Backend;
 
 use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Psr7\ServerRequest;
+use Sabre\DAV\Psr7RequestWrapper;
 use Sabre\DAV\Psr7ResponseWrapper;
 use Sabre\HTTP;
 
@@ -10,20 +12,20 @@ class AbstractBearerTest extends \PHPUnit_Framework_TestCase {
 
     function testCheckNoHeaders() {
 
-        $request = new HTTP\Request('GET', '/');
+        $request = new ServerRequest('GET', '/');
         $response = new HTTP\Response();
 
         $backend = new AbstractBearerMock();
 
         $this->assertFalse(
-            $backend->check($request, $response)[0]
+            $backend->check(new Psr7RequestWrapper($request), $response)[0]
         );
 
     }
 
     function testCheckInvalidToken() {
 
-        $request = new HTTP\Request('GET', '/', [
+        $request = new ServerRequest('GET', '/', [
             'Authorization' => 'Bearer foo',
         ]);
         $response = new HTTP\Response();
@@ -31,14 +33,14 @@ class AbstractBearerTest extends \PHPUnit_Framework_TestCase {
         $backend = new AbstractBearerMock();
 
         $this->assertFalse(
-            $backend->check($request, $response)[0]
+            $backend->check(new Psr7RequestWrapper($request), $response)[0]
         );
 
     }
 
     function testCheckSuccess() {
 
-        $request = new HTTP\Request('GET', '/', [
+        $request = new ServerRequest('GET', '/', [
             'Authorization' => 'Bearer valid',
         ]);
         $response = new HTTP\Response();
@@ -46,19 +48,19 @@ class AbstractBearerTest extends \PHPUnit_Framework_TestCase {
         $backend = new AbstractBearerMock();
         $this->assertEquals(
             [true, 'principals/username'],
-            $backend->check($request, $response)
+            $backend->check(new Psr7RequestWrapper($request), $response)
         );
 
     }
 
     function testRequireAuth() {
 
-        $request = new HTTP\Request('GET', '/');
+        $request = new ServerRequest('GET', '/');
         $response = new Psr7ResponseWrapper(function() { return new Response(); });
 
         $backend = new AbstractBearerMock();
         $backend->setRealm('writing unittests on a saturday night');
-        $backend->challenge($request, $response);
+        $backend->challenge(new Psr7RequestWrapper($request), $response);
 
         $this->assertEquals(
             'Bearer realm="writing unittests on a saturday night"',

--- a/tests/Sabre/DAV/Auth/Backend/AbstractBearerTest.php
+++ b/tests/Sabre/DAV/Auth/Backend/AbstractBearerTest.php
@@ -2,6 +2,8 @@
 
 namespace Sabre\DAV\Auth\Backend;
 
+use GuzzleHttp\Psr7\Response;
+use Sabre\DAV\Psr7ResponseWrapper;
 use Sabre\HTTP;
 
 class AbstractBearerTest extends \PHPUnit_Framework_TestCase {
@@ -52,7 +54,7 @@ class AbstractBearerTest extends \PHPUnit_Framework_TestCase {
     function testRequireAuth() {
 
         $request = new HTTP\Request('GET', '/');
-        $response = new HTTP\Response();
+        $response = new Psr7ResponseWrapper(function() { return new Response(); });
 
         $backend = new AbstractBearerMock();
         $backend->setRealm('writing unittests on a saturday night');
@@ -60,7 +62,7 @@ class AbstractBearerTest extends \PHPUnit_Framework_TestCase {
 
         $this->assertEquals(
             'Bearer realm="writing unittests on a saturday night"',
-            $response->getHeader('WWW-Authenticate')
+            $response->getResponse()->getHeaderLine('WWW-Authenticate')
         );
 
     }

--- a/tests/Sabre/DAV/Auth/Backend/AbstractDigestTest.php
+++ b/tests/Sabre/DAV/Auth/Backend/AbstractDigestTest.php
@@ -2,6 +2,8 @@
 
 namespace Sabre\DAV\Auth\Backend;
 
+use GuzzleHttp\Psr7\Response;
+use Sabre\DAV\Psr7ResponseWrapper;
 use Sabre\HTTP;
 
 class AbstractDigestTest extends \PHPUnit_Framework_TestCase {
@@ -36,7 +38,7 @@ class AbstractDigestTest extends \PHPUnit_Framework_TestCase {
     }
 
     /**
-     * @expectedException Sabre\DAV\Exception
+     * @expectedException \Sabre\DAV\Exception
      */
     function testCheckBadGetUserInfoResponse2() {
 
@@ -113,7 +115,7 @@ class AbstractDigestTest extends \PHPUnit_Framework_TestCase {
     function testRequireAuth() {
 
         $request = new HTTP\Request('GET', '/');
-        $response = new HTTP\Response();
+        $response = new Psr7ResponseWrapper(function() { return new Response(); });
 
         $backend = new AbstractDigestMock();
         $backend->setRealm('writing unittests on a saturday night');
@@ -121,7 +123,7 @@ class AbstractDigestTest extends \PHPUnit_Framework_TestCase {
 
         $this->assertStringStartsWith(
             'Digest realm="writing unittests on a saturday night"',
-            $response->getHeader('WWW-Authenticate')
+            $response->getResponse()->getHeaderLine('WWW-Authenticate')
         );
 
     }

--- a/tests/Sabre/DAV/Auth/Backend/AbstractPDOTest.php
+++ b/tests/Sabre/DAV/Auth/Backend/AbstractPDOTest.php
@@ -2,7 +2,9 @@
 
 namespace Sabre\DAV\Auth\Backend;
 
-abstract class AbstractPDOTest extends \PHPUnit_Framework_TestCase {
+use PHPUnit\Framework\TestCase;
+
+abstract class AbstractPDOTest extends TestCase {
 
     use \Sabre\DAV\DbTestHelperTrait;
 

--- a/tests/Sabre/DAV/Auth/Backend/ApacheTest.php
+++ b/tests/Sabre/DAV/Auth/Backend/ApacheTest.php
@@ -2,6 +2,8 @@
 
 namespace Sabre\DAV\Auth\Backend;
 
+use GuzzleHttp\Psr7\Response;
+use Sabre\DAV\Psr7ResponseWrapper;
 use Sabre\HTTP;
 
 class ApacheTest extends \PHPUnit_Framework_TestCase {
@@ -62,13 +64,13 @@ class ApacheTest extends \PHPUnit_Framework_TestCase {
     function testRequireAuth() {
 
         $request = new HTTP\Request('GET', '/');
-        $response = new HTTP\Response();
+        $response = new Psr7ResponseWrapper(function() { return new Response(); });
 
         $backend = new Apache();
         $backend->challenge($request, $response);
 
-        $this->assertNull(
-            $response->getHeader('WWW-Authenticate')
+        $this->assertEmpty(
+            $response->getResponse()->getHeader('WWW-Authenticate')
         );
 
     }

--- a/tests/Sabre/DAV/Auth/Backend/BasicCallBackTest.php
+++ b/tests/Sabre/DAV/Auth/Backend/BasicCallBackTest.php
@@ -2,6 +2,8 @@
 
 namespace Sabre\DAV\Auth\Backend;
 
+use GuzzleHttp\Psr7\ServerRequest;
+use Sabre\DAV\Psr7RequestWrapper;
 use Sabre\HTTP;
 
 class BasicCallBackTest extends \PHPUnit_Framework_TestCase {
@@ -18,14 +20,14 @@ class BasicCallBackTest extends \PHPUnit_Framework_TestCase {
 
         $backend = new BasicCallBack($callBack);
 
-        $request = new HTTP\Request('GET', '/', [
+        $request = new ServerRequest('GET', '/', [
             'Authorization' => 'Basic ' . base64_encode('foo:bar'),
         ]);
         $response = new HTTP\Response();
 
         $this->assertEquals(
             [true, 'principals/foo'],
-            $backend->check($request, $response)
+            $backend->check(new Psr7RequestWrapper($request), $response)
         );
 
         $this->assertEquals(['foo', 'bar'], $args);

--- a/tests/Sabre/DAV/Auth/Backend/FileTest.php
+++ b/tests/Sabre/DAV/Auth/Backend/FileTest.php
@@ -27,6 +27,17 @@ class FileTest extends \PHPUnit_Framework_TestCase {
 
     }
 
+    /**
+     * @expectedException \Sabre\DAV\Exception
+     */
+    function testLoadFileMissingColon() {
+
+        file_put_contents(SABRE_TEMPDIR . '/backend', 'user:hash');
+        $file = new File(SABRE_TEMPDIR . '/backend');
+
+    }
+
+
     function testLoadFile() {
 
         file_put_contents(SABRE_TEMPDIR . '/backend', 'user:realm:' . md5('user:realm:password'));

--- a/tests/Sabre/DAV/Auth/Backend/FileTest.php
+++ b/tests/Sabre/DAV/Auth/Backend/FileTest.php
@@ -18,7 +18,7 @@ class FileTest extends \PHPUnit_Framework_TestCase {
     }
 
     /**
-     * @expectedException Sabre\DAV\Exception
+     * @expectedException \Sabre\DAV\Exception
      */
     function testLoadFileBroken() {
 

--- a/tests/Sabre/DAV/Auth/PluginTest.php
+++ b/tests/Sabre/DAV/Auth/PluginTest.php
@@ -5,13 +5,15 @@ namespace Sabre\DAV\Auth;
 use GuzzleHttp\Psr7\ServerRequest;
 use Sabre\DAV;
 use Sabre\DAV\Psr7RequestWrapper;
+use Sabre\DAV\Server;
+use Sabre\DAV\SimpleCollection;
 use Sabre\HTTP;
 
 class PluginTest extends \PHPUnit_Framework_TestCase {
 
     function testInit() {
 
-        $fakeServer = new DAV\Server(new DAV\SimpleCollection('bla'));
+        $fakeServer = new Server(new SimpleCollection('bla'), null, null, function(){});
         $plugin = new Plugin(new Backend\Mock());
         $this->assertTrue($plugin instanceof Plugin);
         $fakeServer->addPlugin($plugin);
@@ -25,7 +27,7 @@ class PluginTest extends \PHPUnit_Framework_TestCase {
      */
     function testAuthenticate() {
 
-        $fakeServer = new DAV\Server(new DAV\SimpleCollection('bla'));
+        $fakeServer = new Server(new SimpleCollection('bla'), null, null, function(){});
         $plugin = new Plugin(new Backend\Mock());
         $fakeServer->addPlugin($plugin);
         $this->assertTrue(
@@ -40,7 +42,7 @@ class PluginTest extends \PHPUnit_Framework_TestCase {
      */
     function testAuthenticateFail() {
 
-        $fakeServer = new DAV\Server(new DAV\SimpleCollection('bla'));
+        $fakeServer = new Server(new SimpleCollection('bla'), null, null, function(){});
         $backend = new Backend\Mock();
         $backend->fail = true;
 
@@ -55,7 +57,7 @@ class PluginTest extends \PHPUnit_Framework_TestCase {
      */
     function testAuthenticateFailDontAutoRequire() {
 
-        $fakeServer = new DAV\Server(new DAV\SimpleCollection('bla'));
+        $fakeServer = new Server(new SimpleCollection('bla'), null, null, function(){});
         $backend = new Backend\Mock();
         $backend->fail = true;
 
@@ -74,7 +76,7 @@ class PluginTest extends \PHPUnit_Framework_TestCase {
      */
     function testMultipleBackend() {
 
-        $fakeServer = new DAV\Server(new DAV\SimpleCollection('bla'));
+        $fakeServer = new Server(new SimpleCollection('bla'), null, null, function(){});
         $backend1 = new Backend\Mock();
         $backend2 = new Backend\Mock();
         $backend2->fail = true;
@@ -96,7 +98,7 @@ class PluginTest extends \PHPUnit_Framework_TestCase {
      */
     function testNoAuthBackend() {
 
-        $fakeServer = new DAV\Server(new DAV\SimpleCollection('bla'));
+        $fakeServer = new Server(new SimpleCollection('bla'), null, null, function(){});
 
         $plugin = new Plugin();
         $fakeServer->addPlugin($plugin);
@@ -109,7 +111,7 @@ class PluginTest extends \PHPUnit_Framework_TestCase {
      */
     function testInvalidCheckResponse() {
 
-        $fakeServer = new DAV\Server(new DAV\SimpleCollection('bla'));
+        $fakeServer = new Server(new SimpleCollection('bla'), null, null, function(){});
         $backend = new Backend\Mock();
         $backend->invalidCheckResponse = true;
 
@@ -124,7 +126,7 @@ class PluginTest extends \PHPUnit_Framework_TestCase {
      */
     function testGetCurrentPrincipal() {
 
-        $fakeServer = new DAV\Server(new DAV\SimpleCollection('bla'));
+        $fakeServer = new Server(new SimpleCollection('bla'), null, null, function(){});
         $plugin = new Plugin(new Backend\Mock());
         $fakeServer->addPlugin($plugin);
         $fakeServer->emit('beforeMethod:GET', [new Psr7RequestWrapper(new ServerRequest('GET', '/')), new HTTP\Response()]);

--- a/tests/Sabre/DAV/Auth/PluginTest.php
+++ b/tests/Sabre/DAV/Auth/PluginTest.php
@@ -2,7 +2,9 @@
 
 namespace Sabre\DAV\Auth;
 
+use GuzzleHttp\Psr7\ServerRequest;
 use Sabre\DAV;
+use Sabre\DAV\Psr7RequestWrapper;
 use Sabre\HTTP;
 
 class PluginTest extends \PHPUnit_Framework_TestCase {
@@ -27,14 +29,14 @@ class PluginTest extends \PHPUnit_Framework_TestCase {
         $plugin = new Plugin(new Backend\Mock());
         $fakeServer->addPlugin($plugin);
         $this->assertTrue(
-            $fakeServer->emit('beforeMethod:GET', [new HTTP\Request('GET', '/'), new HTTP\Response()])
+            $fakeServer->emit('beforeMethod:GET', [new Psr7RequestWrapper(new ServerRequest('GET', '/')), new HTTP\Response()])
         );
 
     }
 
     /**
      * @depends testInit
-     * @expectedException Sabre\DAV\Exception\NotAuthenticated
+     * @expectedException \Sabre\DAV\Exception\NotAuthenticated
      */
     function testAuthenticateFail() {
 
@@ -44,7 +46,7 @@ class PluginTest extends \PHPUnit_Framework_TestCase {
 
         $plugin = new Plugin($backend);
         $fakeServer->addPlugin($plugin);
-        $fakeServer->emit('beforeMethod:GET', [new HTTP\Request('GET', '/'), new HTTP\Response()]);
+        $fakeServer->emit('beforeMethod:GET', [new Psr7RequestWrapper(new ServerRequest('GET', '/')), new HTTP\Response()]);
 
     }
 
@@ -61,7 +63,7 @@ class PluginTest extends \PHPUnit_Framework_TestCase {
         $plugin->autoRequireLogin = false;
         $fakeServer->addPlugin($plugin);
         $this->assertTrue(
-            $fakeServer->emit('beforeMethod:GET', [new HTTP\Request('GET', '/'), new HTTP\Response()])
+            $fakeServer->emit('beforeMethod:GET', [new Psr7RequestWrapper(new ServerRequest('GET', '/')), new HTTP\Response()])
         );
         $this->assertEquals(1, count($plugin->getLoginFailedReasons()));
 
@@ -82,7 +84,7 @@ class PluginTest extends \PHPUnit_Framework_TestCase {
         $plugin->addBackend($backend2);
 
         $fakeServer->addPlugin($plugin);
-        $fakeServer->emit('beforeMethod:GET', [new HTTP\Request('GET', '/'), new HTTP\Response()]);
+        $fakeServer->emit('beforeMethod:GET', [new Psr7RequestWrapper(new ServerRequest('GET', '/')), new HTTP\Response()]);
 
         $this->assertEquals('principals/admin', $plugin->getCurrentPrincipal());
 
@@ -90,7 +92,7 @@ class PluginTest extends \PHPUnit_Framework_TestCase {
 
     /**
      * @depends testInit
-     * @expectedException Sabre\DAV\Exception
+     * @expectedException \Sabre\DAV\Exception
      */
     function testNoAuthBackend() {
 
@@ -98,12 +100,12 @@ class PluginTest extends \PHPUnit_Framework_TestCase {
 
         $plugin = new Plugin();
         $fakeServer->addPlugin($plugin);
-        $fakeServer->emit('beforeMethod:GET', [new HTTP\Request('GET', '/'), new HTTP\Response()]);
+        $fakeServer->emit('beforeMethod:GET', [new Psr7RequestWrapper(new ServerRequest('GET', '/')), new HTTP\Response()]);
 
     }
     /**
      * @depends testInit
-     * @expectedException Sabre\DAV\Exception
+     * @expectedException \Sabre\DAV\Exception
      */
     function testInvalidCheckResponse() {
 
@@ -113,7 +115,7 @@ class PluginTest extends \PHPUnit_Framework_TestCase {
 
         $plugin = new Plugin($backend);
         $fakeServer->addPlugin($plugin);
-        $fakeServer->emit('beforeMethod:GET', [new HTTP\Request('GET', '/'), new HTTP\Response()]);
+        $fakeServer->emit('beforeMethod:GET', [new Psr7RequestWrapper(new ServerRequest('GET', '/')), new HTTP\Response()]);
 
     }
 
@@ -125,7 +127,7 @@ class PluginTest extends \PHPUnit_Framework_TestCase {
         $fakeServer = new DAV\Server(new DAV\SimpleCollection('bla'));
         $plugin = new Plugin(new Backend\Mock());
         $fakeServer->addPlugin($plugin);
-        $fakeServer->emit('beforeMethod:GET', [new HTTP\Request('GET', '/'), new HTTP\Response()]);
+        $fakeServer->emit('beforeMethod:GET', [new Psr7RequestWrapper(new ServerRequest('GET', '/')), new HTTP\Response()]);
         $this->assertEquals('principals/admin', $plugin->getCurrentPrincipal());
 
     }

--- a/tests/Sabre/DAV/BasicNodeTest.php
+++ b/tests/Sabre/DAV/BasicNodeTest.php
@@ -5,7 +5,7 @@ namespace Sabre\DAV;
 class BasicNodeTest extends \PHPUnit_Framework_TestCase {
 
     /**
-     * @expectedException Sabre\DAV\Exception\Forbidden
+     * @expectedException \Sabre\DAV\Exception\Forbidden
      */
     function testPut() {
 
@@ -15,7 +15,7 @@ class BasicNodeTest extends \PHPUnit_Framework_TestCase {
     }
 
     /**
-     * @expectedException Sabre\DAV\Exception\Forbidden
+     * @expectedException \Sabre\DAV\Exception\Forbidden
      */
     function testGet() {
 
@@ -47,7 +47,7 @@ class BasicNodeTest extends \PHPUnit_Framework_TestCase {
     }
 
     /**
-     * @expectedException Sabre\DAV\Exception\Forbidden
+     * @expectedException \Sabre\DAV\Exception\Forbidden
      */
     function testDelete() {
 
@@ -57,7 +57,7 @@ class BasicNodeTest extends \PHPUnit_Framework_TestCase {
     }
 
     /**
-     * @expectedException Sabre\DAV\Exception\Forbidden
+     * @expectedException \Sabre\DAV\Exception\Forbidden
      */
     function testSetName() {
 
@@ -99,7 +99,7 @@ class BasicNodeTest extends \PHPUnit_Framework_TestCase {
     }
 
     /**
-     * @expectedException Sabre\DAV\Exception\NotFound
+     * @expectedException \Sabre\DAV\Exception\NotFound
      */
     function testGetChild404() {
 
@@ -109,7 +109,7 @@ class BasicNodeTest extends \PHPUnit_Framework_TestCase {
     }
 
     /**
-     * @expectedException Sabre\DAV\Exception\Forbidden
+     * @expectedException \Sabre\DAV\Exception\Forbidden
      */
     function testCreateFile() {
 
@@ -119,7 +119,7 @@ class BasicNodeTest extends \PHPUnit_Framework_TestCase {
     }
 
     /**
-     * @expectedException Sabre\DAV\Exception\Forbidden
+     * @expectedException \Sabre\DAV\Exception\Forbidden
      */
     function testCreateDirectory() {
 

--- a/tests/Sabre/DAV/Browser/MapGetToPropFindTest.php
+++ b/tests/Sabre/DAV/Browser/MapGetToPropFindTest.php
@@ -26,7 +26,7 @@ class MapGetToPropFindTest extends DAV\AbstractServer {
 
         $this->assertEquals(207, $response->getStatusCode(), 'Incorrect status response received. Full response body: ' . $response->getBody()->getContents());
         $this->assertEquals([
-            'X-Sabre-Version' => [DAV\Version::VERSION],
+
             'Content-Type'    => ['application/xml; charset=utf-8'],
             'DAV'             => ['1, 3, extended-mkcol'],
             'Vary'            => ['Brief,Prefer'],

--- a/tests/Sabre/DAV/Browser/MapGetToPropFindTest.php
+++ b/tests/Sabre/DAV/Browser/MapGetToPropFindTest.php
@@ -2,6 +2,7 @@
 
 namespace Sabre\DAV\Browser;
 
+use Psr\Http\Message\ResponseInterface;
 use Sabre\DAV;
 use Sabre\HTTP;
 
@@ -26,16 +27,16 @@ class MapGetToPropFindTest extends DAV\AbstractServer {
         $request = HTTP\Sapi::createFromServerArray($serverVars);
         $request->setBody('');
         $this->server->httpRequest = ($request);
-        $this->server->exec();
+        $this->server->start();
 
-        $this->assertEquals(207, $this->response->status, 'Incorrect status response received. Full response body: ' . $this->response->body);
+        $this->assertEquals(207, $this->getResponse()->getStatusCode(), 'Incorrect status response received. Full response body: ' . $this->getResponse()->getBody()->getContents());
         $this->assertEquals([
             'X-Sabre-Version' => [DAV\Version::VERSION],
             'Content-Type'    => ['application/xml; charset=utf-8'],
             'DAV'             => ['1, 3, extended-mkcol'],
             'Vary'            => ['Brief,Prefer'],
             ],
-            $this->response->getHeaders()
+            $this->getResponse()->getHeaders()
          );
 
     }

--- a/tests/Sabre/DAV/Browser/MapGetToPropFindTest.php
+++ b/tests/Sabre/DAV/Browser/MapGetToPropFindTest.php
@@ -2,6 +2,7 @@
 
 namespace Sabre\DAV\Browser;
 
+use GuzzleHttp\Psr7\ServerRequest;
 use Psr\Http\Message\ResponseInterface;
 use Sabre\DAV;
 use Sabre\HTTP;
@@ -19,24 +20,18 @@ class MapGetToPropFindTest extends DAV\AbstractServer {
 
     function testCollectionGet() {
 
-        $serverVars = [
-            'REQUEST_URI'    => '/',
-            'REQUEST_METHOD' => 'GET',
-        ];
+        $request = new ServerRequest('GET', '/', [], '');
+        $response = $this->server->handle($request);
 
-        $request = HTTP\Sapi::createFromServerArray($serverVars);
-        $request->setBody('');
-        $this->server->httpRequest = ($request);
-        $this->server->start();
 
-        $this->assertEquals(207, $this->getResponse()->getStatusCode(), 'Incorrect status response received. Full response body: ' . $this->getResponse()->getBody()->getContents());
+        $this->assertEquals(207, $response->getStatusCode(), 'Incorrect status response received. Full response body: ' . $response->getBody()->getContents());
         $this->assertEquals([
             'X-Sabre-Version' => [DAV\Version::VERSION],
             'Content-Type'    => ['application/xml; charset=utf-8'],
             'DAV'             => ['1, 3, extended-mkcol'],
             'Vary'            => ['Brief,Prefer'],
             ],
-            $this->getResponse()->getHeaders()
+            $response->getHeaders()
          );
 
     }

--- a/tests/Sabre/DAV/Browser/PluginTest.php
+++ b/tests/Sabre/DAV/Browser/PluginTest.php
@@ -31,7 +31,6 @@ class PluginTest extends DAV\AbstractServer{
         $this->assertEquals(200, $response->getStatusCode(), "Incorrect status received. Full response body: " . $body);
         $this->assertEquals(
             [
-                'X-Sabre-Version'         => [DAV\Version::VERSION],
                 'Content-Type'            => ['text/html; charset=utf-8'],
                 'Content-Security-Policy' => ["default-src 'none'; img-src 'self'; style-src 'self'; font-src 'self';"]
             ],
@@ -58,7 +57,6 @@ class PluginTest extends DAV\AbstractServer{
         $this->assertEquals(200, $response->getStatusCode(), "Incorrect status received. Full response body: " . $body);
         $this->assertEquals(
             [
-                'X-Sabre-Version'         => [DAV\Version::VERSION],
                 'Content-Type'            => ['text/html; charset=utf-8'],
                 'Content-Security-Policy' => ["default-src 'none'; img-src 'self'; style-src 'self'; font-src 'self';"]
             ],
@@ -79,7 +77,6 @@ class PluginTest extends DAV\AbstractServer{
         $this->assertEquals(200, $response->getStatusCode(), "Incorrect status received. Full response body: " . $body);
         $this->assertEquals(
             [
-                'X-Sabre-Version'         => [DAV\Version::VERSION],
                 'Content-Type'            => ['text/html; charset=utf-8'],
                 'Content-Security-Policy' => ["default-src 'none'; img-src 'self'; style-src 'self'; font-src 'self';"]
             ],
@@ -137,7 +134,7 @@ class PluginTest extends DAV\AbstractServer{
 
         $this->assertEquals(302, $response->getStatusCode(), $response->getBody()->getContents());
         $this->assertEquals([
-            'X-Sabre-Version' => [DAV\Version::VERSION],
+
             'Location'        => ['/'],
         ], $response->getHeaders());
 
@@ -157,7 +154,6 @@ class PluginTest extends DAV\AbstractServer{
 
         $this->assertEquals(200, $response->getStatusCode(), 'Error: ' . $response->getBody()->getContents());
         $this->assertEquals([
-            'X-Sabre-Version'         => [DAV\Version::VERSION],
             'Content-Type'            => ['image/vnd.microsoft.icon'],
             'Content-Length'          => ['4286'],
             'Cache-Control'           => ['public, max-age=1209600'],

--- a/tests/Sabre/DAV/Browser/PluginTest.php
+++ b/tests/Sabre/DAV/Browser/PluginTest.php
@@ -23,19 +23,21 @@ class PluginTest extends DAV\AbstractServer{
 
         $request = new HTTP\Request('GET', '/dir');
         $this->server->httpRequest = $request;
-        $this->server->exec();
+        $this->server->start();
 
-        $this->assertEquals(200, $this->response->getStatus(), "Incorrect status received. Full response body: " . $this->response->getBodyAsString());
+        $body = $this->getResponse()->getBody()->getContents();
+
+        $this->assertEquals(200, $this->getResponse()->getStatusCode(), "Incorrect status received. Full response body: " . $body);
         $this->assertEquals(
             [
                 'X-Sabre-Version'         => [DAV\Version::VERSION],
                 'Content-Type'            => ['text/html; charset=utf-8'],
                 'Content-Security-Policy' => ["default-src 'none'; img-src 'self'; style-src 'self'; font-src 'self';"]
             ],
-            $this->response->getHeaders()
+            $this->getResponse()->getHeaders()
         );
 
-        $body = $this->response->getBodyAsString();
+
         $this->assertTrue(strpos($body, '<title>dir') !== false, $body);
         $this->assertTrue(strpos($body, '<a href="/dir/child.txt">') !== false);
 
@@ -49,19 +51,20 @@ class PluginTest extends DAV\AbstractServer{
         $request = new HTTP\Request('GET', '/dir');
         $request->setHeader('If-None-Match', '"foo-bar"');
         $this->server->httpRequest = $request;
-        $this->server->exec();
+        $this->server->start();
 
-        $this->assertEquals(200, $this->response->getStatus(), "Incorrect status received. Full response body: " . $this->response->getBodyAsString());
+        $body = $this->getResponse()->getBody()->getContents();
+        $this->assertEquals(200, $this->getResponse()->getStatusCode(), "Incorrect status received. Full response body: " . $body);
         $this->assertEquals(
             [
                 'X-Sabre-Version'         => [DAV\Version::VERSION],
                 'Content-Type'            => ['text/html; charset=utf-8'],
                 'Content-Security-Policy' => ["default-src 'none'; img-src 'self'; style-src 'self'; font-src 'self';"]
             ],
-            $this->response->getHeaders()
+            $this->getResponse()->getHeaders()
         );
 
-        $body = $this->response->getBodyAsString();
+
         $this->assertTrue(strpos($body, '<title>dir') !== false, $body);
         $this->assertTrue(strpos($body, '<a href="/dir/child.txt">') !== false);
 
@@ -70,19 +73,19 @@ class PluginTest extends DAV\AbstractServer{
 
         $request = new HTTP\Request('GET', '/');
         $this->server->httpRequest = ($request);
-        $this->server->exec();
-
-        $this->assertEquals(200, $this->response->status, "Incorrect status received. Full response body: " . $this->response->getBodyAsString());
+        $this->server->start();
+        $body = $this->getResponse()->getBody()->getContents();
+        $this->assertEquals(200, $this->getResponse()->getStatusCode(), "Incorrect status received. Full response body: " . $body);
         $this->assertEquals(
             [
                 'X-Sabre-Version'         => [DAV\Version::VERSION],
                 'Content-Type'            => ['text/html; charset=utf-8'],
                 'Content-Security-Policy' => ["default-src 'none'; img-src 'self'; style-src 'self'; font-src 'self';"]
             ],
-            $this->response->getHeaders()
+            $this->getResponse()->getHeaders()
         );
 
-        $body = $this->response->getBodyAsString();
+
         $this->assertTrue(strpos($body, '<title>/') !== false, $body);
         $this->assertTrue(strpos($body, '<a href="/dir/">') !== false);
         $this->assertTrue(strpos($body, '<span class="btn disabled">') !== false);
@@ -103,9 +106,9 @@ class PluginTest extends DAV\AbstractServer{
 
         $request = new HTTP\Request('POST', '/', ['Content-Type' => 'text/xml']);
         $this->server->httpRequest = $request;
-        $this->server->exec();
+        $this->server->start();
 
-        $this->assertEquals(501, $this->response->status);
+        $this->assertEquals(501, $this->getResponse()->getStatusCode());
 
     }
 
@@ -114,9 +117,9 @@ class PluginTest extends DAV\AbstractServer{
         $request = new HTTP\Request('POST', '/', ['Content-Type' => 'application/x-www-form-urlencoded']);
         $request->setPostData([]);
         $this->server->httpRequest = $request;
-        $this->server->exec();
+        $this->server->start();
 
-        $this->assertEquals(501, $this->response->status);
+        $this->assertEquals(501, $this->getResponse()->getStatusCode());
 
     }
 
@@ -135,13 +138,13 @@ class PluginTest extends DAV\AbstractServer{
         $request = HTTP\Sapi::createFromServerArray($serverVars);
         $request->setPostData($postVars);
         $this->server->httpRequest = $request;
-        $this->server->exec();
+        $this->server->start();
 
-        $this->assertEquals(302, $this->response->status);
+        $this->assertEquals(302, $this->getResponse()->getStatusCode());
         $this->assertEquals([
             'X-Sabre-Version' => [DAV\Version::VERSION],
             'Location'        => ['/'],
-        ], $this->response->getHeaders());
+        ], $this->getResponse()->getHeaders());
 
         $this->assertTrue(is_dir(SABRE_TEMPDIR . '/new_collection'));
 
@@ -151,16 +154,16 @@ class PluginTest extends DAV\AbstractServer{
 
         $request = new HTTP\Request('GET', '/?sabreAction=asset&assetName=favicon.ico');
         $this->server->httpRequest = $request;
-        $this->server->exec();
+        $this->server->start();
 
-        $this->assertEquals(200, $this->response->getStatus(), 'Error: ' . $this->response->body);
+        $this->assertEquals(200, $this->getResponse()->getStatusCode(), 'Error: ' . $this->getResponse()->getBody()->getContents());
         $this->assertEquals([
             'X-Sabre-Version'         => [DAV\Version::VERSION],
             'Content-Type'            => ['image/vnd.microsoft.icon'],
             'Content-Length'          => ['4286'],
             'Cache-Control'           => ['public, max-age=1209600'],
             'Content-Security-Policy' => ["default-src 'none'; img-src 'self'; style-src 'self'; font-src 'self';"]
-        ], $this->response->getHeaders());
+        ], $this->getResponse()->getHeaders());
 
     }
 
@@ -168,9 +171,9 @@ class PluginTest extends DAV\AbstractServer{
 
         $request = new HTTP\Request('GET', '/?sabreAction=asset&assetName=flavicon.ico');
         $this->server->httpRequest = $request;
-        $this->server->exec();
+        $this->server->start();
 
-        $this->assertEquals(404, $this->response->getStatus(), 'Error: ' . $this->response->body);
+        $this->assertEquals(404, $this->getResponse()->getStatusCode(), 'Error: ' . $this->getResponse()->getBody()->getContents());
 
     }
 
@@ -178,9 +181,9 @@ class PluginTest extends DAV\AbstractServer{
 
         $request = new HTTP\Request('GET', '/?sabreAction=asset&assetName=./../assets/favicon.ico');
         $this->server->httpRequest = $request;
-        $this->server->exec();
+        $this->server->start();
 
-        $this->assertEquals(404, $this->response->getStatus(), 'Error: ' . $this->response->body);
+        $this->assertEquals(404, $this->getResponse()->getStatusCode(), 'Error: ' . $this->getResponse()->getBody()->getContents());
 
     }
 }

--- a/tests/Sabre/DAV/Browser/PluginTest.php
+++ b/tests/Sabre/DAV/Browser/PluginTest.php
@@ -194,4 +194,20 @@ class PluginTest extends DAV\AbstractServer{
         $this->assertEquals(404, $response->getStatusCode(), 'Error: ' . $response->getBody()->getContents());
 
     }
+
+    public function testGetPlugins()
+    {
+        $request = (new ServerRequest('GET', '/'))
+            ->withQueryParams([
+                'sabreAction' => 'plugins'
+            ]);
+        $response = $this->server->handle($request);
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('text/html; charset=utf-8', $response->getHeaderLine('Content-Type'));
+        $responseBody = $response->getBody()->getContents();
+        /** @var  $plugin DAV\ServerPlugin */
+        foreach($this->server->getPlugins() as $plugin) {
+            $this->assertContains('<th>' . $plugin->getPluginName() . '</th>', $responseBody);
+        }
+    }
 }

--- a/tests/Sabre/DAV/ClientTest.php
+++ b/tests/Sabre/DAV/ClientTest.php
@@ -252,7 +252,7 @@ XML;
 
     /**
      * @depends testPropPatch
-     * @expectedException Sabre\HTTP\ClientException
+     * @expectedException \Sabre\HTTP\ClientException
      */
     function testPropPatchMultiStatusError() {
 

--- a/tests/Sabre/DAV/DbTestHelperTrait.php
+++ b/tests/Sabre/DAV/DbTestHelperTrait.php
@@ -50,8 +50,8 @@ trait DbTestHelperTrait {
                 case 'pgsql' :
                     $pdo = new \PDO(SABRE_PGSQLDSN);
                     $version = $pdo->query('SELECT VERSION()')->fetchColumn();
-                    preg_match('|([0-9\.]){5,}|', $version, $matches);
-                    $version = $matches[0];
+                    preg_match('|PostgreSQL (\d+\.\d+)|', $version, $matches);
+                    $version = $matches[1];
                     if (version_compare($version, '9.5.0', '<')) {
                         DbCache::$cache[$this->driver] = null;
                         $this->markTestSkipped('We require at least Postgres 9.5. This server is running ' . $version);
@@ -64,7 +64,7 @@ trait DbTestHelperTrait {
             $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
 
         } catch (PDOException $e) {
-
+            throw $e;
             $this->markTestSkipped($this->driver . ' was not enabled or not correctly configured. Error message: ' . $e->getMessage());
 
         }

--- a/tests/Sabre/DAV/DbTestHelperTrait.php
+++ b/tests/Sabre/DAV/DbTestHelperTrait.php
@@ -52,7 +52,7 @@ trait DbTestHelperTrait {
                     $version = $pdo->query('SELECT VERSION()')->fetchColumn();
                     preg_match('|PostgreSQL (\d+\.\d+)|', $version, $matches);
                     $version = $matches[1];
-                    if (version_compare($version, '9.5', '<=')) {
+                    if (version_compare($version, '9.5', '<')) {
                         DbCache::$cache[$this->driver] = null;
                         $this->markTestSkipped('We require at least Postgres 9.5. This server is running ' . $version);
                     }

--- a/tests/Sabre/DAV/DbTestHelperTrait.php
+++ b/tests/Sabre/DAV/DbTestHelperTrait.php
@@ -52,7 +52,7 @@ trait DbTestHelperTrait {
                     $version = $pdo->query('SELECT VERSION()')->fetchColumn();
                     preg_match('|PostgreSQL (\d+\.\d+)|', $version, $matches);
                     $version = $matches[1];
-                    if (version_compare($version, '9.5.0', '<=')) {
+                    if (version_compare($version, '9.5', '<=')) {
                         DbCache::$cache[$this->driver] = null;
                         $this->markTestSkipped('We require at least Postgres 9.5. This server is running ' . $version);
                     }

--- a/tests/Sabre/DAV/DbTestHelperTrait.php
+++ b/tests/Sabre/DAV/DbTestHelperTrait.php
@@ -52,7 +52,7 @@ trait DbTestHelperTrait {
                     $version = $pdo->query('SELECT VERSION()')->fetchColumn();
                     preg_match('|PostgreSQL (\d+\.\d+)|', $version, $matches);
                     $version = $matches[1];
-                    if (version_compare($version, '9.5.0', '<')) {
+                    if (version_compare($version, '9.5.0', '<=')) {
                         DbCache::$cache[$this->driver] = null;
                         $this->markTestSkipped('We require at least Postgres 9.5. This server is running ' . $version);
                     }

--- a/tests/Sabre/DAV/Exception/LockedTest.php
+++ b/tests/Sabre/DAV/Exception/LockedTest.php
@@ -20,7 +20,7 @@ class LockedTest extends \PHPUnit_Framework_TestCase {
         $lockInfo->uri = '/foo';
         $locked = new Locked($lockInfo);
 
-        $locked->serialize(new DAV\Server(), $root);
+        $locked->serialize(new DAV\Server(null, null, null, function() {}), $root);
 
         $output = $dom->saveXML();
 
@@ -49,7 +49,7 @@ class LockedTest extends \PHPUnit_Framework_TestCase {
         $lockInfo->uri = '/foo&bar';
         $locked = new Locked($lockInfo);
 
-        $locked->serialize(new DAV\Server(), $root);
+        $locked->serialize(new DAV\Server(null, null, null, function(){}), $root);
 
         $output = $dom->saveXML();
 

--- a/tests/Sabre/DAV/Exception/TooManyMatchesTest.php
+++ b/tests/Sabre/DAV/Exception/TooManyMatchesTest.php
@@ -4,6 +4,7 @@ namespace Sabre\DAV\Exception;
 
 use DOMDocument;
 use Sabre\DAV;
+use Sabre\DAV\Server;
 
 class TooManyMatchesTest extends \PHPUnit_Framework_TestCase {
 
@@ -18,7 +19,7 @@ class TooManyMatchesTest extends \PHPUnit_Framework_TestCase {
 
         $locked = new TooManyMatches();
 
-        $locked->serialize(new DAV\Server(), $root);
+        $locked->serialize(new Server(null, null, null, function(){}), $root);
 
         $output = $dom->saveXML();
 

--- a/tests/Sabre/DAV/FSExt/ServerTest.php
+++ b/tests/Sabre/DAV/FSExt/ServerTest.php
@@ -26,7 +26,7 @@ class ServerTest extends DAV\AbstractServer{
 
         $this->assertEquals(200, $response->getStatusCode(), 'Invalid status code received.');
         $this->assertEquals([
-            'X-Sabre-Version' => [DAV\Version::VERSION],
+
             'Content-Type'    => ['application/octet-stream'],
             'Content-Length'  => [13],
             'Last-Modified'   => [HTTP\toDate(new \DateTime('@' . filemtime($filename)))],
@@ -48,7 +48,7 @@ class ServerTest extends DAV\AbstractServer{
 
 
         $this->assertEquals([
-            'X-Sabre-Version' => [DAV\Version::VERSION],
+
             'Content-Type'    => ['application/octet-stream'],
             'Content-Length'  => [13],
             'Last-Modified'   => [HTTP\toDate(new \DateTime('@' . filemtime($this->tempDir . '/test.txt')))],
@@ -70,7 +70,7 @@ class ServerTest extends DAV\AbstractServer{
 
 
         $this->assertEquals([
-            'X-Sabre-Version' => [DAV\Version::VERSION],
+
             'Content-Length'  => ['0'],
             'ETag'            => ['"' . sha1(fileinode($filename) . filesize($filename) . filemtime($filename)) . '"'],
         ], $response->getHeaders());
@@ -86,9 +86,8 @@ class ServerTest extends DAV\AbstractServer{
         $request = new ServerRequest('PUT', '/test.txt', ['If-None-Match' => '*'], 'Testing new file');
         $response = $this->server->handle($request);
 
-
         $this->assertEquals([
-            'X-Sabre-Version' => [DAV\Version::VERSION],
+
             'Content-Type'    => ['application/xml; charset=utf-8'],
         ], $response->getHeaders());
 
@@ -104,7 +103,7 @@ class ServerTest extends DAV\AbstractServer{
 
 
         $this->assertEquals([
-            'X-Sabre-Version' => [DAV\Version::VERSION],
+
             'Content-Length'  => ['0'],
         ], $response->getHeaders());
 
@@ -135,7 +134,7 @@ class ServerTest extends DAV\AbstractServer{
 
 
         $this->assertEquals([
-            'X-Sabre-Version' => [DAV\Version::VERSION],
+
             'Content-Length'  => ['0'],
         ], $response->getHeaders());
 
@@ -155,7 +154,7 @@ class ServerTest extends DAV\AbstractServer{
 
 
         $this->assertEquals([
-            'X-Sabre-Version' => [DAV\Version::VERSION],
+
             'Content-Length'  => ['0'],
         ], $response->getHeaders());
         $this->assertEquals(204, $response->getStatusCode());
@@ -176,7 +175,7 @@ class ServerTest extends DAV\AbstractServer{
             'Allow'           => ['OPTIONS, GET, HEAD, DELETE, PROPFIND, PUT, PROPPATCH, COPY, MOVE, REPORT'],
             'Accept-Ranges'   => ['bytes'],
             'Content-Length'  => ['0'],
-            'X-Sabre-Version' => [DAV\Version::VERSION],
+
         ], $response->getHeaders());
 
         $this->assertEquals(200, $response->getStatusCode());
@@ -197,7 +196,7 @@ class ServerTest extends DAV\AbstractServer{
 
         $this->assertEquals([
             'Content-Length'  => ['0'],
-            'X-Sabre-Version' => [DAV\Version::VERSION],
+
         ], $response->getHeaders());
 
         $this->assertTrue(
@@ -234,7 +233,7 @@ class ServerTest extends DAV\AbstractServer{
 
         $this->assertEquals([
             'Content-Length'  => ['0'],
-            'X-Sabre-Version' => [DAV\Version::VERSION],
+
         ], $response->getHeaders());
 
         $this->assertTrue(
@@ -255,7 +254,7 @@ class ServerTest extends DAV\AbstractServer{
 
         $this->assertEquals([
             'Content-Length'  => ['0'],
-            'X-Sabre-Version' => [DAV\Version::VERSION],
+
         ], $response->getHeaders());
 
         $this->assertTrue(is_file($this->tempDir . '/test.txt'));

--- a/tests/Sabre/DAV/FSExt/ServerTest.php
+++ b/tests/Sabre/DAV/FSExt/ServerTest.php
@@ -247,17 +247,16 @@ class ServerTest extends DAV\AbstractServer{
 
         mkdir($this->tempDir . '/testcol');
 
-        $request = new HTTP\Request('COPY', '/test.txt', ['Destination' => '/testcol/test2.txt']);
-        $this->server->httpRequest = ($request);
-        $this->server->exec();
+        $request = new ServerRequest('COPY', '/test.txt', ['Destination' => '/testcol/test2.txt']);
+        $response = $this->server->handle($request);
 
-        $this->assertEquals(201, $this->response->status);
-        $this->assertEquals('', $this->response->body);
+        $this->assertEquals(201, $response->getStatusCode());
+        $this->assertEquals(0, $response->getBody()->getSize());
 
         $this->assertEquals([
             'Content-Length'  => ['0'],
             'X-Sabre-Version' => [DAV\Version::VERSION],
-        ], $this->response->getHeaders());
+        ], $response->getHeaders());
 
         $this->assertTrue(is_file($this->tempDir . '/test.txt'));
         $this->assertTrue(is_file($this->tempDir . '/testcol/test2.txt'));

--- a/tests/Sabre/DAV/FSExt/ServerTest.php
+++ b/tests/Sabre/DAV/FSExt/ServerTest.php
@@ -20,9 +20,9 @@ class ServerTest extends DAV\AbstractServer{
         $request = new HTTP\Request('GET', '/test.txt');
         $filename = $this->tempDir . '/test.txt';
         $this->server->httpRequest = $request;
-        $this->server->exec();
+        $this->server->start();
 
-        $this->assertEquals(200, $this->response->getStatus(), 'Invalid status code received.');
+        $this->assertEquals(200, $this->getResponse()->getStatusCode(), 'Invalid status code received.');
         $this->assertEquals([
             'X-Sabre-Version' => [DAV\Version::VERSION],
             'Content-Type'    => ['application/octet-stream'],
@@ -30,11 +30,11 @@ class ServerTest extends DAV\AbstractServer{
             'Last-Modified'   => [HTTP\toDate(new \DateTime('@' . filemtime($filename)))],
             'ETag'            => ['"' . sha1(fileinode($filename) . filesize($filename) . filemtime($filename)) . '"'],
             ],
-            $this->response->getHeaders()
+            $this->getResponse()->getHeaders()
          );
 
 
-        $this->assertEquals('Test contents', stream_get_contents($this->response->body));
+        $this->assertEquals('Test contents', $this->getResponse()->getBody()->getContents());
 
     }
 
@@ -43,7 +43,7 @@ class ServerTest extends DAV\AbstractServer{
         $request = new HTTP\Request('HEAD', '/test.txt');
         $filename = $this->tempDir . '/test.txt';
         $this->server->httpRequest = ($request);
-        $this->server->exec();
+        $this->server->start();
 
         $this->assertEquals([
             'X-Sabre-Version' => [DAV\Version::VERSION],
@@ -52,11 +52,11 @@ class ServerTest extends DAV\AbstractServer{
             'Last-Modified'   => [HTTP\toDate(new \DateTime('@' . filemtime($this->tempDir . '/test.txt')))],
             'ETag'            => ['"' . sha1(fileinode($filename) . filesize($filename) . filemtime($filename)) . '"'],
             ],
-            $this->response->getHeaders()
+            $this->getResponse()->getHeaders()
          );
 
-        $this->assertEquals(200, $this->response->status);
-        $this->assertEquals('', $this->response->body);
+        $this->assertEquals(200, $this->getResponse()->getStatusCode());
+        $this->assertEquals('', $this->getResponse()->getBody()->getContents());
 
     }
 
@@ -66,16 +66,16 @@ class ServerTest extends DAV\AbstractServer{
         $filename = $this->tempDir . '/testput.txt';
         $request->setBody('Testing new file');
         $this->server->httpRequest = ($request);
-        $this->server->exec();
+        $this->server->start();
 
         $this->assertEquals([
             'X-Sabre-Version' => [DAV\Version::VERSION],
             'Content-Length'  => ['0'],
             'ETag'            => ['"' . sha1(fileinode($filename) . filesize($filename) . filemtime($filename)) . '"'],
-        ], $this->response->getHeaders());
+        ], $this->getResponse()->getHeaders());
 
-        $this->assertEquals(201, $this->response->status);
-        $this->assertEquals('', $this->response->body);
+        $this->assertEquals(201, $this->getResponse()->getStatusCode());
+        $this->assertEquals('', $this->getResponse()->getBody()->getContents());
         $this->assertEquals('Testing new file', file_get_contents($filename));
 
     }
@@ -85,14 +85,14 @@ class ServerTest extends DAV\AbstractServer{
         $request = new HTTP\Request('PUT', '/test.txt', ['If-None-Match' => '*']);
         $request->setBody('Testing new file');
         $this->server->httpRequest = ($request);
-        $this->server->exec();
+        $this->server->start();
 
         $this->assertEquals([
             'X-Sabre-Version' => [DAV\Version::VERSION],
             'Content-Type'    => ['application/xml; charset=utf-8'],
-        ], $this->response->getHeaders());
+        ], $this->getResponse()->getHeaders());
 
-        $this->assertEquals(412, $this->response->status);
+        $this->assertEquals(412, $this->getResponse()->getStatusCode());
         $this->assertNotEquals('Testing new file', file_get_contents($this->tempDir . '/test.txt'));
 
     }
@@ -101,15 +101,15 @@ class ServerTest extends DAV\AbstractServer{
 
         $request = new HTTP\Request('MKCOL', '/testcol');
         $this->server->httpRequest = ($request);
-        $this->server->exec();
+        $this->server->start();
 
         $this->assertEquals([
             'X-Sabre-Version' => [DAV\Version::VERSION],
             'Content-Length'  => ['0'],
-        ], $this->response->getHeaders());
+        ], $this->getResponse()->getHeaders());
 
-        $this->assertEquals(201, $this->response->status);
-        $this->assertEquals('', $this->response->body);
+        $this->assertEquals(201, $this->getResponse()->getStatusCode());
+        $this->assertEquals('', $this->getResponse()->getBody()->getContents());
         $this->assertTrue(is_dir($this->tempDir . '/testcol'));
 
     }
@@ -119,12 +119,12 @@ class ServerTest extends DAV\AbstractServer{
         $request = new HTTP\Request('PUT', '/test.txt');
         $request->setBody('Testing updated file');
         $this->server->httpRequest = ($request);
-        $this->server->exec();
+        $this->server->start();
 
-        $this->assertEquals('0', $this->response->getHeader('Content-Length'));
+        $this->assertEquals('0', $this->getResponse()->getHeaderLine('Content-Length'));
 
-        $this->assertEquals(204, $this->response->status);
-        $this->assertEquals('', $this->response->body);
+        $this->assertEquals(204, $this->getResponse()->getStatusCode());
+        $this->assertEquals('', $this->getResponse()->getBody()->getContents());
         $this->assertEquals('Testing updated file', file_get_contents($this->tempDir . '/test.txt'));
 
     }
@@ -133,15 +133,15 @@ class ServerTest extends DAV\AbstractServer{
 
         $request = new HTTP\Request('DELETE', '/test.txt');
         $this->server->httpRequest = ($request);
-        $this->server->exec();
+        $this->server->start();
 
         $this->assertEquals([
             'X-Sabre-Version' => [DAV\Version::VERSION],
             'Content-Length'  => ['0'],
-        ], $this->response->getHeaders());
+        ], $this->getResponse()->getHeaders());
 
-        $this->assertEquals(204, $this->response->status);
-        $this->assertEquals('', $this->response->body);
+        $this->assertEquals(204, $this->getResponse()->getStatusCode());
+        $this->assertEquals('', $this->getResponse()->getBody()->getContents());
         $this->assertFalse(file_exists($this->tempDir . '/test.txt'));
 
     }
@@ -153,14 +153,14 @@ class ServerTest extends DAV\AbstractServer{
 
         $request = new HTTP\Request('DELETE', '/testcol');
         $this->server->httpRequest = ($request);
-        $this->server->exec();
+        $this->server->start();
 
         $this->assertEquals([
             'X-Sabre-Version' => [DAV\Version::VERSION],
             'Content-Length'  => ['0'],
-        ], $this->response->getHeaders());
-        $this->assertEquals(204, $this->response->status);
-        $this->assertEquals('', $this->response->body);
+        ], $this->getResponse()->getHeaders());
+        $this->assertEquals(204, $this->getResponse()->getStatusCode());
+        $this->assertEquals('', $this->getResponse()->getBody()->getContents());
         $this->assertFalse(file_exists($this->tempDir . '/testcol'));
 
     }
@@ -169,7 +169,7 @@ class ServerTest extends DAV\AbstractServer{
 
         $request = new HTTP\Request('OPTIONS', '/');
         $this->server->httpRequest = ($request);
-        $this->server->exec();
+        $this->server->start();
 
         $this->assertEquals([
             'DAV'             => ['1, 3, extended-mkcol'],
@@ -178,10 +178,10 @@ class ServerTest extends DAV\AbstractServer{
             'Accept-Ranges'   => ['bytes'],
             'Content-Length'  => ['0'],
             'X-Sabre-Version' => [DAV\Version::VERSION],
-        ], $this->response->getHeaders());
+        ], $this->getResponse()->getHeaders());
 
-        $this->assertEquals(200, $this->response->status);
-        $this->assertEquals('', $this->response->body);
+        $this->assertEquals(200, $this->getResponse()->getStatusCode());
+        $this->assertEquals('', $this->getResponse()->getBody()->getContents());
 
     }
 
@@ -191,15 +191,15 @@ class ServerTest extends DAV\AbstractServer{
 
         $request = new HTTP\Request('MOVE', '/test.txt', ['Destination' => '/testcol/test2.txt']);
         $this->server->httpRequest = ($request);
-        $this->server->exec();
+        $this->server->start();
 
-        $this->assertEquals(201, $this->response->status);
-        $this->assertEquals('', $this->response->body);
+        $this->assertEquals(201, $this->getResponse()->getStatusCode());
+        $this->assertEquals('', $this->getResponse()->getBody()->getContents());
 
         $this->assertEquals([
             'Content-Length'  => ['0'],
             'X-Sabre-Version' => [DAV\Version::VERSION],
-        ], $this->response->getHeaders());
+        ], $this->getResponse()->getHeaders());
 
         $this->assertTrue(
             is_file($this->tempDir . '/testcol/test2.txt')
@@ -228,15 +228,15 @@ class ServerTest extends DAV\AbstractServer{
 
         $request = new HTTP\Request('MOVE', '/tree1', ['Destination' => '/tree2/tree1']);
         $this->server->httpRequest = ($request);
-        $this->server->exec();
+        $this->server->start();
 
-        $this->assertEquals(201, $this->response->status);
-        $this->assertEquals('', $this->response->body);
+        $this->assertEquals(201, $this->getResponse()->getStatusCode());
+        $this->assertEquals('', $this->getResponse()->getBody()->getContents());
 
         $this->assertEquals([
             'Content-Length'  => ['0'],
             'X-Sabre-Version' => [DAV\Version::VERSION],
-        ], $this->response->getHeaders());
+        ], $this->getResponse()->getHeaders());
 
         $this->assertTrue(
             is_dir($this->tempDir . '/tree2/tree1')

--- a/tests/Sabre/DAV/FSExt/ServerTest.php
+++ b/tests/Sabre/DAV/FSExt/ServerTest.php
@@ -2,6 +2,7 @@
 
 namespace Sabre\DAV\FSExt;
 
+use GuzzleHttp\Psr7\ServerRequest;
 use Sabre\DAV;
 use Sabre\HTTP;
 
@@ -17,12 +18,13 @@ class ServerTest extends DAV\AbstractServer{
 
     function testGet() {
 
-        $request = new HTTP\Request('GET', '/test.txt');
+        $request = new ServerRequest('GET', '/test.txt');
         $filename = $this->tempDir . '/test.txt';
-        $this->server->httpRequest = $request;
-        $this->server->start();
 
-        $this->assertEquals(200, $this->getResponse()->getStatusCode(), 'Invalid status code received.');
+        $response = $this->server->handle($request);
+
+
+        $this->assertEquals(200, $response->getStatusCode(), 'Invalid status code received.');
         $this->assertEquals([
             'X-Sabre-Version' => [DAV\Version::VERSION],
             'Content-Type'    => ['application/octet-stream'],
@@ -30,20 +32,20 @@ class ServerTest extends DAV\AbstractServer{
             'Last-Modified'   => [HTTP\toDate(new \DateTime('@' . filemtime($filename)))],
             'ETag'            => ['"' . sha1(fileinode($filename) . filesize($filename) . filemtime($filename)) . '"'],
             ],
-            $this->getResponse()->getHeaders()
+            $response->getHeaders()
          );
 
 
-        $this->assertEquals('Test contents', $this->getResponse()->getBody()->getContents());
+        $this->assertEquals('Test contents', $response->getBody()->getContents());
 
     }
 
     function testHEAD() {
 
-        $request = new HTTP\Request('HEAD', '/test.txt');
+        $request = new ServerRequest('HEAD', '/test.txt');
         $filename = $this->tempDir . '/test.txt';
-        $this->server->httpRequest = ($request);
-        $this->server->start();
+        $response = $this->server->handle($request);
+
 
         $this->assertEquals([
             'X-Sabre-Version' => [DAV\Version::VERSION],
@@ -52,96 +54,93 @@ class ServerTest extends DAV\AbstractServer{
             'Last-Modified'   => [HTTP\toDate(new \DateTime('@' . filemtime($this->tempDir . '/test.txt')))],
             'ETag'            => ['"' . sha1(fileinode($filename) . filesize($filename) . filemtime($filename)) . '"'],
             ],
-            $this->getResponse()->getHeaders()
+            $response->getHeaders()
          );
 
-        $this->assertEquals(200, $this->getResponse()->getStatusCode());
-        $this->assertEquals('', $this->getResponse()->getBody()->getContents());
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('', $response->getBody()->getContents());
 
     }
 
     function testPut() {
 
-        $request = new HTTP\Request('PUT', '/testput.txt');
+        $request = new ServerRequest('PUT', '/testput.txt', [], 'Testing new file');
         $filename = $this->tempDir . '/testput.txt';
-        $request->setBody('Testing new file');
-        $this->server->httpRequest = ($request);
-        $this->server->start();
+        $response = $this->server->handle($request);
+
 
         $this->assertEquals([
             'X-Sabre-Version' => [DAV\Version::VERSION],
             'Content-Length'  => ['0'],
             'ETag'            => ['"' . sha1(fileinode($filename) . filesize($filename) . filemtime($filename)) . '"'],
-        ], $this->getResponse()->getHeaders());
+        ], $response->getHeaders());
 
-        $this->assertEquals(201, $this->getResponse()->getStatusCode());
-        $this->assertEquals('', $this->getResponse()->getBody()->getContents());
+        $this->assertEquals(201, $response->getStatusCode());
+        $this->assertEquals('', $response->getBody()->getContents());
         $this->assertEquals('Testing new file', file_get_contents($filename));
 
     }
 
     function testPutAlreadyExists() {
 
-        $request = new HTTP\Request('PUT', '/test.txt', ['If-None-Match' => '*']);
-        $request->setBody('Testing new file');
-        $this->server->httpRequest = ($request);
-        $this->server->start();
+        $request = new ServerRequest('PUT', '/test.txt', ['If-None-Match' => '*'], 'Testing new file');
+        $response = $this->server->handle($request);
+
 
         $this->assertEquals([
             'X-Sabre-Version' => [DAV\Version::VERSION],
             'Content-Type'    => ['application/xml; charset=utf-8'],
-        ], $this->getResponse()->getHeaders());
+        ], $response->getHeaders());
 
-        $this->assertEquals(412, $this->getResponse()->getStatusCode());
+        $this->assertEquals(412, $response->getStatusCode());
         $this->assertNotEquals('Testing new file', file_get_contents($this->tempDir . '/test.txt'));
 
     }
 
     function testMkcol() {
 
-        $request = new HTTP\Request('MKCOL', '/testcol');
-        $this->server->httpRequest = ($request);
-        $this->server->start();
+        $request = new ServerRequest('MKCOL', '/testcol');
+        $response = $this->server->handle($request);
+
 
         $this->assertEquals([
             'X-Sabre-Version' => [DAV\Version::VERSION],
             'Content-Length'  => ['0'],
-        ], $this->getResponse()->getHeaders());
+        ], $response->getHeaders());
 
-        $this->assertEquals(201, $this->getResponse()->getStatusCode());
-        $this->assertEquals('', $this->getResponse()->getBody()->getContents());
+        $this->assertEquals(201, $response->getStatusCode());
+        $this->assertEquals('', $response->getBody()->getContents());
         $this->assertTrue(is_dir($this->tempDir . '/testcol'));
 
     }
 
     function testPutUpdate() {
 
-        $request = new HTTP\Request('PUT', '/test.txt');
-        $request->setBody('Testing updated file');
-        $this->server->httpRequest = ($request);
-        $this->server->start();
+        $request = new ServerRequest('PUT', '/test.txt', [], 'Testing updated file');
+        $response = $this->server->handle($request);
 
-        $this->assertEquals('0', $this->getResponse()->getHeaderLine('Content-Length'));
 
-        $this->assertEquals(204, $this->getResponse()->getStatusCode());
-        $this->assertEquals('', $this->getResponse()->getBody()->getContents());
+        $this->assertEquals('0', $response->getHeaderLine('Content-Length'));
+
+        $this->assertEquals(204, $response->getStatusCode());
+        $this->assertEquals('', $response->getBody()->getContents());
         $this->assertEquals('Testing updated file', file_get_contents($this->tempDir . '/test.txt'));
 
     }
 
     function testDelete() {
 
-        $request = new HTTP\Request('DELETE', '/test.txt');
-        $this->server->httpRequest = ($request);
-        $this->server->start();
+        $request = new ServerRequest('DELETE', '/test.txt');
+        $response = $this->server->handle($request);
+
 
         $this->assertEquals([
             'X-Sabre-Version' => [DAV\Version::VERSION],
             'Content-Length'  => ['0'],
-        ], $this->getResponse()->getHeaders());
+        ], $response->getHeaders());
 
-        $this->assertEquals(204, $this->getResponse()->getStatusCode());
-        $this->assertEquals('', $this->getResponse()->getBody()->getContents());
+        $this->assertEquals(204, $response->getStatusCode());
+        $this->assertEquals('', $response->getBody()->getContents());
         $this->assertFalse(file_exists($this->tempDir . '/test.txt'));
 
     }
@@ -151,25 +150,25 @@ class ServerTest extends DAV\AbstractServer{
         mkdir($this->tempDir . '/testcol');
         file_put_contents($this->tempDir . '/testcol/test.txt', 'Hi! I\'m a file with a short lifespan');
 
-        $request = new HTTP\Request('DELETE', '/testcol');
-        $this->server->httpRequest = ($request);
-        $this->server->start();
+        $request = new ServerRequest('DELETE', '/testcol');
+        $response = $this->server->handle($request);
+
 
         $this->assertEquals([
             'X-Sabre-Version' => [DAV\Version::VERSION],
             'Content-Length'  => ['0'],
-        ], $this->getResponse()->getHeaders());
-        $this->assertEquals(204, $this->getResponse()->getStatusCode());
-        $this->assertEquals('', $this->getResponse()->getBody()->getContents());
+        ], $response->getHeaders());
+        $this->assertEquals(204, $response->getStatusCode());
+        $this->assertEquals('', $response->getBody()->getContents());
         $this->assertFalse(file_exists($this->tempDir . '/testcol'));
 
     }
 
     function testOptions() {
 
-        $request = new HTTP\Request('OPTIONS', '/');
-        $this->server->httpRequest = ($request);
-        $this->server->start();
+        $request = new ServerRequest('OPTIONS', '/');
+        $response = $this->server->handle($request);
+
 
         $this->assertEquals([
             'DAV'             => ['1, 3, extended-mkcol'],
@@ -178,10 +177,10 @@ class ServerTest extends DAV\AbstractServer{
             'Accept-Ranges'   => ['bytes'],
             'Content-Length'  => ['0'],
             'X-Sabre-Version' => [DAV\Version::VERSION],
-        ], $this->getResponse()->getHeaders());
+        ], $response->getHeaders());
 
-        $this->assertEquals(200, $this->getResponse()->getStatusCode());
-        $this->assertEquals('', $this->getResponse()->getBody()->getContents());
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('', $response->getBody()->getContents());
 
     }
 
@@ -189,17 +188,17 @@ class ServerTest extends DAV\AbstractServer{
 
         mkdir($this->tempDir . '/testcol');
 
-        $request = new HTTP\Request('MOVE', '/test.txt', ['Destination' => '/testcol/test2.txt']);
-        $this->server->httpRequest = ($request);
-        $this->server->start();
+        $request = new ServerRequest('MOVE', '/test.txt', ['Destination' => '/testcol/test2.txt']);
+        $response = $this->server->handle($request);
 
-        $this->assertEquals(201, $this->getResponse()->getStatusCode());
-        $this->assertEquals('', $this->getResponse()->getBody()->getContents());
+
+        $this->assertEquals(201, $response->getStatusCode());
+        $this->assertEquals('', $response->getBody()->getContents());
 
         $this->assertEquals([
             'Content-Length'  => ['0'],
             'X-Sabre-Version' => [DAV\Version::VERSION],
-        ], $this->getResponse()->getHeaders());
+        ], $response->getHeaders());
 
         $this->assertTrue(
             is_file($this->tempDir . '/testcol/test2.txt')
@@ -226,17 +225,17 @@ class ServerTest extends DAV\AbstractServer{
         ]));
         $this->server->tree = $tree;
 
-        $request = new HTTP\Request('MOVE', '/tree1', ['Destination' => '/tree2/tree1']);
-        $this->server->httpRequest = ($request);
-        $this->server->start();
+        $request = new ServerRequest('MOVE', '/tree1', ['Destination' => '/tree2/tree1']);
+        $response = $this->server->handle($request);
 
-        $this->assertEquals(201, $this->getResponse()->getStatusCode());
-        $this->assertEquals('', $this->getResponse()->getBody()->getContents());
+
+        $this->assertEquals(201, $response->getStatusCode());
+        $this->assertEquals('', $response->getBody()->getContents());
 
         $this->assertEquals([
             'Content-Length'  => ['0'],
             'X-Sabre-Version' => [DAV\Version::VERSION],
-        ], $this->getResponse()->getHeaders());
+        ], $response->getHeaders());
 
         $this->assertTrue(
             is_dir($this->tempDir . '/tree2/tree1')

--- a/tests/Sabre/DAV/GetIfConditionsTest.php
+++ b/tests/Sabre/DAV/GetIfConditionsTest.php
@@ -2,6 +2,7 @@
 
 namespace Sabre\DAV;
 
+use GuzzleHttp\Psr7\ServerRequest;
 use Sabre\HTTP;
 
 require_once 'Sabre/HTTP/ResponseMock.php';
@@ -11,17 +12,17 @@ class GetIfConditionsTest extends AbstractServer {
 
     function testNoConditions() {
 
-        $request = new HTTP\Request('GET', '/foo');
+        $request = new ServerRequest('GET', '/foo');
 
-        $conditions = $this->server->getIfConditions($request);
+        $conditions = $this->server->getIfConditions(new Psr7RequestWrapper($request));
         $this->assertEquals([], $conditions);
 
     }
 
     function testLockToken() {
 
-        $request = new HTTP\Request('GET', '/path/', ['If' => '(<opaquelocktoken:token1>)']);
-        $conditions = $this->server->getIfConditions($request);
+        $request = new ServerRequest('GET', '/path/', ['If' => '(<opaquelocktoken:token1>)']);
+        $conditions = $this->server->getIfConditions(new Psr7RequestWrapper($request));
 
         $compare = [
 
@@ -45,11 +46,11 @@ class GetIfConditionsTest extends AbstractServer {
 
     function testNotLockToken() {
 
-        $request = new HTTP\Request('GET', '/bla', [
+        $request = new ServerRequest('GET', '/bla', [
             'If' => '(Not <opaquelocktoken:token1>)',
         ]);
 
-        $conditions = $this->server->getIfConditions($request);
+        $conditions = $this->server->getIfConditions(new Psr7RequestWrapper($request));
 
         $compare = [
 
@@ -72,10 +73,10 @@ class GetIfConditionsTest extends AbstractServer {
 
     function testLockTokenUrl() {
 
-        $request = new HTTP\Request('GET', '/bla', [
+        $request = new ServerRequest('GET', '/bla', [
             'If' => '<http://www.example.com/> (<opaquelocktoken:token1>)',
         ]);
-        $conditions = $this->server->getIfConditions($request);
+        $conditions = $this->server->getIfConditions(new Psr7RequestWrapper($request));
 
         $compare = [
 
@@ -98,11 +99,11 @@ class GetIfConditionsTest extends AbstractServer {
 
     function test2LockTokens() {
 
-        $request = new HTTP\Request('GET', '/bla', [
+        $request = new ServerRequest('GET', '/bla', [
             'If' => '(<opaquelocktoken:token1>) (Not <opaquelocktoken:token2>)',
         ]);
 
-        $conditions = $this->server->getIfConditions($request);
+        $conditions = $this->server->getIfConditions(new Psr7RequestWrapper($request));
 
         $compare = [
 
@@ -130,11 +131,11 @@ class GetIfConditionsTest extends AbstractServer {
 
     function test2UriLockTokens() {
 
-        $request = new HTTP\Request('GET', '/bla', [
+        $request = new ServerRequest('GET', '/bla', [
             'If' => '<http://www.example.org/node1> (<opaquelocktoken:token1>) <http://www.example.org/node2> (Not <opaquelocktoken:token2>)',
         ]);
 
-        $conditions = $this->server->getIfConditions($request);
+        $conditions = $this->server->getIfConditions(new Psr7RequestWrapper($request));
 
         $compare = [
 
@@ -167,11 +168,11 @@ class GetIfConditionsTest extends AbstractServer {
 
     function test2UriMultiLockTokens() {
 
-        $request = new HTTP\Request('GET', '/bla', [
+        $request = new ServerRequest('GET', '/bla', [
             'If' => '<http://www.example.org/node1> (<opaquelocktoken:token1>) (<opaquelocktoken:token2>) <http://www.example.org/node2> (Not <opaquelocktoken:token3>)',
         ]);
 
-        $conditions = $this->server->getIfConditions($request);
+        $conditions = $this->server->getIfConditions(new Psr7RequestWrapper($request));
 
         $compare = [
 
@@ -209,11 +210,11 @@ class GetIfConditionsTest extends AbstractServer {
 
     function testEtag() {
 
-        $request = new HTTP\Request('GET', '/foo', [
+        $request = new ServerRequest('GET', '/foo', [
             'If' => '(["etag1"])',
         ]);
 
-        $conditions = $this->server->getIfConditions($request);
+        $conditions = $this->server->getIfConditions(new Psr7RequestWrapper($request));
 
         $compare = [
 
@@ -235,11 +236,11 @@ class GetIfConditionsTest extends AbstractServer {
 
     function test2Etags() {
 
-        $request = new HTTP\Request('GET', '/foo', [
+        $request = new ServerRequest('GET', '/foo', [
             'If' => '<http://www.example.org/> (["etag1"]) (["etag2"])',
         ]);
 
-        $conditions = $this->server->getIfConditions($request);
+        $conditions = $this->server->getIfConditions(new Psr7RequestWrapper($request));
 
         $compare = [
 
@@ -266,13 +267,13 @@ class GetIfConditionsTest extends AbstractServer {
 
     function testComplexIf() {
 
-        $request = new HTTP\Request('GET', '/foo', [
+        $request = new ServerRequest('GET', '/foo', [
             'If' => '<http://www.example.org/node1> (<opaquelocktoken:token1> ["etag1"]) ' .
                     '(Not <opaquelocktoken:token2>) (["etag2"]) <http://www.example.org/node2> ' .
                     '(<opaquelocktoken:token3>) (Not <opaquelocktoken:token4>) (["etag3"])',
         ]);
 
-        $conditions = $this->server->getIfConditions($request);
+        $conditions = $this->server->getIfConditions(new Psr7RequestWrapper($request));
 
         $compare = [
 

--- a/tests/Sabre/DAV/HTTPPreferParsingTest.php
+++ b/tests/Sabre/DAV/HTTPPreferParsingTest.php
@@ -13,7 +13,7 @@ class HTTPPreferParsingTest extends \Sabre\DAVServerTest {
             'Prefer' => $input,
         ]);
 
-        $server = new Server();
+        $server = new Server(null, null, null, function(){});
         $server->handle($httpRequest);
         $this->assertEquals(
             $expected,
@@ -84,7 +84,7 @@ class HTTPPreferParsingTest extends \Sabre\DAVServerTest {
             'Brief' => 't',
         ]);
 
-        $server = new Server();
+        $server = new Server(null, null, null, function(){});
         $server->handle($httpRequest);
 
         $this->assertEquals([

--- a/tests/Sabre/DAV/HTTPPreferParsingTest.php
+++ b/tests/Sabre/DAV/HTTPPreferParsingTest.php
@@ -2,19 +2,19 @@
 
 namespace Sabre\DAV;
 
+use GuzzleHttp\Psr7\ServerRequest;
 use Sabre\HTTP;
 
 class HTTPPreferParsingTest extends \Sabre\DAVServerTest {
 
     function assertParseResult($input, $expected) {
 
-        $httpRequest = new HTTP\Request('GET', '/foo', [
+        $httpRequest = new ServerRequest('GET', '/foo', [
             'Prefer' => $input,
         ]);
 
         $server = new Server();
-        $server->httpRequest = $httpRequest;
-
+        $server->handle($httpRequest);
         $this->assertEquals(
             $expected,
             $server->getHTTPPrefer()
@@ -80,12 +80,12 @@ class HTTPPreferParsingTest extends \Sabre\DAVServerTest {
 
     function testBrief() {
 
-        $httpRequest = new HTTP\Request('GET', '/foo', [
+        $httpRequest = new ServerRequest('GET', '/foo', [
             'Brief' => 't',
         ]);
 
         $server = new Server();
-        $server->httpRequest = $httpRequest;
+        $server->handle($httpRequest);
 
         $this->assertEquals([
             'respond-async' => false,
@@ -103,10 +103,9 @@ class HTTPPreferParsingTest extends \Sabre\DAVServerTest {
      */
     function testpropfindMinimal() {
 
-        $request = new HTTP\Request('PROPFIND', '/', [
+        $request = new ServerRequest('PROPFIND', '/', [
             'Prefer' => 'return-minimal',
-        ]);
-        $request->setBody(<<<BLA
+        ], <<<BLA
 <?xml version="1.0"?>
 <d:propfind xmlns:d="DAV:">
     <d:prop>
@@ -130,8 +129,7 @@ BLA
 
     function testproppatchMinimal() {
 
-        $request = new HTTP\Request('PROPPATCH', '/', ['Prefer' => 'return-minimal']);
-        $request->setBody(<<<BLA
+        $request = new ServerRequest('PROPPATCH', '/', ['Prefer' => 'return-minimal'], <<<BLA
 <?xml version="1.0"?>
 <d:propertyupdate xmlns:d="DAV:">
     <d:set>
@@ -159,8 +157,7 @@ BLA
 
     function testproppatchMinimalError() {
 
-        $request = new HTTP\Request('PROPPATCH', '/', ['Prefer' => 'return-minimal']);
-        $request->setBody(<<<BLA
+        $request = new ServerRequest('PROPPATCH', '/', ['Prefer' => 'return-minimal'], <<<BLA
 <?xml version="1.0"?>
 <d:propertyupdate xmlns:d="DAV:">
     <d:set>

--- a/tests/Sabre/DAV/HTTPPreferParsingTest.php
+++ b/tests/Sabre/DAV/HTTPPreferParsingTest.php
@@ -119,9 +119,9 @@ BLA
 
         $response = $this->request($request);
 
-        $body = $response->getBodyAsString();
+        $body = $response->getBody()->getContents();
 
-        $this->assertEquals(207, $response->getStatus(), $body);
+        $this->assertEquals(207, $response->getStatusCode(), $body);
 
         $this->assertTrue(strpos($body, 'resourcetype') !== false, $body);
         $this->assertTrue(strpos($body, 'something') === false, $body);
@@ -152,9 +152,8 @@ BLA
         });
 
         $response = $this->request($request);
-
-        $this->assertEquals('', $response->getBodyAsString(), 'Expected empty body: ' . $response->body);
-        $this->assertEquals(204, $response->status);
+        $this->assertEmpty($response->getBody()->getContents());
+        $this->assertEquals(204, $response->getStatusCode());
 
     }
 
@@ -175,11 +174,11 @@ BLA
 
         $response = $this->request($request);
 
-        $body = $response->getBodyAsString();
+        $responseBody = $response->getBody()->getContents();
 
-        $this->assertEquals(207, $response->status);
-        $this->assertTrue(strpos($body, 'something') !== false);
-        $this->assertTrue(strpos($body, '403 Forbidden') !== false, $body);
+        $this->assertEquals(207, $response->getStatusCode());
+        $this->assertTrue(strpos($responseBody, 'something') !== false);
+        $this->assertTrue(strpos($responseBody, '403 Forbidden') !== false, $responseBody);
 
     }
 }

--- a/tests/Sabre/DAV/HttpCopyTest.php
+++ b/tests/Sabre/DAV/HttpCopyTest.php
@@ -38,7 +38,7 @@ class HttpCopyTest extends DAVServerTest {
             'Destination' => '/file5'
         ]);
         $response = $this->request($request);
-        $this->assertEquals(201, $response->getStatus());
+        $this->assertEquals(201, $response->getStatusCode());
         $this->assertEquals('content1', $this->tree->getChild('file5')->get());
 
     }
@@ -49,7 +49,7 @@ class HttpCopyTest extends DAVServerTest {
             'Destination' => '/file1'
         ]);
         $response = $this->request($request);
-        $this->assertEquals(403, $response->getStatus());
+        $this->assertEquals(403, $response->getStatusCode());
 
     }
 
@@ -59,7 +59,7 @@ class HttpCopyTest extends DAVServerTest {
             'Destination' => '/file2'
         ]);
         $response = $this->request($request);
-        $this->assertEquals(204, $response->getStatus());
+        $this->assertEquals(204, $response->getStatusCode());
         $this->assertEquals('content1', $this->tree->getChild('file2')->get());
 
     }
@@ -71,7 +71,7 @@ class HttpCopyTest extends DAVServerTest {
             'Overwrite'   => 'T',
         ]);
         $response = $this->request($request);
-        $this->assertEquals(204, $response->getStatus());
+        $this->assertEquals(204, $response->getStatusCode());
         $this->assertEquals('content1', $this->tree->getChild('file2')->get());
 
     }
@@ -83,7 +83,7 @@ class HttpCopyTest extends DAVServerTest {
             'Overwrite'   => 'B',
         ]);
         $response = $this->request($request);
-        $this->assertEquals(400, $response->getStatus());
+        $this->assertEquals(400, $response->getStatusCode());
 
     }
 
@@ -93,7 +93,7 @@ class HttpCopyTest extends DAVServerTest {
             'Destination' => '/notfound/file2',
         ]);
         $response = $this->request($request);
-        $this->assertEquals(409, $response->getStatus());
+        $this->assertEquals(409, $response->getStatusCode());
 
     }
 
@@ -104,7 +104,7 @@ class HttpCopyTest extends DAVServerTest {
             'Overwrite'   => 'F',
         ]);
         $response = $this->request($request);
-        $this->assertEquals(412, $response->getStatus());
+        $this->assertEquals(412, $response->getStatusCode());
         $this->assertEquals('content2', $this->tree->getChild('file2')->get());
 
     }
@@ -135,7 +135,7 @@ class HttpCopyTest extends DAVServerTest {
             'Destination' => '/coll2'
         ]);
         $response = $this->request($request);
-        $this->assertEquals(201, $response->getStatus());
+        $this->assertEquals(201, $response->getStatusCode());
         $this->assertEquals('content3', $this->tree->getChild('coll2')->getChild('file3')->get());
 
     }
@@ -146,7 +146,7 @@ class HttpCopyTest extends DAVServerTest {
             'Destination' => '/coll1'
         ]);
         $response = $this->request($request);
-        $this->assertEquals(403, $response->getStatus());
+        $this->assertEquals(403, $response->getStatusCode());
 
     }
 
@@ -156,7 +156,7 @@ class HttpCopyTest extends DAVServerTest {
             'Destination' => '/file2'
         ]);
         $response = $this->request($request);
-        $this->assertEquals(204, $response->getStatus());
+        $this->assertEquals(204, $response->getStatusCode());
         $this->assertEquals('content3', $this->tree->getChild('file2')->getChild('file3')->get());
 
     }
@@ -168,7 +168,7 @@ class HttpCopyTest extends DAVServerTest {
             'Overwrite'   => 'T',
         ]);
         $response = $this->request($request);
-        $this->assertEquals(204, $response->getStatus());
+        $this->assertEquals(204, $response->getStatusCode());
         $this->assertEquals('content3', $this->tree->getChild('file2')->getChild('file3')->get());
 
     }
@@ -180,7 +180,7 @@ class HttpCopyTest extends DAVServerTest {
             'Overwrite'   => 'F',
         ]);
         $response = $this->request($request);
-        $this->assertEquals(412, $response->getStatus());
+        $this->assertEquals(412, $response->getStatusCode());
         $this->assertEquals('content2', $this->tree->getChild('file2')->get());
 
     }
@@ -191,7 +191,7 @@ class HttpCopyTest extends DAVServerTest {
             'Destination' => '/coll1/subcol',
         ]);
         $response = $this->request($request);
-        $this->assertEquals(409, $response->getStatus());
+        $this->assertEquals(409, $response->getStatusCode());
 
     }
 

--- a/tests/Sabre/DAV/HttpCopyTest.php
+++ b/tests/Sabre/DAV/HttpCopyTest.php
@@ -2,6 +2,7 @@
 
 namespace Sabre\DAV;
 
+use GuzzleHttp\Psr7\ServerRequest;
 use Sabre\DAVServerTest;
 use Sabre\HTTP;
 
@@ -34,7 +35,7 @@ class HttpCopyTest extends DAVServerTest {
     
     function testCopyFile() {
 
-        $request = new HTTP\Request('COPY', '/file1', [
+        $request = new ServerRequest('COPY', '/file1', [
             'Destination' => '/file5'
         ]);
         $response = $this->request($request);
@@ -45,7 +46,7 @@ class HttpCopyTest extends DAVServerTest {
 
     function testCopyFileToSelf() {
 
-        $request = new HTTP\Request('COPY', '/file1', [
+        $request = new ServerRequest('COPY', '/file1', [
             'Destination' => '/file1'
         ]);
         $response = $this->request($request);
@@ -55,7 +56,7 @@ class HttpCopyTest extends DAVServerTest {
 
     function testCopyFileToExisting() {
 
-        $request = new HTTP\Request('COPY', '/file1', [
+        $request = new ServerRequest('COPY', '/file1', [
             'Destination' => '/file2'
         ]);
         $response = $this->request($request);
@@ -66,7 +67,7 @@ class HttpCopyTest extends DAVServerTest {
 
     function testCopyFileToExistingOverwriteT() {
 
-        $request = new HTTP\Request('COPY', '/file1', [
+        $request = new ServerRequest('COPY', '/file1', [
             'Destination' => '/file2',
             'Overwrite'   => 'T',
         ]);
@@ -78,7 +79,7 @@ class HttpCopyTest extends DAVServerTest {
    
     function testCopyFileToExistingOverwriteBadValue() {
 
-        $request = new HTTP\Request('COPY', '/file1', [
+        $request = new ServerRequest('COPY', '/file1', [
             'Destination' => '/file2',
             'Overwrite'   => 'B',
         ]);
@@ -89,7 +90,7 @@ class HttpCopyTest extends DAVServerTest {
 
     function testCopyFileNonExistantParent() {
 
-        $request = new HTTP\Request('COPY', '/file1', [
+        $request = new ServerRequest('COPY', '/file1', [
             'Destination' => '/notfound/file2',
         ]);
         $response = $this->request($request);
@@ -99,7 +100,7 @@ class HttpCopyTest extends DAVServerTest {
 
     function testCopyFileToExistingOverwriteF() {
 
-        $request = new HTTP\Request('COPY', '/file1', [
+        $request = new ServerRequest('COPY', '/file1', [
             'Destination' => '/file2',
             'Overwrite'   => 'F',
         ]);
@@ -118,7 +119,7 @@ class HttpCopyTest extends DAVServerTest {
             }
 
         });
-        $request = new HTTP\Request('COPY', '/file1', [
+        $request = new ServerRequest('COPY', '/file1', [
             'Destination' => '/file2',
             'Overwrite'   => 'T',
         ]);
@@ -131,7 +132,7 @@ class HttpCopyTest extends DAVServerTest {
 
     function testCopyColl() {
 
-        $request = new HTTP\Request('COPY', '/coll1', [
+        $request = new ServerRequest('COPY', '/coll1', [
             'Destination' => '/coll2'
         ]);
         $response = $this->request($request);
@@ -142,7 +143,7 @@ class HttpCopyTest extends DAVServerTest {
 
     function testCopyCollToSelf() {
 
-        $request = new HTTP\Request('COPY', '/coll1', [
+        $request = new ServerRequest('COPY', '/coll1', [
             'Destination' => '/coll1'
         ]);
         $response = $this->request($request);
@@ -152,7 +153,7 @@ class HttpCopyTest extends DAVServerTest {
 
     function testCopyCollToExisting() {
 
-        $request = new HTTP\Request('COPY', '/coll1', [
+        $request = new ServerRequest('COPY', '/coll1', [
             'Destination' => '/file2'
         ]);
         $response = $this->request($request);
@@ -163,7 +164,7 @@ class HttpCopyTest extends DAVServerTest {
 
     function testCopyCollToExistingOverwriteT() {
 
-        $request = new HTTP\Request('COPY', '/coll1', [
+        $request = new ServerRequest('COPY', '/coll1', [
             'Destination' => '/file2',
             'Overwrite'   => 'T',
         ]);
@@ -175,7 +176,7 @@ class HttpCopyTest extends DAVServerTest {
 
     function testCopyCollToExistingOverwriteF() {
 
-        $request = new HTTP\Request('COPY', '/coll1', [
+        $request = new ServerRequest('COPY', '/coll1', [
             'Destination' => '/file2',
             'Overwrite'   => 'F',
         ]);
@@ -187,7 +188,7 @@ class HttpCopyTest extends DAVServerTest {
 
     function testCopyCollIntoSubtree() {
 
-        $request = new HTTP\Request('COPY', '/coll1', [
+        $request = new ServerRequest('COPY', '/coll1', [
             'Destination' => '/coll1/subcol',
         ]);
         $response = $this->request($request);

--- a/tests/Sabre/DAV/HttpDeleteTest.php
+++ b/tests/Sabre/DAV/HttpDeleteTest.php
@@ -49,7 +49,7 @@ class HttpDeleteTest extends DAVServerTest {
 
         $this->assertEquals(
             [
-                'X-Sabre-Version' => [Version::VERSION],
+
                 'Content-Length'  => ['0'],
             ],
             $response->getHeaders()
@@ -74,7 +74,7 @@ class HttpDeleteTest extends DAVServerTest {
 
         $this->assertEquals(
             [
-                'X-Sabre-Version' => [Version::VERSION],
+
                 'Content-Length'  => ['0'],
             ],
             $response->getHeaders()

--- a/tests/Sabre/DAV/HttpDeleteTest.php
+++ b/tests/Sabre/DAV/HttpDeleteTest.php
@@ -2,6 +2,7 @@
 
 namespace Sabre\DAV;
 
+use GuzzleHttp\Psr7\ServerRequest;
 use Sabre\DAVServerTest;
 use Sabre\HTTP;
 
@@ -36,7 +37,7 @@ class HttpDeleteTest extends DAVServerTest {
      */
     function testDelete() {
 
-        $request = new HTTP\Request('DELETE', '/file1');
+        $request = new ServerRequest('DELETE', '/file1');
 
         $response = $this->request($request);
 
@@ -61,7 +62,7 @@ class HttpDeleteTest extends DAVServerTest {
      */
     function testDeleteDirectory() {
 
-        $request = new HTTP\Request('DELETE', '/dir');
+        $request = new ServerRequest('DELETE', '/dir');
 
         $response = $this->request($request);
 
@@ -86,7 +87,7 @@ class HttpDeleteTest extends DAVServerTest {
      */
     function testDeleteNotFound() {
 
-        $request = new HTTP\Request('DELETE', '/file2');
+        $request = new ServerRequest('DELETE', '/file2');
         $response = $this->request($request);
 
         $this->assertEquals(
@@ -102,7 +103,7 @@ class HttpDeleteTest extends DAVServerTest {
      */
     function testDeletePreconditions() {
 
-        $request = new HTTP\Request('DELETE', '/file1', [
+        $request = new ServerRequest('DELETE', '/file1', [
             'If-Match' => '"' . md5('foo') . '"',
         ]);
 
@@ -121,7 +122,7 @@ class HttpDeleteTest extends DAVServerTest {
      */
     function testDeletePreconditionsFailed() {
 
-        $request = new HTTP\Request('DELETE', '/file1', [
+        $request = new ServerRequest('DELETE', '/file1', [
             'If-Match' => '"' . md5('bar') . '"',
         ]);
 

--- a/tests/Sabre/DAV/HttpDeleteTest.php
+++ b/tests/Sabre/DAV/HttpDeleteTest.php
@@ -42,8 +42,8 @@ class HttpDeleteTest extends DAVServerTest {
 
         $this->assertEquals(
             204,
-            $response->getStatus(),
-            "Incorrect status code. Response body:  " . $response->getBodyAsString()
+            $response->getStatusCode(),
+            "Incorrect status code. Response body:  " . $response->getBody()->getContents()
         );
 
         $this->assertEquals(
@@ -67,8 +67,8 @@ class HttpDeleteTest extends DAVServerTest {
 
         $this->assertEquals(
             204,
-            $response->getStatus(),
-            "Incorrect status code. Response body:  " . $response->getBodyAsString()
+            $response->getStatusCode(),
+            "Incorrect status code. Response body:  " . $response->getBody()->getContents()
         );
 
         $this->assertEquals(
@@ -91,8 +91,8 @@ class HttpDeleteTest extends DAVServerTest {
 
         $this->assertEquals(
             404,
-            $response->getStatus(),
-            "Incorrect status code. Response body:  " . $response->getBodyAsString()
+            $response->getStatusCode(),
+            "Incorrect status code. Response body:  " . $response->getBody()->getContents()
         );
 
     }
@@ -110,8 +110,8 @@ class HttpDeleteTest extends DAVServerTest {
 
         $this->assertEquals(
             204,
-            $response->getStatus(),
-            "Incorrect status code. Response body:  " . $response->getBodyAsString()
+            $response->getStatusCode(),
+            "Incorrect status code. Response body:  " . $response->getBody()->getContents()
         );
 
     }
@@ -129,8 +129,8 @@ class HttpDeleteTest extends DAVServerTest {
 
         $this->assertEquals(
             412,
-            $response->getStatus(),
-            "Incorrect status code. Response body:  " . $response->getBodyAsString()
+            $response->getStatusCode(),
+            "Incorrect status code. Response body:  " . $response->getBody()->getContents()
         );
 
     }

--- a/tests/Sabre/DAV/HttpGetTest.php
+++ b/tests/Sabre/DAV/HttpGetTest.php
@@ -43,7 +43,7 @@ class HttpGetTest extends DAVServerTest {
 
         $this->assertEquals(
             [
-                'X-Sabre-Version' => [Version::VERSION],
+
                 'Content-Type'    => ['application/octet-stream'],
                 'Content-Length'  => [3],
                 'ETag'            => ['"' . md5('foo') . '"'],
@@ -70,7 +70,7 @@ class HttpGetTest extends DAVServerTest {
 
         $this->assertEquals(
             [
-                'X-Sabre-Version' => [Version::VERSION],
+
                 'Content-Type'    => ['application/octet-stream'],
                 'Content-Length'  => [3],
                 'ETag'            => ['"' . md5('foo') . '"'],
@@ -119,7 +119,7 @@ class HttpGetTest extends DAVServerTest {
 
         $this->assertEquals(
             [
-                'X-Sabre-Version' => [Version::VERSION],
+
                 'Content-Type'    => ['application/octet-stream'],
                 'Content-Length'  => [3],
                 'ETag'            => ['"' . md5('foo') . '"'],
@@ -153,7 +153,7 @@ class HttpGetTest extends DAVServerTest {
 
         $this->assertEquals(
             [
-                'X-Sabre-Version' => [Version::VERSION],
+
                 'Content-Type'    => ['application/octet-stream'],
             ],
             $headers

--- a/tests/Sabre/DAV/HttpGetTest.php
+++ b/tests/Sabre/DAV/HttpGetTest.php
@@ -3,6 +3,7 @@
 namespace Sabre\DAV;
 
 use GuzzleHttp\Psr7\ServerRequest;
+use GuzzleHttp\Psr7\Uri;
 use Sabre\DAVServerTest;
 
 /**
@@ -106,8 +107,11 @@ class HttpGetTest extends DAVServerTest {
      */
     function testGetDoubleSlash() {
 
-        $request = new ServerRequest('GET', '//file1');
+        $request = new ServerRequest('GET', 'http://localhost//file1');
+        $this->assertNotEmpty($request->getUri()->getPath());
+
         $response = $this->request($request, 200);
+
 
         // Removing Last-Modified because it keeps changing.
         $headers = $response->getHeaders();

--- a/tests/Sabre/DAV/HttpGetTest.php
+++ b/tests/Sabre/DAV/HttpGetTest.php
@@ -34,10 +34,11 @@ class HttpGetTest extends DAVServerTest {
         $request = new HTTP\Request('GET', '/file1');
         $response = $this->request($request);
 
-        $this->assertEquals(200, $response->getStatus());
+        $this->assertEquals(200, $response->getStatusCode());
 
         // Removing Last-Modified because it keeps changing.
-        $response->removeHeader('Last-Modified');
+        $headers = $response->getHeaders();
+        unset($headers['Last-Modified']);
 
         $this->assertEquals(
             [
@@ -46,10 +47,10 @@ class HttpGetTest extends DAVServerTest {
                 'Content-Length'  => [3],
                 'ETag'            => ['"' . md5('foo') . '"'],
             ],
-            $response->getHeaders()
+            $headers
         );
 
-        $this->assertEquals('foo', $response->getBodyAsString());
+        $this->assertEquals('foo', $response->getBody()->getContents());
 
     }
 
@@ -59,10 +60,11 @@ class HttpGetTest extends DAVServerTest {
         $request->setHttpVersion('1.0');
         $response = $this->request($request);
 
-        $this->assertEquals(200, $response->getStatus());
+        $this->assertEquals(200, $response->getStatusCode());
 
         // Removing Last-Modified because it keeps changing.
-        $response->removeHeader('Last-Modified');
+        $headers = $response->getHeaders();
+        unset($headers['Last-Modified']);
 
         $this->assertEquals(
             [
@@ -71,12 +73,12 @@ class HttpGetTest extends DAVServerTest {
                 'Content-Length'  => [3],
                 'ETag'            => ['"' . md5('foo') . '"'],
             ],
-            $response->getHeaders()
+            $headers
         );
 
-        $this->assertEquals('1.0', $response->getHttpVersion());
+        $this->assertEquals('1.0', $response->getProtocolVersion());
 
-        $this->assertEquals('foo', $response->getBodyAsString());
+        $this->assertEquals('foo', $response->getBody()->getContents());
 
     }
 
@@ -85,7 +87,7 @@ class HttpGetTest extends DAVServerTest {
         $request = new HTTP\Request('GET', '/notfound');
         $response = $this->request($request);
 
-        $this->assertEquals(404, $response->getStatus());
+        $this->assertEquals(404, $response->getStatusCode());
 
     }
 
@@ -94,7 +96,7 @@ class HttpGetTest extends DAVServerTest {
         $request = new HTTP\Request('GET', '/file1/subfile');
         $response = $this->request($request);
 
-        $this->assertEquals(404, $response->getStatus());
+        $this->assertEquals(404, $response->getStatusCode());
 
     }
 
@@ -106,10 +108,11 @@ class HttpGetTest extends DAVServerTest {
         $request = new HTTP\Request('GET', '//file1');
         $response = $this->request($request);
 
-        $this->assertEquals(200, $response->getStatus());
+        $this->assertEquals(200, $response->getStatusCode());
 
         // Removing Last-Modified because it keeps changing.
-        $response->removeHeader('Last-Modified');
+        $headers = $response->getHeaders();
+        unset($headers['Last-Modified']);
 
         $this->assertEquals(
             [
@@ -118,10 +121,10 @@ class HttpGetTest extends DAVServerTest {
                 'Content-Length'  => [3],
                 'ETag'            => ['"' . md5('foo') . '"'],
             ],
-            $response->getHeaders()
+            $headers
         );
 
-        $this->assertEquals('foo', $response->getBodyAsString());
+        $this->assertEquals('foo', $response->getBody()->getContents());
 
     }
 
@@ -130,7 +133,7 @@ class HttpGetTest extends DAVServerTest {
         $request = new HTTP\Request('GET', '/dir');
         $response = $this->request($request);
 
-        $this->assertEquals(501, $response->getStatus());
+        $this->assertEquals(501, $response->getStatusCode());
 
     }
 
@@ -139,20 +142,21 @@ class HttpGetTest extends DAVServerTest {
         $request = new HTTP\Request('GET', '/streaming');
         $response = $this->request($request);
 
-        $this->assertEquals(200, $response->getStatus());
+        $this->assertEquals(200, $response->getStatusCode());
 
         // Removing Last-Modified because it keeps changing.
-        $response->removeHeader('Last-Modified');
+        $headers = $response->getHeaders();
+        unset($headers['Last-Modified']);
 
         $this->assertEquals(
             [
                 'X-Sabre-Version' => [Version::VERSION],
                 'Content-Type'    => ['application/octet-stream'],
             ],
-            $response->getHeaders()
+            $headers
         );
 
-        $this->assertEquals('stream', $response->getBodyAsString());
+        $this->assertEquals('stream',$response->getBody()->getContents());
 
     }
 }

--- a/tests/Sabre/DAV/HttpGetTest.php
+++ b/tests/Sabre/DAV/HttpGetTest.php
@@ -2,8 +2,8 @@
 
 namespace Sabre\DAV;
 
+use GuzzleHttp\Psr7\ServerRequest;
 use Sabre\DAVServerTest;
-use Sabre\HTTP;
 
 /**
  * Tests related to the GET request.
@@ -31,7 +31,7 @@ class HttpGetTest extends DAVServerTest {
 
     function testGet() {
 
-        $request = new HTTP\Request('GET', '/file1');
+        $request = new ServerRequest('GET', '/file1');
         $response = $this->request($request);
 
         $this->assertEquals(200, $response->getStatusCode());
@@ -56,8 +56,9 @@ class HttpGetTest extends DAVServerTest {
 
     function testGetHttp10() {
 
-        $request = new HTTP\Request('GET', '/file1');
-        $request->setHttpVersion('1.0');
+        $request = (new ServerRequest('GET', '/file1'))
+            ->withProtocolVersion('1.0');
+
         $response = $this->request($request);
 
         $this->assertEquals(200, $response->getStatusCode());
@@ -84,7 +85,7 @@ class HttpGetTest extends DAVServerTest {
 
     function testGet404() {
 
-        $request = new HTTP\Request('GET', '/notfound');
+        $request = new ServerRequest('GET', '/notfound');
         $response = $this->request($request);
 
         $this->assertEquals(404, $response->getStatusCode());
@@ -93,7 +94,7 @@ class HttpGetTest extends DAVServerTest {
 
     function testGet404_aswell() {
 
-        $request = new HTTP\Request('GET', '/file1/subfile');
+        $request = new ServerRequest('GET', '/file1/subfile');
         $response = $this->request($request);
 
         $this->assertEquals(404, $response->getStatusCode());
@@ -105,10 +106,8 @@ class HttpGetTest extends DAVServerTest {
      */
     function testGetDoubleSlash() {
 
-        $request = new HTTP\Request('GET', '//file1');
-        $response = $this->request($request);
-
-        $this->assertEquals(200, $response->getStatusCode());
+        $request = new ServerRequest('GET', '//file1');
+        $response = $this->request($request, 200);
 
         // Removing Last-Modified because it keeps changing.
         $headers = $response->getHeaders();
@@ -130,7 +129,7 @@ class HttpGetTest extends DAVServerTest {
 
     function testGetCollection() {
 
-        $request = new HTTP\Request('GET', '/dir');
+        $request = new ServerRequest('GET', '/dir');
         $response = $this->request($request);
 
         $this->assertEquals(501, $response->getStatusCode());
@@ -139,7 +138,7 @@ class HttpGetTest extends DAVServerTest {
 
     function testGetStreaming() {
 
-        $request = new HTTP\Request('GET', '/streaming');
+        $request = new ServerRequest('GET', '/streaming');
         $response = $this->request($request);
 
         $this->assertEquals(200, $response->getStatusCode());

--- a/tests/Sabre/DAV/HttpHeadTest.php
+++ b/tests/Sabre/DAV/HttpHeadTest.php
@@ -41,7 +41,7 @@ class HttpHeadTest extends DAVServerTest {
 
         $this->assertEquals(
             [
-                'X-Sabre-Version' => [Version::VERSION],
+
                 'Content-Type'    => ['application/octet-stream'],
                 'Content-Length'  => [3],
                 'ETag'            => ['"' . md5('foo') . '"'],

--- a/tests/Sabre/DAV/HttpHeadTest.php
+++ b/tests/Sabre/DAV/HttpHeadTest.php
@@ -2,6 +2,7 @@
 
 namespace Sabre\DAV;
 
+use GuzzleHttp\Psr7\ServerRequest;
 use Sabre\DAVServerTest;
 use Sabre\HTTP;
 
@@ -31,10 +32,8 @@ class HttpHeadTest extends DAVServerTest {
 
     function testHEAD() {
 
-        $request = new HTTP\Request('HEAD', '//file1');
-        $response = $this->request($request);
-
-        $this->assertEquals(200, $response->getStatusCode());
+        $request = new ServerRequest('HEAD', '/file1');
+        $response = $this->request($request, 200);
 
         $headers = $response->getHeaders();
         // Removing Last-Modified because it keeps changing.
@@ -46,8 +45,8 @@ class HttpHeadTest extends DAVServerTest {
                 'Content-Type'    => ['application/octet-stream'],
                 'Content-Length'  => [3],
                 'ETag'            => ['"' . md5('foo') . '"'],
-            ], $headers
-
+            ], $headers,
+            print_r($headers, true)
         );
 
         $this->assertEmpty($response->getBody()->getContents());
@@ -61,7 +60,7 @@ class HttpHeadTest extends DAVServerTest {
      */
     function testHEADCollection() {
 
-        $request = new HTTP\Request('HEAD', '/dir');
+        $request = new ServerRequest('HEAD', '/dir');
         $response = $this->request($request);
 
         $this->assertEquals(200, $response->getStatusCode());
@@ -86,7 +85,7 @@ class HttpHeadTest extends DAVServerTest {
                 $authBackend
             )
         );
-        $request = new HTTP\Request('HEAD', '/file1', ['Authorization' => 'Basic ' . base64_encode('user:pass')]);
+        $request = new ServerRequest('HEAD', '/file1', ['Authorization' => 'Basic ' . base64_encode('user:pass')]);
         $response = $this->request($request);
 
         $this->assertEquals(200, $response->getStatusCode());

--- a/tests/Sabre/DAV/HttpHeadTest.php
+++ b/tests/Sabre/DAV/HttpHeadTest.php
@@ -34,10 +34,11 @@ class HttpHeadTest extends DAVServerTest {
         $request = new HTTP\Request('HEAD', '//file1');
         $response = $this->request($request);
 
-        $this->assertEquals(200, $response->getStatus());
+        $this->assertEquals(200, $response->getStatusCode());
 
+        $headers = $response->getHeaders();
         // Removing Last-Modified because it keeps changing.
-        $response->removeHeader('Last-Modified');
+        unset($headers['Last-Modified']);
 
         $this->assertEquals(
             [
@@ -45,11 +46,11 @@ class HttpHeadTest extends DAVServerTest {
                 'Content-Type'    => ['application/octet-stream'],
                 'Content-Length'  => [3],
                 'ETag'            => ['"' . md5('foo') . '"'],
-            ],
-            $response->getHeaders()
+            ], $headers
+
         );
 
-        $this->assertEquals('', $response->getBodyAsString());
+        $this->assertEmpty($response->getBody()->getContents());
 
     }
 
@@ -63,7 +64,7 @@ class HttpHeadTest extends DAVServerTest {
         $request = new HTTP\Request('HEAD', '/dir');
         $response = $this->request($request);
 
-        $this->assertEquals(200, $response->getStatus());
+        $this->assertEquals(200, $response->getStatusCode());
 
     }
 
@@ -88,7 +89,7 @@ class HttpHeadTest extends DAVServerTest {
         $request = new HTTP\Request('HEAD', '/file1', ['Authorization' => 'Basic ' . base64_encode('user:pass')]);
         $response = $this->request($request);
 
-        $this->assertEquals(200, $response->getStatus());
+        $this->assertEquals(200, $response->getStatusCode());
 
         $this->assertEquals(1, $count, 'Auth was triggered twice :(');
 

--- a/tests/Sabre/DAV/HttpMoveTest.php
+++ b/tests/Sabre/DAV/HttpMoveTest.php
@@ -34,7 +34,7 @@ class HttpMoveTest extends DAVServerTest {
             'Destination' => '/file1'
         ]);
         $response = $this->request($request);
-        $this->assertEquals(403, $response->getStatus());
+        $this->assertEquals(403, $response->getStatusCode());
         $this->assertEquals('content1', $this->tree->getChild('file1')->get());
 
     }
@@ -45,7 +45,7 @@ class HttpMoveTest extends DAVServerTest {
             'Destination' => '/file3'
         ]);
         $response = $this->request($request);
-        $this->assertEquals(201, $response->getStatus(), print_r($response, true));
+        $this->assertEquals(201, $response->getStatusCode(), print_r($response, true));
         $this->assertEquals('content1', $this->tree->getChild('file3')->get());
         $this->assertFalse($this->tree->childExists('file1'));
 
@@ -57,7 +57,7 @@ class HttpMoveTest extends DAVServerTest {
             'Destination' => '/file2'
         ]);
         $response = $this->request($request);
-        $this->assertEquals(204, $response->getStatus(), print_r($response, true));
+        $this->assertEquals(204, $response->getStatusCode(), print_r($response, true));
         $this->assertEquals('content1', $this->tree->getChild('file2')->get());
         $this->assertFalse($this->tree->childExists('file1'));
 
@@ -70,7 +70,7 @@ class HttpMoveTest extends DAVServerTest {
             'Overwrite'   => 'T',
         ]);
         $response = $this->request($request);
-        $this->assertEquals(204, $response->getStatus(), print_r($response, true));
+        $this->assertEquals(204, $response->getStatusCode(), print_r($response, true));
         $this->assertEquals('content1', $this->tree->getChild('file2')->get());
         $this->assertFalse($this->tree->childExists('file1'));
 
@@ -83,7 +83,7 @@ class HttpMoveTest extends DAVServerTest {
             'Overwrite'   => 'F',
         ]);
         $response = $this->request($request);
-        $this->assertEquals(412, $response->getStatus(), print_r($response, true));
+        $this->assertEquals(412, $response->getStatusCode(), print_r($response, true));
         $this->assertEquals('content1', $this->tree->getChild('file1')->get());
         $this->assertEquals('content2', $this->tree->getChild('file2')->get());
         $this->assertTrue($this->tree->childExists('file1'));
@@ -109,7 +109,7 @@ class HttpMoveTest extends DAVServerTest {
             'Destination' => '/file2'
         ]);
         $response = $this->request($request);
-        $this->assertEquals(403, $response->getStatus(), print_r($response, true));
+        $this->assertEquals(403, $response->getStatusCode(), print_r($response, true));
         $this->assertEquals('content1', $this->tree->getChild('file1')->get());
         $this->assertEquals('content2', $this->tree->getChild('file2')->get());
         $this->assertTrue($this->tree->childExists('file1'));

--- a/tests/Sabre/DAV/HttpMoveTest.php
+++ b/tests/Sabre/DAV/HttpMoveTest.php
@@ -2,6 +2,7 @@
 
 namespace Sabre\DAV;
 
+use GuzzleHttp\Psr7\ServerRequest;
 use Sabre\DAVServerTest;
 use Sabre\HTTP;
 
@@ -30,7 +31,7 @@ class HttpMoveTest extends DAVServerTest {
 
     function testMoveToSelf() {
 
-        $request = new HTTP\Request('MOVE', '/file1', [
+        $request = new ServerRequest('MOVE', '/file1', [
             'Destination' => '/file1'
         ]);
         $response = $this->request($request);
@@ -41,7 +42,7 @@ class HttpMoveTest extends DAVServerTest {
 
     function testMove() {
 
-        $request = new HTTP\Request('MOVE', '/file1', [
+        $request = new ServerRequest('MOVE', '/file1', [
             'Destination' => '/file3'
         ]);
         $response = $this->request($request);
@@ -53,7 +54,7 @@ class HttpMoveTest extends DAVServerTest {
 
     function testMoveToExisting() {
 
-        $request = new HTTP\Request('MOVE', '/file1', [
+        $request = new ServerRequest('MOVE', '/file1', [
             'Destination' => '/file2'
         ]);
         $response = $this->request($request);
@@ -65,7 +66,7 @@ class HttpMoveTest extends DAVServerTest {
 
     function testMoveToExistingOverwriteT() {
 
-        $request = new HTTP\Request('MOVE', '/file1', [
+        $request = new ServerRequest('MOVE', '/file1', [
             'Destination' => '/file2',
             'Overwrite'   => 'T',
         ]);
@@ -78,7 +79,7 @@ class HttpMoveTest extends DAVServerTest {
 
     function testMoveToExistingOverwriteF() {
 
-        $request = new HTTP\Request('MOVE', '/file1', [
+        $request = new ServerRequest('MOVE', '/file1', [
             'Destination' => '/file2',
             'Overwrite'   => 'F',
         ]);
@@ -105,7 +106,7 @@ class HttpMoveTest extends DAVServerTest {
             }
 
         });
-        $request = new HTTP\Request('MOVE', '/file1', [
+        $request = new ServerRequest('MOVE', '/file1', [
             'Destination' => '/file2'
         ]);
         $response = $this->request($request);

--- a/tests/Sabre/DAV/HttpPutTest.php
+++ b/tests/Sabre/DAV/HttpPutTest.php
@@ -46,7 +46,7 @@ class HttpPutTest extends DAVServerTest {
 
         $this->assertEquals(
             [
-                'X-Sabre-Version' => [Version::VERSION],
+
                 'Content-Length'  => ['0'],
                 'ETag'            => ['"' . md5('hello') . '"']
             ],
@@ -75,7 +75,7 @@ class HttpPutTest extends DAVServerTest {
 
         $this->assertEquals(
             [
-                'X-Sabre-Version' => [Version::VERSION],
+
                 'Content-Length'  => ['0'],
                 'ETag'            => ['"' . md5('bar') . '"']
             ],
@@ -109,7 +109,7 @@ class HttpPutTest extends DAVServerTest {
 
         $this->assertEquals(
             [
-                'X-Sabre-Version' => [Version::VERSION],
+
                 'Content-Length'  => ['0'],
                 'ETag'            => ['"' . md5('hello') . '"']
             ],
@@ -143,7 +143,7 @@ class HttpPutTest extends DAVServerTest {
 
         $this->assertEquals(
             [
-                'X-Sabre-Version' => [Version::VERSION],
+
                 'Content-Length'  => ['0'],
                 'ETag'            => ['"' . md5('hello') . '"'],
             ],
@@ -196,7 +196,7 @@ class HttpPutTest extends DAVServerTest {
 
         $this->assertEquals(
             [
-                'X-Sabre-Version' => [Version::VERSION],
+
                 'Content-Length'  => ['0'],
                 'ETag'            => ['"' . md5('hello') . '"']
             ],
@@ -291,7 +291,7 @@ class HttpPutTest extends DAVServerTest {
 
         $this->assertEquals(
             [
-                'X-Sabre-Version' => [Version::VERSION],
+
                 'Content-Length'  => ['0'],
                 'ETag'            => ['"' . md5('hello') . '"'],
             ],
@@ -342,7 +342,7 @@ class HttpPutTest extends DAVServerTest {
         );
 
         $this->assertEquals([
-            'X-Sabre-Version' => [Version::VERSION],
+
         ], $response->getHeaders());
 
     }

--- a/tests/Sabre/DAV/HttpPutTest.php
+++ b/tests/Sabre/DAV/HttpPutTest.php
@@ -36,7 +36,7 @@ class HttpPutTest extends DAVServerTest {
 
         $response = $this->request($request);
 
-        $this->assertEquals(201, $response->getStatus(), 'Incorrect status code received. Full response body:' . $response->getBodyAsString());
+        $this->assertEquals(201, $response->getStatusCode(), 'Incorrect status code received. Full response body:' . $response->getBody()->getContents());
 
         $this->assertEquals(
             'hello',
@@ -65,7 +65,7 @@ class HttpPutTest extends DAVServerTest {
 
         $response = $this->request($request);
 
-        $this->assertEquals(204, $response->getStatus());
+        $this->assertEquals(204, $response->getStatusCode());
 
         $this->assertEquals(
             'bar',
@@ -99,7 +99,7 @@ class HttpPutTest extends DAVServerTest {
 
         $response = $this->request($request);
 
-        $this->assertEquals(204, $response->getStatus());
+        $this->assertEquals(204, $response->getStatusCode());
 
         $this->assertEquals(
             'hello',
@@ -133,7 +133,7 @@ class HttpPutTest extends DAVServerTest {
 
         $response = $this->request($request);
 
-        $this->assertEquals(204, $response->status);
+        $this->assertEquals(204, $response->getStatusCode());
 
         $this->assertEquals(
             'hello',
@@ -166,7 +166,7 @@ class HttpPutTest extends DAVServerTest {
         );
 
         $response = $this->request($request);
-        $this->assertEquals(400, $response->getStatus());
+        $this->assertEquals(400, $response->getStatusCode());
 
     }
 
@@ -186,7 +186,7 @@ class HttpPutTest extends DAVServerTest {
 
         $response = $this->request($request);
 
-        $this->assertEquals(201, $response->getStatus());
+        $this->assertEquals(201, $response->getStatusCode());
 
         $this->assertEquals(
             'hello',
@@ -220,7 +220,7 @@ class HttpPutTest extends DAVServerTest {
 
         $response = $this->request($request);
 
-        $this->assertEquals(412, $response->getStatus());
+        $this->assertEquals(412, $response->getStatusCode());
 
     }
 
@@ -241,7 +241,7 @@ class HttpPutTest extends DAVServerTest {
 
         $response = $this->request($request);
 
-        $this->assertEquals(412, $response->getStatus());
+        $this->assertEquals(412, $response->getStatusCode());
 
     }
 
@@ -260,7 +260,7 @@ class HttpPutTest extends DAVServerTest {
         );
 
         $response = $this->request($request);
-        $this->assertEquals(409, $response->getStatus());
+        $this->assertEquals(409, $response->getStatusCode());
 
     }
 
@@ -281,7 +281,7 @@ class HttpPutTest extends DAVServerTest {
         );
         $response = $this->request($request);
 
-        $this->assertEquals(201, $response->getStatus());
+        $this->assertEquals(201, $response->getStatusCode());
 
         $this->assertEquals(
             'hello',
@@ -315,7 +315,7 @@ class HttpPutTest extends DAVServerTest {
 
         $response = $this->request($request);
 
-        $this->assertEquals(403, $response->getStatus());
+        $this->assertEquals(403, $response->getStatusCode());
 
     }
 
@@ -334,7 +334,7 @@ class HttpPutTest extends DAVServerTest {
         $request = new HTTP\Request('PUT', '/file2', [], 'hello');
         $response = $this->request($request);
 
-        $this->assertEquals(418, $response->getStatus(), 'Incorrect status code received. Full response body: ' . $response->getBodyAsString());
+        $this->assertEquals(418, $response->getStatusCode(), 'Incorrect status code received. Full response body: ' . $response->getBody()->getContents());
 
         $this->assertFalse(
             $this->server->tree->nodeExists('file2')

--- a/tests/Sabre/DAV/HttpPutTest.php
+++ b/tests/Sabre/DAV/HttpPutTest.php
@@ -2,6 +2,7 @@
 
 namespace Sabre\DAV;
 
+use GuzzleHttp\Psr7\ServerRequest;
 use Sabre\DAVServerTest;
 use Sabre\HTTP;
 
@@ -32,7 +33,7 @@ class HttpPutTest extends DAVServerTest {
      */
     function testPut() {
 
-        $request = new HTTP\Request('PUT', '/file2', [], 'hello');
+        $request = new ServerRequest('PUT', '/file2', [], 'hello');
 
         $response = $this->request($request);
 
@@ -61,7 +62,7 @@ class HttpPutTest extends DAVServerTest {
      */
     function testPutExisting() {
 
-        $request = new HTTP\Request('PUT', '/file1', [], 'bar');
+        $request = new ServerRequest('PUT', '/file1', [], 'bar');
 
         $response = $this->request($request);
 
@@ -90,7 +91,7 @@ class HttpPutTest extends DAVServerTest {
      */
     function testPutExistingIfMatchStar() {
 
-        $request = new HTTP\Request(
+        $request = new ServerRequest(
             'PUT',
             '/file1',
             ['If-Match' => '*'],
@@ -124,7 +125,7 @@ class HttpPutTest extends DAVServerTest {
      */
     function testPutExistingIfMatchCorrect() {
 
-        $request = new HTTP\Request(
+        $request = new ServerRequest(
             'PUT',
             '/file1',
             ['If-Match' => '"' . md5('foo') . '"'],
@@ -158,7 +159,7 @@ class HttpPutTest extends DAVServerTest {
      */
     function testPutContentRange() {
 
-        $request = new HTTP\Request(
+        $request = new ServerRequest(
             'PUT',
             '/file2',
             ['Content-Range' => 'bytes/100-200'],
@@ -177,7 +178,7 @@ class HttpPutTest extends DAVServerTest {
      */
     function testPutIfNoneMatchStar() {
 
-        $request = new HTTP\Request(
+        $request = new ServerRequest(
             'PUT',
             '/file2',
             ['If-None-Match' => '*'],
@@ -211,7 +212,7 @@ class HttpPutTest extends DAVServerTest {
      */
     function testPutIfMatchStar() {
 
-        $request = new HTTP\Request(
+        $request = new ServerRequest(
             'PUT',
             '/file2',
             ['If-Match' => '*'],
@@ -231,13 +232,13 @@ class HttpPutTest extends DAVServerTest {
      */
     function testPutExistingIfNoneMatchStar() {
 
-        $request = new HTTP\Request(
+        $request = new ServerRequest(
             'PUT',
             '/file1',
             ['If-None-Match' => '*'],
             'hello'
         );
-        $request->setBody('hello');
+
 
         $response = $this->request($request);
 
@@ -252,7 +253,7 @@ class HttpPutTest extends DAVServerTest {
      */
     function testPutNoParent() {
 
-        $request = new HTTP\Request(
+        $request = new ServerRequest(
             'PUT',
             '/file1/file2',
             [],
@@ -273,7 +274,7 @@ class HttpPutTest extends DAVServerTest {
      */
     function testFinderPutSuccess() {
 
-        $request = new HTTP\Request(
+        $request = new ServerRequest(
             'PUT',
             '/file2',
             ['X-Expected-Entity-Length' => '5'],
@@ -306,7 +307,7 @@ class HttpPutTest extends DAVServerTest {
      */
     function testFinderPutFail() {
 
-        $request = new HTTP\Request(
+        $request = new ServerRequest(
             'PUT',
             '/file2',
             ['X-Expected-Entity-Length' => '5'],
@@ -331,7 +332,7 @@ class HttpPutTest extends DAVServerTest {
             return false;
         });
 
-        $request = new HTTP\Request('PUT', '/file2', [], 'hello');
+        $request = new ServerRequest('PUT', '/file2', [], 'hello');
         $response = $this->request($request);
 
         $this->assertEquals(418, $response->getStatusCode(), 'Incorrect status code received. Full response body: ' . $response->getBody()->getContents());

--- a/tests/Sabre/DAV/Issue33Test.php
+++ b/tests/Sabre/DAV/Issue33Test.php
@@ -20,7 +20,7 @@ class Issue33Test extends \PHPUnit_Framework_TestCase {
         $bar = new SimpleCollection('bar');
         $root = new SimpleCollection('webdav', [$bar]);
 
-        $server = new Server($root);
+        $server = new Server($root, null, null, function() {});
         $server->setBaseUri('/webdav/');
 
         $request = new ServerRequest('GET', '/webdav/bar', [
@@ -80,7 +80,7 @@ class Issue33Test extends \PHPUnit_Framework_TestCase {
 
         $tree = new Tree($dir);
 
-        $server = new Server($tree);
+        $server = new Server($tree, null, null, function(){});
         $server->setBaseUri('/webdav/');
         $response = $server->handle($request);
         $this->assertEquals(201, $response->getStatusCode(), $response->getBody()->getContents());

--- a/tests/Sabre/DAV/Issue33Test.php
+++ b/tests/Sabre/DAV/Issue33Test.php
@@ -82,8 +82,8 @@ class Issue33Test extends \PHPUnit_Framework_TestCase {
 
         $server = new Server($tree);
         $server->setBaseUri('/webdav/');
-
-        $server->handle($request);
+        $response = $server->handle($request);
+        $this->assertEquals(201, $response->getStatusCode(), $response->getBody()->getContents());
 
         $this->assertTrue(file_exists(SABRE_TEMPDIR . '/issue33/' . urldecode('%C3%A0fo%C3%B3')));
 

--- a/tests/Sabre/DAV/Issue33Test.php
+++ b/tests/Sabre/DAV/Issue33Test.php
@@ -74,8 +74,6 @@ class Issue33Test extends \PHPUnit_Framework_TestCase {
 
         $request->setBody('');
 
-        $response = new HTTP\ResponseMock();
-
         // Server setup
         mkdir(SABRE_TEMPDIR . '/issue33');
         $dir = new FS\Directory(SABRE_TEMPDIR . '/issue33');
@@ -88,9 +86,8 @@ class Issue33Test extends \PHPUnit_Framework_TestCase {
         $server->setBaseUri('/webdav/');
 
         $server->httpRequest = $request;
-        $server->httpResponse = $response;
         $server->sapi = new HTTP\SapiMock();
-        $server->exec();
+        $server->start();
 
         $this->assertTrue(file_exists(SABRE_TEMPDIR . '/issue33/' . urldecode('%C3%A0fo%C3%B3')));
 

--- a/tests/Sabre/DAV/Locks/MSWordTest.php
+++ b/tests/Sabre/DAV/Locks/MSWordTest.php
@@ -22,7 +22,7 @@ class MSWordTest extends \PHPUnit_Framework_TestCase {
         mkdir(SABRE_TEMPDIR . '/mstest');
         $tree = new DAV\FS\Directory(SABRE_TEMPDIR . '/mstest');
 
-        $server = new DAV\Server($tree);
+        $server = new DAV\Server($tree, null, null, function(){});
         $server->debugExceptions = true;
         $locksBackend = new Backend\File(SABRE_TEMPDIR . '/locksdb');
         $locksPlugin = new Plugin($locksBackend);

--- a/tests/Sabre/DAV/Locks/MSWordTest.php
+++ b/tests/Sabre/DAV/Locks/MSWordTest.php
@@ -27,36 +27,29 @@ class MSWordTest extends \PHPUnit_Framework_TestCase {
         $locksPlugin = new Plugin($locksBackend);
         $server->addPlugin($locksPlugin);
 
-        $response1 = new HTTP\ResponseMock();
-
         $server->httpRequest = $this->getLockRequest();
-        $server->httpResponse = $response1;
         $server->sapi = new HTTP\SapiMock();
-        $server->exec();
+        $server->start();
 
-        $this->assertEquals(201, $server->httpResponse->getStatus(), 'Full response body:' . $response1->getBodyAsString());
-        $this->assertTrue(!!$server->httpResponse->getHeaders('Lock-Token'));
-        $lockToken = $server->httpResponse->getHeader('Lock-Token');
+        $response = $server->httpResponse->getResponse();
+        $this->assertEquals(201, $response->getStatusCode(), 'Full response body:' . $response->getBody()->getContents());
+        $this->assertNotEmpty($response->getHeaderLine('Lock-Token'));
+        $lockToken = $response->getHeaderLine('Lock-Token');
 
         //sleep(10);
-
-        $response2 = new HTTP\ResponseMock();
-
         $server->httpRequest = $this->getLockRequest2();
-        $server->httpResponse = $response2;
-        $server->exec();
+        $server->start();
 
-        $this->assertEquals(201, $server->httpResponse->status);
-        $this->assertTrue(!!$server->httpResponse->getHeaders('Lock-Token'));
+        $response = $server->httpResponse->getResponse();
+        $this->assertEquals(201, $response->getStatusCode());
+        $this->assertNotEmpty($response->getHeaderLine('Lock-Token'));
 
         //sleep(10);
-
-        $response3 = new HTTP\ResponseMock();
         $server->httpRequest = $this->getPutRequest($lockToken);
-        $server->httpResponse = $response3;
-        $server->exec();
+        $server->start();
 
-        $this->assertEquals(204, $server->httpResponse->status);
+        $response = $server->httpResponse->getResponse();
+        $this->assertEquals(204, $response->getStatusCode());
 
     }
 

--- a/tests/Sabre/DAV/Locks/Plugin2Test.php
+++ b/tests/Sabre/DAV/Locks/Plugin2Test.php
@@ -2,6 +2,7 @@
 
 namespace Sabre\DAV\Locks;
 
+use GuzzleHttp\Psr7\ServerRequest;
 use Sabre\HTTP\Request;
 
 class Plugin2Test extends \Sabre\DAVServerTest {
@@ -36,7 +37,7 @@ class Plugin2Test extends \Sabre\DAVServerTest {
     <D:locktype><D:write/></D:locktype>
 </D:lockinfo>';
 
-        $request = new Request(
+        $request = new ServerRequest(
             'LOCK',
             '/file.txt',
             [],
@@ -50,7 +51,7 @@ class Plugin2Test extends \Sabre\DAVServerTest {
             count($this->locksBackend->getLocks('file.txt', true))
         );
 
-        $request = new Request(
+        $request = new ServerRequest(
             'DELETE',
             '/file.txt',
             [

--- a/tests/Sabre/DAV/Locks/Plugin2Test.php
+++ b/tests/Sabre/DAV/Locks/Plugin2Test.php
@@ -43,7 +43,7 @@ class Plugin2Test extends \Sabre\DAVServerTest {
             $body
         );
         $response = $this->request($request);
-        $this->assertEquals(201, $response->getStatus(), $response->getBodyAsString());
+        $this->assertEquals(201, $response->getStatusCode(), $response->getBody()->getContents());
 
         $this->assertEquals(
             1,
@@ -54,11 +54,11 @@ class Plugin2Test extends \Sabre\DAVServerTest {
             'DELETE',
             '/file.txt',
             [
-                'If' => '(' . $response->getHeader('Lock-Token') . ')',
+                'If' => '(' . $response->getHeaderLine('Lock-Token') . ')',
             ]
         );
         $response = $this->request($request);
-        $this->assertEquals(204, $response->getStatus(), $response->getBodyAsString());
+        $this->assertEquals(204, $response->getStatusCode(), $response->getBody()->getContents());
 
         $this->assertEquals(
             0,

--- a/tests/Sabre/DAV/Locks/PluginTest.php
+++ b/tests/Sabre/DAV/Locks/PluginTest.php
@@ -54,7 +54,7 @@ class PluginTest extends DAV\AbstractServer {
         $this->assertEquals(400, $response->getStatusCode(), $response->getBody()->getContents());
 
         $this->assertEquals([
-            'X-Sabre-Version' => [DAV\Version::VERSION],
+
             'Content-Type'    => ['application/xml; charset=utf-8'],
             ],
             $response->getHeaders());
@@ -228,7 +228,7 @@ class PluginTest extends DAV\AbstractServer {
         
 
         $this->assertEquals([
-            'X-Sabre-Version' => [DAV\Version::VERSION],
+
             'Content-Type'    => ['application/xml; charset=utf-8'],
             ],
             $response->getHeaders()
@@ -248,7 +248,7 @@ class PluginTest extends DAV\AbstractServer {
         
 
         $this->assertEquals([
-            'X-Sabre-Version' => [DAV\Version::VERSION],
+
             'Content-Type'    => ['application/xml; charset=utf-8'],
             ],
             $response->getHeaders()
@@ -316,7 +316,7 @@ class PluginTest extends DAV\AbstractServer {
         $responseBody = $response->getBody()->getContents();
         $this->assertEquals(204, $response->getStatusCode(), 'Got an incorrect status code. Full response body: ' . $responseBody);
         $this->assertEquals([
-            'X-Sabre-Version' => [DAV\Version::VERSION],
+
             'Content-Length'  => ['0'],
             ],
             $response->getHeaders()
@@ -348,7 +348,7 @@ class PluginTest extends DAV\AbstractServer {
         
         $this->assertEquals(204, $response->getStatusCode(), 'Got an incorrect status code. Full response body: ' . $response->getBody()->getContents());
         $this->assertEquals([
-            'X-Sabre-Version' => [DAV\Version::VERSION],
+
             'Content-Length'  => ['0'],
             ],
             $response->getHeaders()

--- a/tests/Sabre/DAV/Mount/PluginTest.php
+++ b/tests/Sabre/DAV/Mount/PluginTest.php
@@ -25,9 +25,9 @@ class PluginTest extends DAV\AbstractServer {
 
         $request = HTTP\Sapi::createFromServerArray($serverVars);
         $this->server->httpRequest = ($request);
-        $this->server->exec();
+        $this->server->start();
 
-        $this->assertEquals(501, $this->response->status, 'We expected GET to not be implemented for Directories. Response body: ' . $this->response->body);
+        $this->assertEquals(501, $this->getResponse()->getStatusCode(), 'We expected GET to not be implemented for Directories. Response body: ' . $this->getResponse()->getBody()->getContents());
 
     }
 
@@ -42,12 +42,12 @@ class PluginTest extends DAV\AbstractServer {
 
         $request = HTTP\Sapi::createFromServerArray($serverVars);
         $this->server->httpRequest = ($request);
-        $this->server->exec();
+        $this->server->start();
 
-        $this->assertEquals(200, $this->response->status);
+        $this->assertEquals(200, $this->getResponse()->getStatusCode());
 
-        $xml = simplexml_load_string($this->response->body);
-        $this->assertInstanceOf('SimpleXMLElement', $xml, 'Response was not a valid xml document. The list of errors:' . print_r(libxml_get_errors(), true) . '. xml body: ' . $this->response->body . '. What type we got: ' . gettype($xml) . ' class, if object: ' . get_class($xml));
+        $xml = simplexml_load_string($this->getResponse()->getBody()->getContents());
+        $this->assertInstanceOf('SimpleXMLElement', $xml, 'Response was not a valid xml document. The list of errors:' . print_r(libxml_get_errors(), true) . '. xml body: ' . $this->getResponse()->getBody()->getContents() . '. What type we got: ' . gettype($xml) . ' class, if object: ' . get_class($xml));
 
         $xml->registerXPathNamespace('dm', 'http://purl.org/NET/webdav/mount');
         $url = $xml->xpath('//dm:url');

--- a/tests/Sabre/DAV/PSR3Test.php
+++ b/tests/Sabre/DAV/PSR3Test.php
@@ -8,7 +8,7 @@ class PSR3Test extends \PHPUnit_Framework_TestCase {
 
     function testIsLoggerAware() {
 
-        $server = new Server();
+        $server = new Server(null, null, null, function(){});
         $this->assertInstanceOf(
             'Psr\Log\LoggerAwareInterface',
             $server
@@ -18,7 +18,7 @@ class PSR3Test extends \PHPUnit_Framework_TestCase {
 
     function testGetNullLoggerByDefault() {
 
-        $server = new Server();
+        $server = new Server(null, null, null, function(){});
         $this->assertInstanceOf(
             'Psr\Log\NullLogger',
             $server->getLogger()
@@ -28,7 +28,7 @@ class PSR3Test extends \PHPUnit_Framework_TestCase {
 
     function testSetLogger() {
 
-        $server = new Server();
+        $server = new Server(null, null, null, function(){});
         $logger = new MockLogger();
 
         $server->setLogger($logger);
@@ -46,7 +46,7 @@ class PSR3Test extends \PHPUnit_Framework_TestCase {
      */
     function testLogException() {
 
-        $server = new Server();
+        $server = new Server(null, null, null, function(){});
         $logger = new MockLogger();
 
         $server->setLogger($logger);

--- a/tests/Sabre/DAV/PSR3Test.php
+++ b/tests/Sabre/DAV/PSR3Test.php
@@ -2,6 +2,8 @@
 
 namespace Sabre\DAV;
 
+use GuzzleHttp\Psr7\ServerRequest;
+
 class PSR3Test extends \PHPUnit_Framework_TestCase {
 
     function testIsLoggerAware() {
@@ -50,21 +52,16 @@ class PSR3Test extends \PHPUnit_Framework_TestCase {
         $server->setLogger($logger);
 
         // Creating a fake environment to execute http requests in.
-        $request = new \Sabre\HTTP\Request(
+        $request = new ServerRequest(
             'GET',
             '/not-found',
             []
         );
 
-        $server->httpRequest = $request;
-        $response = $server->httpResponse;
-        $server->sapi = new \Sabre\HTTP\SapiMock();
-
-        // Executing the request.
-        $server->start();
+        $response = $server->handle($request);
 
         // The request should have triggered a 404 status.
-        $this->assertEquals(404, $response->getResponse()->getStatusCode());
+        $this->assertEquals(404, $response->getStatusCode());
 
         // We should also see this in the PSR-3 log.
         $this->assertEquals(1, count($logger->logs));

--- a/tests/Sabre/DAV/PSR3Test.php
+++ b/tests/Sabre/DAV/PSR3Test.php
@@ -55,17 +55,16 @@ class PSR3Test extends \PHPUnit_Framework_TestCase {
             '/not-found',
             []
         );
-        $response = new \Sabre\HTTP\Response();
 
         $server->httpRequest = $request;
-        $server->httpResponse = $response;
+        $response = $server->httpResponse;
         $server->sapi = new \Sabre\HTTP\SapiMock();
 
         // Executing the request.
-        $server->exec();
+        $server->start();
 
         // The request should have triggered a 404 status.
-        $this->assertEquals(404, $response->getStatus());
+        $this->assertEquals(404, $response->getResponse()->getStatusCode());
 
         // We should also see this in the PSR-3 log.
         $this->assertEquals(1, count($logger->logs));

--- a/tests/Sabre/DAV/PartialUpdate/PluginTest.php
+++ b/tests/Sabre/DAV/PartialUpdate/PluginTest.php
@@ -2,6 +2,7 @@
 
 namespace Sabre\DAV\PartialUpdate;
 
+use GuzzleHttp\Psr7\ServerRequest;
 use Sabre\DAV;
 use Sabre\HTTP;
 
@@ -41,78 +42,44 @@ class PluginTest extends \Sabre\DAVServerTest {
     function testPatchNoRange() {
 
         $this->node->put('aaaaaaaa');
-        $request = HTTP\Sapi::createFromServerArray([
-            'REQUEST_METHOD' => 'PATCH',
-            'REQUEST_URI'    => '/partial',
-        ]);
-        $response = $this->request($request);
-
-        $this->assertEquals(400, $response->getStatusCode(), 'Full response body:' . $response->getBody()->getContents());
-
+        $request = new ServerRequest('PATCH', '/partial');
+        $this->request($request, 400);
     }
 
     function testPatchNotSupported() {
 
         $this->node->put('aaaaaaaa');
-        $request = new HTTP\Request('PATCH', '/', ['X-Update-Range' => '3-4']);
-        $request->setBody(
-            'bbb'
-        );
-        $response = $this->request($request);
-
-        $this->assertEquals(405, $response->getStatusCode(), 'Full response body:' . $response->getBody()->getContents());
-
+        $request = new ServerRequest('PATCH', '/', ['X-Update-Range' => '3-4'], 'bbb');
+        $this->request($request, 405);
     }
 
     function testPatchNoContentType() {
 
         $this->node->put('aaaaaaaa');
-        $request = new HTTP\Request('PATCH', '/partial', ['X-Update-Range' => 'bytes=3-4']);
-        $request->setBody(
-            'bbb'
-        );
-        $response = $this->request($request);
-
-        $this->assertEquals(415, $response->getStatusCode(), 'Full response body:' . $response->getBody()->getContents());
-
+        $request = new ServerRequest('PATCH', '/partial', ['X-Update-Range' => 'bytes=3-4'], 'bbb');
+        $this->request($request, 415);
     }
 
     function testPatchBadRange() {
 
         $this->node->put('aaaaaaaa');
-        $request = new HTTP\Request('PATCH', '/partial', ['X-Update-Range' => 'bytes=3-4', 'Content-Type' => 'application/x-sabredav-partialupdate', 'Content-Length' => '3']);
-        $request->setBody(
-            'bbb'
-        );
-        $response = $this->request($request);
-
-        $this->assertEquals(416, $response->getStatusCode(), 'Full response body:' . $response->getBody()->getContents());
-
+        $request = new ServerRequest('PATCH', '/partial', ['X-Update-Range' => 'bytes=3-4', 'Content-Type' => 'application/x-sabredav-partialupdate', 'Content-Length' => '3'], 'bbb');
+        $this->request($request, 416);
     }
 
     function testPatchNoLength() {
 
         $this->node->put('aaaaaaaa');
-        $request = new HTTP\Request('PATCH', '/partial', ['X-Update-Range' => 'bytes=3-5', 'Content-Type' => 'application/x-sabredav-partialupdate']);
-        $request->setBody(
-            'bbb'
-        );
-        $response = $this->request($request);
-
-        $this->assertEquals(411, $response->getStatusCode(), 'Full response body:' . $response->getBody()->getContents());
-
+        $request = new ServerRequest('PATCH', '/partial', ['X-Update-Range' => 'bytes=3-5', 'Content-Type' => 'application/x-sabredav-partialupdate'], 'bbb');
+        $this->request($request, 411);
     }
 
     function testPatchSuccess() {
 
         $this->node->put('aaaaaaaa');
-        $request = new HTTP\Request('PATCH', '/partial', ['X-Update-Range' => 'bytes=3-5', 'Content-Type' => 'application/x-sabredav-partialupdate', 'Content-Length' => 3]);
-        $request->setBody(
-            'bbb'
-        );
-        $response = $this->request($request);
+        $request = new ServerRequest('PATCH', '/partial', ['X-Update-Range' => 'bytes=3-5', 'Content-Type' => 'application/x-sabredav-partialupdate', 'Content-Length' => 3], 'bbb');
+        $this->request($request, 204);
 
-        $this->assertEquals(204, $response->getStatusCode(), 'Full response body:' . $response->getBody()->getContents());
         $this->assertEquals('aaabbbaa', $this->node->get());
 
     }
@@ -120,14 +87,10 @@ class PluginTest extends \Sabre\DAVServerTest {
     function testPatchNoEndRange() {
 
         $this->node->put('aaaaa');
-        $request = new HTTP\Request('PATCH', '/partial', ['X-Update-Range' => 'bytes=3-', 'Content-Type' => 'application/x-sabredav-partialupdate', 'Content-Length' => '3']);
-        $request->setBody(
-            'bbb'
-        );
+        $request = new ServerRequest('PATCH', '/partial', ['X-Update-Range' => 'bytes=3-', 'Content-Type' => 'application/x-sabredav-partialupdate', 'Content-Length' => '3'], 'bbb');
 
-        $response = $this->request($request);
+        $this->request($request, 204);
 
-        $this->assertEquals(204, $response->getStatusCode(), 'Full response body:' . $response->getBody()->getContents());
         $this->assertEquals('aaabbb', $this->node->get());
 
     }

--- a/tests/Sabre/DAV/PartialUpdate/PluginTest.php
+++ b/tests/Sabre/DAV/PartialUpdate/PluginTest.php
@@ -47,7 +47,7 @@ class PluginTest extends \Sabre\DAVServerTest {
         ]);
         $response = $this->request($request);
 
-        $this->assertEquals(400, $response->status, 'Full response body:' . $response->body);
+        $this->assertEquals(400, $response->getStatusCode(), 'Full response body:' . $response->getBody()->getContents());
 
     }
 
@@ -60,7 +60,7 @@ class PluginTest extends \Sabre\DAVServerTest {
         );
         $response = $this->request($request);
 
-        $this->assertEquals(405, $response->status, 'Full response body:' . $response->body);
+        $this->assertEquals(405, $response->getStatusCode(), 'Full response body:' . $response->getBody()->getContents());
 
     }
 
@@ -73,7 +73,7 @@ class PluginTest extends \Sabre\DAVServerTest {
         );
         $response = $this->request($request);
 
-        $this->assertEquals(415, $response->status, 'Full response body:' . $response->body);
+        $this->assertEquals(415, $response->getStatusCode(), 'Full response body:' . $response->getBody()->getContents());
 
     }
 
@@ -86,7 +86,7 @@ class PluginTest extends \Sabre\DAVServerTest {
         );
         $response = $this->request($request);
 
-        $this->assertEquals(416, $response->status, 'Full response body:' . $response->body);
+        $this->assertEquals(416, $response->getStatusCode(), 'Full response body:' . $response->getBody()->getContents());
 
     }
 
@@ -99,7 +99,7 @@ class PluginTest extends \Sabre\DAVServerTest {
         );
         $response = $this->request($request);
 
-        $this->assertEquals(411, $response->status, 'Full response body:' . $response->body);
+        $this->assertEquals(411, $response->getStatusCode(), 'Full response body:' . $response->getBody()->getContents());
 
     }
 
@@ -112,7 +112,7 @@ class PluginTest extends \Sabre\DAVServerTest {
         );
         $response = $this->request($request);
 
-        $this->assertEquals(204, $response->status, 'Full response body:' . $response->body);
+        $this->assertEquals(204, $response->getStatusCode(), 'Full response body:' . $response->getBody()->getContents());
         $this->assertEquals('aaabbbaa', $this->node->get());
 
     }
@@ -127,7 +127,7 @@ class PluginTest extends \Sabre\DAVServerTest {
 
         $response = $this->request($request);
 
-        $this->assertEquals(204, $response->getStatus(), 'Full response body:' . $response->getBodyAsString());
+        $this->assertEquals(204, $response->getStatusCode(), 'Full response body:' . $response->getBody()->getContents());
         $this->assertEquals('aaabbb', $this->node->get());
 
     }

--- a/tests/Sabre/DAV/PartialUpdate/SpecificationTest.php
+++ b/tests/Sabre/DAV/PartialUpdate/SpecificationTest.php
@@ -22,7 +22,7 @@ class SpecificationTest extends \PHPUnit_Framework_TestCase {
         $tree = [
             new File(SABRE_TEMPDIR . '/foobar.txt')
         ];
-        $server = new Server($tree);
+        $server = new Server($tree, null, null, function(){});
         $server->debugExceptions = true;
         $server->addPlugin(new Plugin());
 

--- a/tests/Sabre/DAV/PartialUpdate/SpecificationTest.php
+++ b/tests/Sabre/DAV/PartialUpdate/SpecificationTest.php
@@ -2,6 +2,7 @@
 
 namespace Sabre\DAV\PartialUpdate;
 
+use GuzzleHttp\Psr7\ServerRequest;
 use Sabre\DAV\FSExt\File;
 use Sabre\DAV\Server;
 use Sabre\HTTP;
@@ -56,14 +57,9 @@ class SpecificationTest extends \PHPUnit_Framework_TestCase {
             $headers['Content-Length'] = (string)$contentLength;
         }
 
-        $request = new HTTP\Request('PATCH', '/foobar.txt', $headers, '----');
+        $request = new ServerRequest('PATCH', '/foobar.txt', $headers, '----');
 
-        $request->setBody('----');
-        $this->server->httpRequest = $request;
-        $this->server->sapi = new HTTP\SapiMock();
-        $this->server->start();
-
-        $response = $this->server->httpResponse->getResponse();
+        $response = $this->server->handle($request);
 
         $this->assertEquals($httpStatus, $response->getStatusCode(), 'Incorrect http status received: ' . $response->getBody()->getContents());
         if (!is_null($endResult)) {

--- a/tests/Sabre/DAV/PartialUpdate/SpecificationTest.php
+++ b/tests/Sabre/DAV/PartialUpdate/SpecificationTest.php
@@ -60,11 +60,12 @@ class SpecificationTest extends \PHPUnit_Framework_TestCase {
 
         $request->setBody('----');
         $this->server->httpRequest = $request;
-        $this->server->httpResponse = new HTTP\ResponseMock();
         $this->server->sapi = new HTTP\SapiMock();
-        $this->server->exec();
+        $this->server->start();
 
-        $this->assertEquals($httpStatus, $this->server->httpResponse->status, 'Incorrect http status received: ' . $this->server->httpResponse->body);
+        $response = $this->server->httpResponse->getResponse();
+
+        $this->assertEquals($httpStatus, $response->getStatusCode(), 'Incorrect http status received: ' . $response->getBody()->getContents());
         if (!is_null($endResult)) {
             $this->assertEquals($endResult, file_get_contents(SABRE_TEMPDIR . '/foobar.txt'));
         }

--- a/tests/Sabre/DAV/PropertyStorage/PluginTest.php
+++ b/tests/Sabre/DAV/PropertyStorage/PluginTest.php
@@ -2,6 +2,8 @@
 
 namespace Sabre\DAV\PropertyStorage;
 
+use GuzzleHttp\Psr7\ServerRequest;
+
 class PluginTest extends \Sabre\DAVServerTest {
 
     protected $backend;
@@ -71,8 +73,8 @@ class PluginTest extends \Sabre\DAVServerTest {
         $this->server->tree->getNodeForPath('files')->createFile('source');
         $this->server->updateProperties('files/source', ['{DAV:}displayname' => 'hi']);
 
-        $request = new \Sabre\HTTP\Request('MOVE', '/files/source', ['Destination' => '/files/dest']);
-        $this->assertHTTPStatus(201, $request);
+        $request = new ServerRequest('MOVE', '/files/source', ['Destination' => '/files/dest']);
+        $this->request($request, 201);
 
         $result = $this->server->getProperties('/files/dest', ['{DAV:}displayname']);
 

--- a/tests/Sabre/DAV/ServerEventsTest.php
+++ b/tests/Sabre/DAV/ServerEventsTest.php
@@ -43,7 +43,7 @@ class ServerEventsTest extends AbstractServer {
             'REQUEST_URI'    => '/test.txt',
         ]);
 
-        $this->server->exec();
+        $this->server->start();
 
     }
 
@@ -59,9 +59,12 @@ class ServerEventsTest extends AbstractServer {
         ]);
 
         $this->server->httpRequest = $req;
-        $this->server->exec();
+        $this->server->start();
+        $response = $this->server->httpResponse->getResponse();
+        $responseBody = $response->getBody()->getContents();
 
-        $this->assertEquals(500, $this->server->httpResponse->getStatus());
+
+        $this->assertEquals(500, $response->getStatusCode(), $responseBody);
 
     }
 
@@ -80,7 +83,7 @@ class ServerEventsTest extends AbstractServer {
             'REQUEST_URI'    => '/not/exisitng',
         ]);
         $this->server->httpRequest = $req;
-        $this->server->exec();
+        $this->server->start();
 
         $this->assertInstanceOf('Sabre\\DAV\\Exception\\NotFound', $this->exception);
 

--- a/tests/Sabre/DAV/ServerEventsTest.php
+++ b/tests/Sabre/DAV/ServerEventsTest.php
@@ -2,6 +2,8 @@
 
 namespace Sabre\DAV;
 
+use GuzzleHttp\Psr7\ServerRequest;
+use Sabre\DAV\Exception\NotFound;
 use Sabre\HTTP;
 
 require_once 'Sabre/DAV/AbstractServer.php';
@@ -38,12 +40,9 @@ class ServerEventsTest extends AbstractServer {
 
         $this->server->on('afterResponse', [$mock, 'afterResponseCallback']);
 
-        $this->server->httpRequest = HTTP\Sapi::createFromServerArray([
-            'REQUEST_METHOD' => 'GET',
-            'REQUEST_URI'    => '/test.txt',
-        ]);
+        $this->server->handle(new ServerRequest('GET','/test.txt'));
 
-        $this->server->start();
+
 
     }
 
@@ -53,14 +52,7 @@ class ServerEventsTest extends AbstractServer {
         $this->assertFalse($this->server->createFile('bla', 'body'));
 
         // Also testing put()
-        $req = HTTP\Sapi::createFromServerArray([
-            'REQUEST_METHOD' => 'PUT',
-            'REQUEST_URI'    => '/barbar',
-        ]);
-
-        $this->server->httpRequest = $req;
-        $this->server->start();
-        $response = $this->server->httpResponse->getResponse();
+        $response = $this->server->handle(new ServerRequest('PUT','/barbar'));
         $responseBody = $response->getBody()->getContents();
 
 
@@ -76,17 +68,13 @@ class ServerEventsTest extends AbstractServer {
 
     function testException() {
 
-        $this->server->on('exception', [$this, 'exceptionHandler']);
+        $exception = null;
+        $this->server->on('exception', function(Exception $e) use (&$exception) {
+            $exception = $e;
+        });
 
-        $req = HTTP\Sapi::createFromServerArray([
-            'REQUEST_METHOD' => 'GET',
-            'REQUEST_URI'    => '/not/exisitng',
-        ]);
-        $this->server->httpRequest = $req;
-        $this->server->start();
-
-        $this->assertInstanceOf('Sabre\\DAV\\Exception\\NotFound', $this->exception);
-
+        $this->server->handle(new ServerRequest('GET', '/not/existing'));
+        $this->assertInstanceOf(NotFound::class, $exception);
     }
 
     function exceptionHandler(Exception $exception) {
@@ -114,11 +102,7 @@ class ServerEventsTest extends AbstractServer {
         });
 
         try {
-            $this->server->invokeMethod(
-                new HTTP\Request('BLABLA', '/'),
-                new HTTP\Response(),
-                false
-            );
+            $this->server->handle(new ServerRequest('BLABLA', '/'));
         } catch (Exception $e) {}
 
         // Fun fact, PHP 7.1 changes the order when sorting-by-callback.

--- a/tests/Sabre/DAV/ServerMKCOLTest.php
+++ b/tests/Sabre/DAV/ServerMKCOLTest.php
@@ -12,7 +12,7 @@ class ServerMKCOLTest extends AbstractServer {
 
 
         $this->assertEquals([
-            'X-Sabre-Version' => [Version::VERSION],
+
             'Content-Length'  => ['0'],
         ], $response->getHeaders());
 
@@ -31,7 +31,7 @@ class ServerMKCOLTest extends AbstractServer {
         $response = $this->server->handle($request);
         
         $this->assertEquals([
-            'X-Sabre-Version' => [Version::VERSION],
+
             'Content-Type'    => ['application/xml; charset=utf-8'],
         ], $response->getHeaders());
 
@@ -49,7 +49,7 @@ class ServerMKCOLTest extends AbstractServer {
 
 
         $this->assertEquals([
-            'X-Sabre-Version' => [Version::VERSION],
+
             'Content-Type'    => ['application/xml; charset=utf-8'],
         ], $response->getHeaders());
 
@@ -67,7 +67,7 @@ class ServerMKCOLTest extends AbstractServer {
 
 
         $this->assertEquals([
-            'X-Sabre-Version' => [Version::VERSION],
+
             'Content-Type'    => ['application/xml; charset=utf-8'],
         ], $response->getHeaders());
 
@@ -91,7 +91,7 @@ class ServerMKCOLTest extends AbstractServer {
 
 
         $this->assertEquals([
-            'X-Sabre-Version' => [Version::VERSION],
+
             'Content-Type'    => ['application/xml; charset=utf-8'],
         ], $response->getHeaders());
 
@@ -116,7 +116,7 @@ class ServerMKCOLTest extends AbstractServer {
 
 
         $this->assertEquals([
-            'X-Sabre-Version' => [Version::VERSION],
+
             'Content-Type'    => ['application/xml; charset=utf-8'],
         ], $response->getHeaders());
 
@@ -140,7 +140,7 @@ class ServerMKCOLTest extends AbstractServer {
 
 
         $this->assertEquals([
-            'X-Sabre-Version' => [Version::VERSION],
+
             'Content-Length'  => ['0'],
         ], $response->getHeaders());
 
@@ -166,7 +166,7 @@ class ServerMKCOLTest extends AbstractServer {
 
 
         $this->assertEquals([
-            'X-Sabre-Version' => [Version::VERSION],
+
             'Content-Length'  => ['0'],
         ], $response->getHeaders());
 
@@ -185,7 +185,7 @@ class ServerMKCOLTest extends AbstractServer {
 
 
         $this->assertEquals([
-            'X-Sabre-Version' => [Version::VERSION],
+
             'Content-Type'    => ['application/xml; charset=utf-8'],
         ], $response->getHeaders());
 
@@ -203,7 +203,7 @@ class ServerMKCOLTest extends AbstractServer {
 
 
         $this->assertEquals([
-            'X-Sabre-Version' => [Version::VERSION],
+
             'Content-Type'    => ['application/xml; charset=utf-8'],
         ], $response->getHeaders());
 
@@ -222,7 +222,7 @@ class ServerMKCOLTest extends AbstractServer {
 
 
         $this->assertEquals([
-            'X-Sabre-Version' => [Version::VERSION],
+
             'Content-Type'    => ['application/xml; charset=utf-8'],
             'Allow'           => ['OPTIONS, GET, HEAD, DELETE, PROPFIND, PUT, PROPPATCH, COPY, MOVE, REPORT'],
         ], $response->getHeaders());
@@ -257,7 +257,7 @@ class ServerMKCOLTest extends AbstractServer {
         $this->assertEquals(207, $response->getStatusCode(), 'Wrong statuscode received. Full response body: ' . $responseBody);
 
         $this->assertEquals([
-            'X-Sabre-Version' => [Version::VERSION],
+
             'Content-Type'    => ['application/xml; charset=utf-8'],
         ], $response->getHeaders());
 

--- a/tests/Sabre/DAV/ServerMKCOLTest.php
+++ b/tests/Sabre/DAV/ServerMKCOLTest.php
@@ -16,15 +16,15 @@ class ServerMKCOLTest extends AbstractServer {
         $request = HTTP\Sapi::createFromServerArray($serverVars);
         $request->setBody("");
         $this->server->httpRequest = ($request);
-        $this->server->exec();
+        $this->server->start();
 
         $this->assertEquals([
             'X-Sabre-Version' => [Version::VERSION],
             'Content-Length'  => ['0'],
-        ], $this->response->getHeaders());
+        ], $this->getResponse()->getHeaders());
 
-        $this->assertEquals(201, $this->response->status);
-        $this->assertEquals('', $this->response->body);
+        $this->assertEquals(201, $this->getResponse()->getStatusCode());
+        $this->assertEquals('', $this->getResponse()->getBody()->getContents());
         $this->assertTrue(is_dir($this->tempDir . '/testcol'));
 
     }
@@ -42,14 +42,14 @@ class ServerMKCOLTest extends AbstractServer {
         $request = HTTP\Sapi::createFromServerArray($serverVars);
         $request->setBody("Hello");
         $this->server->httpRequest = ($request);
-        $this->server->exec();
+        $this->server->start();
 
         $this->assertEquals([
             'X-Sabre-Version' => [Version::VERSION],
             'Content-Type'    => ['application/xml; charset=utf-8'],
-        ], $this->response->getHeaders());
+        ], $this->getResponse()->getHeaders());
 
-        $this->assertEquals(415, $this->response->status);
+        $this->assertEquals(415, $this->getResponse()->getStatusCode());
 
     }
 
@@ -67,14 +67,14 @@ class ServerMKCOLTest extends AbstractServer {
         $request = HTTP\Sapi::createFromServerArray($serverVars);
         $request->setBody("Hello");
         $this->server->httpRequest = ($request);
-        $this->server->exec();
+        $this->server->start();
 
         $this->assertEquals([
             'X-Sabre-Version' => [Version::VERSION],
             'Content-Type'    => ['application/xml; charset=utf-8'],
-        ], $this->response->getHeaders());
+        ], $this->getResponse()->getHeaders());
 
-        $this->assertEquals(400, $this->response->getStatus(), $this->response->getBodyAsString());
+        $this->assertEquals(400, $this->getResponse()->getStatusCode(), $this->getResponse()->getBody()->getContents());
 
     }
 
@@ -92,14 +92,14 @@ class ServerMKCOLTest extends AbstractServer {
         $request = HTTP\Sapi::createFromServerArray($serverVars);
         $request->setBody('<?xml version="1.0"?><html></html>');
         $this->server->httpRequest = ($request);
-        $this->server->exec();
+        $this->server->start();
 
         $this->assertEquals([
             'X-Sabre-Version' => [Version::VERSION],
             'Content-Type'    => ['application/xml; charset=utf-8'],
-        ], $this->response->getHeaders());
+        ], $this->getResponse()->getHeaders());
 
-        $this->assertEquals(400, $this->response->getStatus());
+        $this->assertEquals(400, $this->getResponse()->getStatusCode());
 
     }
 
@@ -124,14 +124,14 @@ class ServerMKCOLTest extends AbstractServer {
   </set>
 </mkcol>');
         $this->server->httpRequest = ($request);
-        $this->server->exec();
+        $this->server->start();
 
         $this->assertEquals([
             'X-Sabre-Version' => [Version::VERSION],
             'Content-Type'    => ['application/xml; charset=utf-8'],
-        ], $this->response->getHeaders());
+        ], $this->getResponse()->getHeaders());
 
-        $this->assertEquals(400, $this->response->status, 'Wrong statuscode received. Full response body: ' . $this->response->body);
+        $this->assertEquals(400, $this->getResponse()->getStatusCode(), 'Wrong statuscode received. Full response body: ' . $this->getResponse()->getBody()->getContents());
 
     }
 
@@ -156,14 +156,14 @@ class ServerMKCOLTest extends AbstractServer {
   </set>
 </mkcol>');
         $this->server->httpRequest = ($request);
-        $this->server->exec();
+        $this->server->start();
 
         $this->assertEquals([
             'X-Sabre-Version' => [Version::VERSION],
             'Content-Type'    => ['application/xml; charset=utf-8'],
-        ], $this->response->getHeaders());
+        ], $this->getResponse()->getHeaders());
 
-        $this->assertEquals(403, $this->response->status, 'Wrong statuscode received. Full response body: ' . $this->response->body);
+        $this->assertEquals(403, $this->getResponse()->getStatusCode(), 'Wrong statuscode received. Full response body: ' . $this->getResponse()->getBody()->getContents());
 
     }
 
@@ -188,14 +188,14 @@ class ServerMKCOLTest extends AbstractServer {
   </set>
 </mkcol>');
         $this->server->httpRequest = ($request);
-        $this->server->exec();
+        $this->server->start();
 
         $this->assertEquals([
             'X-Sabre-Version' => [Version::VERSION],
             'Content-Length'  => ['0'],
-        ], $this->response->getHeaders());
+        ], $this->getResponse()->getHeaders());
 
-        $this->assertEquals(201, $this->response->status, 'Wrong statuscode received. Full response body: ' . $this->response->body);
+        $this->assertEquals(201, $this->getResponse()->getStatusCode(), 'Wrong statuscode received. Full response body: ' . $this->getResponse()->getBody()->getContents());
 
     }
 
@@ -222,14 +222,14 @@ class ServerMKCOLTest extends AbstractServer {
   </set>
 </mkcol>');
         $this->server->httpRequest = ($request);
-        $this->server->exec();
+        $this->server->start();
 
         $this->assertEquals([
             'X-Sabre-Version' => [Version::VERSION],
             'Content-Length'  => ['0'],
-        ], $this->response->getHeaders());
+        ], $this->getResponse()->getHeaders());
 
-        $this->assertEquals(201, $this->response->status, 'Wrong statuscode received. Full response body: ' . $this->response->body);
+        $this->assertEquals(201, $this->getResponse()->getStatusCode(), 'Wrong statuscode received. Full response body: ' . $this->getResponse()->getBody()->getContents());
 
     }
 
@@ -247,14 +247,14 @@ class ServerMKCOLTest extends AbstractServer {
         $request->setBody('');
 
         $this->server->httpRequest = ($request);
-        $this->server->exec();
+        $this->server->start();
 
         $this->assertEquals([
             'X-Sabre-Version' => [Version::VERSION],
             'Content-Type'    => ['application/xml; charset=utf-8'],
-        ], $this->response->getHeaders());
+        ], $this->getResponse()->getHeaders());
 
-        $this->assertEquals(409, $this->response->status, 'Wrong statuscode received. Full response body: ' . $this->response->body);
+        $this->assertEquals(409, $this->getResponse()->getStatusCode(), 'Wrong statuscode received. Full response body: ' . $this->getResponse()->getBody()->getContents());
 
     }
 
@@ -272,14 +272,14 @@ class ServerMKCOLTest extends AbstractServer {
         $request->setBody('');
 
         $this->server->httpRequest = ($request);
-        $this->server->exec();
+        $this->server->start();
 
         $this->assertEquals([
             'X-Sabre-Version' => [Version::VERSION],
             'Content-Type'    => ['application/xml; charset=utf-8'],
-        ], $this->response->getHeaders());
+        ], $this->getResponse()->getHeaders());
 
-        $this->assertEquals(409, $this->response->status, 'Wrong statuscode received. Full response body: ' . $this->response->body);
+        $this->assertEquals(409, $this->getResponse()->getStatusCode(), 'Wrong statuscode received. Full response body: ' . $this->getResponse()->getBody()->getContents());
 
     }
 
@@ -297,15 +297,15 @@ class ServerMKCOLTest extends AbstractServer {
         $request->setBody('');
 
         $this->server->httpRequest = ($request);
-        $this->server->exec();
+        $this->server->start();
 
         $this->assertEquals([
             'X-Sabre-Version' => [Version::VERSION],
             'Content-Type'    => ['application/xml; charset=utf-8'],
             'Allow'           => ['OPTIONS, GET, HEAD, DELETE, PROPFIND, PUT, PROPPATCH, COPY, MOVE, REPORT'],
-        ], $this->response->getHeaders());
+        ], $this->getResponse()->getHeaders());
 
-        $this->assertEquals(405, $this->response->status, 'Wrong statuscode received. Full response body: ' . $this->response->body);
+        $this->assertEquals(405, $this->getResponse()->getStatusCode(), 'Wrong statuscode received. Full response body: ' . $this->getResponse()->getBody()->getContents());
 
     }
 
@@ -330,16 +330,17 @@ class ServerMKCOLTest extends AbstractServer {
   </set>
 </mkcol>');
         $this->server->httpRequest = ($request);
-        $this->server->exec();
+        $this->server->start();
+        $responseBody = $this->getResponse()->getBody()->getContents();
 
-        $this->assertEquals(207, $this->response->status, 'Wrong statuscode received. Full response body: ' . $this->response->body);
+        $this->assertEquals(207, $this->getResponse()->getStatusCode(), 'Wrong statuscode received. Full response body: ' . $responseBody);
 
         $this->assertEquals([
             'X-Sabre-Version' => [Version::VERSION],
             'Content-Type'    => ['application/xml; charset=utf-8'],
-        ], $this->response->getHeaders());
+        ], $this->getResponse()->getHeaders());
 
-        $responseBody = $this->response->getBodyAsString();
+
 
         $expected = <<<XML
 <?xml version="1.0"?>

--- a/tests/Sabre/DAV/ServerPluginTest.php
+++ b/tests/Sabre/DAV/ServerPluginTest.php
@@ -54,7 +54,7 @@ class ServerPluginTest extends AbstractServer {
             'Allow'           => ['OPTIONS, GET, HEAD, DELETE, PROPFIND, PUT, PROPPATCH, COPY, MOVE, REPORT, BEER, WINE'],
             'Accept-Ranges'   => ['bytes'],
             'Content-Length'  => ['0'],
-            'X-Sabre-Version' => [Version::VERSION],
+
         ], $response->getHeaders());
 
         $this->assertEquals(200, $response->getStatusCode());

--- a/tests/Sabre/DAV/ServerPluginTest.php
+++ b/tests/Sabre/DAV/ServerPluginTest.php
@@ -2,6 +2,7 @@
 
 namespace Sabre\DAV;
 
+use GuzzleHttp\Psr7\ServerRequest;
 use Sabre\HTTP;
 
 require_once 'Sabre/DAV/AbstractServer.php';
@@ -10,7 +11,7 @@ require_once 'Sabre/DAV/TestPlugin.php';
 class ServerPluginTest extends AbstractServer {
 
     /**
-     * @var Sabre\DAV\TestPlugin
+     * @var \Sabre\DAV\TestPlugin
      */
     protected $testPlugin;
 
@@ -43,14 +44,9 @@ class ServerPluginTest extends AbstractServer {
 
     function testOptions() {
 
-        $serverVars = [
-            'REQUEST_URI'    => '/',
-            'REQUEST_METHOD' => 'OPTIONS',
-        ];
+        $request = new ServerRequest('OPTIONS', '/');
+        $response = $this->server->handle($request);
 
-        $request = HTTP\Sapi::createFromServerArray($serverVars);
-        $this->server->httpRequest = ($request);
-        $this->server->start();
 
         $this->assertEquals([
             'DAV'             => ['1, 3, extended-mkcol, drinking'],
@@ -59,10 +55,10 @@ class ServerPluginTest extends AbstractServer {
             'Accept-Ranges'   => ['bytes'],
             'Content-Length'  => ['0'],
             'X-Sabre-Version' => [Version::VERSION],
-        ], $this->getResponse()->getHeaders());
+        ], $response->getHeaders());
 
-        $this->assertEquals(200, $this->getResponse()->getStatusCode());
-        $this->assertEquals('', $this->getResponse()->getBody()->getContents());
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('', $response->getBody()->getContents());
         $this->assertEquals('OPTIONS', $this->testPlugin->beforeMethod);
 
 

--- a/tests/Sabre/DAV/ServerPluginTest.php
+++ b/tests/Sabre/DAV/ServerPluginTest.php
@@ -50,7 +50,7 @@ class ServerPluginTest extends AbstractServer {
 
         $request = HTTP\Sapi::createFromServerArray($serverVars);
         $this->server->httpRequest = ($request);
-        $this->server->exec();
+        $this->server->start();
 
         $this->assertEquals([
             'DAV'             => ['1, 3, extended-mkcol, drinking'],
@@ -59,10 +59,10 @@ class ServerPluginTest extends AbstractServer {
             'Accept-Ranges'   => ['bytes'],
             'Content-Length'  => ['0'],
             'X-Sabre-Version' => [Version::VERSION],
-        ], $this->response->getHeaders());
+        ], $this->getResponse()->getHeaders());
 
-        $this->assertEquals(200, $this->response->status);
-        $this->assertEquals('', $this->response->body);
+        $this->assertEquals(200, $this->getResponse()->getStatusCode());
+        $this->assertEquals('', $this->getResponse()->getBody()->getContents());
         $this->assertEquals('OPTIONS', $this->testPlugin->beforeMethod);
 
 

--- a/tests/Sabre/DAV/ServerPreconditionTest.php
+++ b/tests/Sabre/DAV/ServerPreconditionTest.php
@@ -15,7 +15,8 @@ class ServerPreconditionsTest extends \PHPUnit_Framework_TestCase {
     function testIfMatchNoNode() {
 
         $root = new SimpleCollection('root', [new ServerPreconditionsNode()]);
-        $server = new Server($root);
+        $server = new Server($root, null, null, function(){});
+
         $httpRequest = new ServerRequest('GET', '/bar', ['If-Match' => '*']);
         $httpResponse = new HTTP\Response();
         $server->checkPreconditions(new Psr7RequestWrapper($httpRequest), $httpResponse);
@@ -27,7 +28,7 @@ class ServerPreconditionsTest extends \PHPUnit_Framework_TestCase {
     function testIfMatchHasNode() {
 
         $root = new SimpleCollection('root', [new ServerPreconditionsNode()]);
-        $server = new Server($root);
+        $server = new Server($root, null, null, function(){});
         $httpRequest = new ServerRequest('GET', '/foo', ['If-Match' => '*']);
         $httpResponse = new HTTP\Response();
         $this->assertTrue($server->checkPreconditions(new Psr7RequestWrapper($httpRequest), $httpResponse));
@@ -40,7 +41,7 @@ class ServerPreconditionsTest extends \PHPUnit_Framework_TestCase {
     function testIfMatchWrongEtag() {
 
         $root = new SimpleCollection('root', [new ServerPreconditionsNode()]);
-        $server = new Server($root);
+        $server = new Server($root, null, null, function(){});
         $httpRequest = new ServerRequest('GET', '/foo', ['If-Match' => '1234']);
         $httpResponse = new HTTP\Response();
         $server->checkPreconditions(new Psr7RequestWrapper($httpRequest), $httpResponse);
@@ -52,7 +53,7 @@ class ServerPreconditionsTest extends \PHPUnit_Framework_TestCase {
     function testIfMatchCorrectEtag() {
 
         $root = new SimpleCollection('root', [new ServerPreconditionsNode()]);
-        $server = new Server($root);
+        $server = new Server($root, null, null, function(){});
         $httpRequest = new ServerRequest('GET', '/foo', ['If-Match' => '"abc123"']);
         $httpResponse = new HTTP\Response();
         $this->assertTrue($server->checkPreconditions(new Psr7RequestWrapper($httpRequest), $httpResponse));
@@ -67,7 +68,7 @@ class ServerPreconditionsTest extends \PHPUnit_Framework_TestCase {
     function testIfMatchEvolutionEtag() {
 
         $root = new SimpleCollection('root', [new ServerPreconditionsNode()]);
-        $server = new Server($root);
+        $server = new Server($root, null, null, function(){});
         $httpRequest = new ServerRequest('GET', '/foo', ['If-Match' => '\\"abc123\\"']);
         $httpResponse = new HTTP\Response();
         $this->assertTrue($server->checkPreconditions(new Psr7RequestWrapper($httpRequest), $httpResponse));
@@ -79,7 +80,7 @@ class ServerPreconditionsTest extends \PHPUnit_Framework_TestCase {
     function testIfMatchMultiple() {
 
         $root = new SimpleCollection('root', [new ServerPreconditionsNode()]);
-        $server = new Server($root);
+        $server = new Server($root, null, null, function(){});
         $httpRequest = new ServerRequest('GET', '/foo', ['If-Match' => '"hellothere", "abc123"']);
         $httpResponse = new HTTP\Response();
         $this->assertTrue($server->checkPreconditions(new Psr7RequestWrapper($httpRequest), $httpResponse));
@@ -91,7 +92,7 @@ class ServerPreconditionsTest extends \PHPUnit_Framework_TestCase {
     function testIfNoneMatchNoNode() {
 
         $root = new SimpleCollection('root', [new ServerPreconditionsNode()]);
-        $server = new Server($root);
+        $server = new Server($root, null, null, function(){});
         $httpRequest = new ServerRequest('GET', '/bar', ['If-None-Match' => '*']);
         $httpResponse = new HTTP\Response();
         $this->assertTrue($server->checkPreconditions(new Psr7RequestWrapper($httpRequest), $httpResponse));
@@ -104,7 +105,7 @@ class ServerPreconditionsTest extends \PHPUnit_Framework_TestCase {
     function testIfNoneMatchHasNode() {
 
         $root = new SimpleCollection('root', [new ServerPreconditionsNode()]);
-        $server = new Server($root);
+        $server = new Server($root, null, null, function(){});
         $httpRequest = new ServerRequest('POST', '/foo', ['If-None-Match' => '*']);
         $httpResponse = new HTTP\Response();
         $server->checkPreconditions(new Psr7RequestWrapper($httpRequest), $httpResponse);
@@ -116,7 +117,7 @@ class ServerPreconditionsTest extends \PHPUnit_Framework_TestCase {
     function testIfNoneMatchWrongEtag() {
 
         $root = new SimpleCollection('root', [new ServerPreconditionsNode()]);
-        $server = new Server($root);
+        $server = new Server($root, null, null, function(){});
         $httpRequest = new ServerRequest('POST', '/foo', ['If-None-Match' => '"1234"']);
         $httpResponse = new HTTP\Response();
         $this->assertTrue($server->checkPreconditions(new Psr7RequestWrapper($httpRequest), $httpResponse));
@@ -128,7 +129,7 @@ class ServerPreconditionsTest extends \PHPUnit_Framework_TestCase {
     function testIfNoneMatchWrongEtagMultiple() {
 
         $root = new SimpleCollection('root', [new ServerPreconditionsNode()]);
-        $server = new Server($root);
+        $server = new Server($root, null, null, function(){});
         $httpRequest = new ServerRequest('POST', '/foo', ['If-None-Match' => '"1234", "5678"']);
         $httpResponse = new HTTP\Response();
         $this->assertTrue($server->checkPreconditions(new Psr7RequestWrapper($httpRequest), $httpResponse));
@@ -141,7 +142,7 @@ class ServerPreconditionsTest extends \PHPUnit_Framework_TestCase {
     function testIfNoneMatchCorrectEtag() {
 
         $root = new SimpleCollection('root', [new ServerPreconditionsNode()]);
-        $server = new Server($root);
+        $server = new Server($root, null, null, function(){});
         $httpRequest = new ServerRequest('POST', '/foo', ['If-None-Match' => '"abc123"']);
         $httpResponse = new HTTP\Response();
         $server->checkPreconditions(new Psr7RequestWrapper($httpRequest), $httpResponse);
@@ -154,7 +155,7 @@ class ServerPreconditionsTest extends \PHPUnit_Framework_TestCase {
     function testIfNoneMatchCorrectEtagMultiple() {
 
         $root = new SimpleCollection('root', [new ServerPreconditionsNode()]);
-        $server = new Server($root);
+        $server = new Server($root, null, null, function(){});
         $httpRequest = new ServerRequest('POST', '/foo', ['If-None-Match' => '"1234, "abc123"']);
         $httpResponse = new HTTP\Response();
         $server->checkPreconditions(new Psr7RequestWrapper($httpRequest), $httpResponse);
@@ -166,7 +167,7 @@ class ServerPreconditionsTest extends \PHPUnit_Framework_TestCase {
     function testIfNoneMatchCorrectEtagAsGet() {
 
         $root = new SimpleCollection('root', [new ServerPreconditionsNode()]);
-        $server = new Server($root);
+        $server = new Server($root, null, null, function(){});
         $httpRequest = new ServerRequest('GET', '/foo', ['If-None-Match' => '"abc123"']);
         $this->assertFalse($server->checkPreconditions(new Psr7RequestWrapper($httpRequest), $server->httpResponse));
 
@@ -182,7 +183,7 @@ class ServerPreconditionsTest extends \PHPUnit_Framework_TestCase {
     function testNoneMatchCorrectEtagEnsureSapiSent() {
 
         $root = new SimpleCollection('root', [new ServerPreconditionsNode()]);
-        $server = new Server($root);
+        $server = new Server($root, null, null, function(){});
         $httpRequest = new ServerRequest('GET', '/foo', ['If-None-Match' => '"abc123"']);
         $this->assertFalse($server->checkPreconditions(new Psr7RequestWrapper($httpRequest), $server->httpResponse));
 
@@ -191,7 +192,7 @@ class ServerPreconditionsTest extends \PHPUnit_Framework_TestCase {
         $this->assertEquals(304, $response->getStatusCode());
         $this->assertEquals([
             'ETag'            => ['"abc123"'],
-            'X-Sabre-Version' => [Version::VERSION],
+
         ], $response->getHeaders());
     }
 
@@ -200,7 +201,7 @@ class ServerPreconditionsTest extends \PHPUnit_Framework_TestCase {
     function testIfModifiedSinceUnModified() {
 
         $root = new SimpleCollection('root', [new ServerPreconditionsNode()]);
-        $server = new Server($root);
+        $server = new Server($root, null, null, function(){});
         $httpRequest = new ServerRequest('GET', '/foo', [
             'If-Modified-Since' => 'Sun, 06 Nov 1994 08:49:37 GMT',
         ]);
@@ -220,7 +221,7 @@ class ServerPreconditionsTest extends \PHPUnit_Framework_TestCase {
     function testIfModifiedSinceModified() {
 
         $root = new SimpleCollection('root', [new ServerPreconditionsNode()]);
-        $server = new Server($root);
+        $server = new Server($root, null, null, function(){});
         $httpRequest = new ServerRequest('GET', '/foo', [
             'If-Modified-Since' => 'Tue, 06 Nov 1984 08:49:37 GMT',
         ]);
@@ -235,7 +236,7 @@ class ServerPreconditionsTest extends \PHPUnit_Framework_TestCase {
     function testIfModifiedSinceInvalidDate() {
 
         $root = new SimpleCollection('root', [new ServerPreconditionsNode()]);
-        $server = new Server($root);
+        $server = new Server($root, null, null, function(){});
         $httpRequest = new ServerRequest('GET', '/foo', [
             'If-Modified-Since' => 'Your mother',
         ]);
@@ -251,7 +252,7 @@ class ServerPreconditionsTest extends \PHPUnit_Framework_TestCase {
     function testIfModifiedSinceInvalidDate2() {
 
         $root = new SimpleCollection('root', [new ServerPreconditionsNode()]);
-        $server = new Server($root);
+        $server = new Server($root, null, null, function(){});
         $httpRequest = new ServerRequest('GET', '/foo', [
             'If-Unmodified-Since' => 'Sun, 06 Nov 1994 08:49:37 EST',
         ]);
@@ -266,7 +267,7 @@ class ServerPreconditionsTest extends \PHPUnit_Framework_TestCase {
     function testIfUnmodifiedSinceUnModified() {
 
         $root = new SimpleCollection('root', [new ServerPreconditionsNode()]);
-        $server = new Server($root);
+        $server = new Server($root, null, null, function(){});
         $httpRequest = new ServerRequest('GET', '/foo', [
             'If-Unmodified-Since' => 'Sun, 06 Nov 1994 08:49:37 GMT',
         ]);
@@ -282,7 +283,7 @@ class ServerPreconditionsTest extends \PHPUnit_Framework_TestCase {
     function testIfUnmodifiedSinceModified() {
 
         $root = new SimpleCollection('root', [new ServerPreconditionsNode()]);
-        $server = new Server($root);
+        $server = new Server($root, null, null, function(){});
         $httpRequest = new ServerRequest('GET', '/foo', [
             'If-Unmodified-Since' => 'Tue, 06 Nov 1984 08:49:37 GMT',
         ]);
@@ -296,7 +297,7 @@ class ServerPreconditionsTest extends \PHPUnit_Framework_TestCase {
     function testIfUnmodifiedSinceInvalidDate() {
 
         $root = new SimpleCollection('root', [new ServerPreconditionsNode()]);
-        $server = new Server($root);
+        $server = new Server($root, null, null, function(){});
         $httpRequest = new ServerRequest('GET', '/foo', [
             'If-Unmodified-Since' => 'Sun, 06 Nov 1984 08:49:37 CET',
         ]);

--- a/tests/Sabre/DAV/ServerPreconditionTest.php
+++ b/tests/Sabre/DAV/ServerPreconditionTest.php
@@ -2,6 +2,7 @@
 
 namespace Sabre\DAV;
 
+use GuzzleHttp\Psr7\ServerRequest;
 use Sabre\HTTP;
 
 require_once 'Sabre/HTTP/ResponseMock.php';
@@ -9,15 +10,15 @@ require_once 'Sabre/HTTP/ResponseMock.php';
 class ServerPreconditionsTest extends \PHPUnit_Framework_TestCase {
 
     /**
-     * @expectedException Sabre\DAV\Exception\PreconditionFailed
+     * @expectedException \Sabre\DAV\Exception\PreconditionFailed
      */
     function testIfMatchNoNode() {
 
         $root = new SimpleCollection('root', [new ServerPreconditionsNode()]);
         $server = new Server($root);
-        $httpRequest = new HTTP\Request('GET', '/bar', ['If-Match' => '*']);
+        $httpRequest = new ServerRequest('GET', '/bar', ['If-Match' => '*']);
         $httpResponse = new HTTP\Response();
-        $server->checkPreconditions($httpRequest, $httpResponse);
+        $server->checkPreconditions(new Psr7RequestWrapper($httpRequest), $httpResponse);
 
     }
 
@@ -27,22 +28,22 @@ class ServerPreconditionsTest extends \PHPUnit_Framework_TestCase {
 
         $root = new SimpleCollection('root', [new ServerPreconditionsNode()]);
         $server = new Server($root);
-        $httpRequest = new HTTP\Request('GET', '/foo', ['If-Match' => '*']);
+        $httpRequest = new ServerRequest('GET', '/foo', ['If-Match' => '*']);
         $httpResponse = new HTTP\Response();
-        $this->assertTrue($server->checkPreconditions($httpRequest, $httpResponse));
+        $this->assertTrue($server->checkPreconditions(new Psr7RequestWrapper($httpRequest), $httpResponse));
 
     }
 
     /**
-     * @expectedException Sabre\DAV\Exception\PreconditionFailed
+     * @expectedException \Sabre\DAV\Exception\PreconditionFailed
      */
     function testIfMatchWrongEtag() {
 
         $root = new SimpleCollection('root', [new ServerPreconditionsNode()]);
         $server = new Server($root);
-        $httpRequest = new HTTP\Request('GET', '/foo', ['If-Match' => '1234']);
+        $httpRequest = new ServerRequest('GET', '/foo', ['If-Match' => '1234']);
         $httpResponse = new HTTP\Response();
-        $server->checkPreconditions($httpRequest, $httpResponse);
+        $server->checkPreconditions(new Psr7RequestWrapper($httpRequest), $httpResponse);
 
     }
 
@@ -52,9 +53,9 @@ class ServerPreconditionsTest extends \PHPUnit_Framework_TestCase {
 
         $root = new SimpleCollection('root', [new ServerPreconditionsNode()]);
         $server = new Server($root);
-        $httpRequest = new HTTP\Request('GET', '/foo', ['If-Match' => '"abc123"']);
+        $httpRequest = new ServerRequest('GET', '/foo', ['If-Match' => '"abc123"']);
         $httpResponse = new HTTP\Response();
-        $this->assertTrue($server->checkPreconditions($httpRequest, $httpResponse));
+        $this->assertTrue($server->checkPreconditions(new Psr7RequestWrapper($httpRequest), $httpResponse));
 
     }
 
@@ -67,9 +68,9 @@ class ServerPreconditionsTest extends \PHPUnit_Framework_TestCase {
 
         $root = new SimpleCollection('root', [new ServerPreconditionsNode()]);
         $server = new Server($root);
-        $httpRequest = new HTTP\Request('GET', '/foo', ['If-Match' => '\\"abc123\\"']);
+        $httpRequest = new ServerRequest('GET', '/foo', ['If-Match' => '\\"abc123\\"']);
         $httpResponse = new HTTP\Response();
-        $this->assertTrue($server->checkPreconditions($httpRequest, $httpResponse));
+        $this->assertTrue($server->checkPreconditions(new Psr7RequestWrapper($httpRequest), $httpResponse));
 
     }
 
@@ -79,9 +80,9 @@ class ServerPreconditionsTest extends \PHPUnit_Framework_TestCase {
 
         $root = new SimpleCollection('root', [new ServerPreconditionsNode()]);
         $server = new Server($root);
-        $httpRequest = new HTTP\Request('GET', '/foo', ['If-Match' => '"hellothere", "abc123"']);
+        $httpRequest = new ServerRequest('GET', '/foo', ['If-Match' => '"hellothere", "abc123"']);
         $httpResponse = new HTTP\Response();
-        $this->assertTrue($server->checkPreconditions($httpRequest, $httpResponse));
+        $this->assertTrue($server->checkPreconditions(new Psr7RequestWrapper($httpRequest), $httpResponse));
 
     }
 
@@ -91,22 +92,22 @@ class ServerPreconditionsTest extends \PHPUnit_Framework_TestCase {
 
         $root = new SimpleCollection('root', [new ServerPreconditionsNode()]);
         $server = new Server($root);
-        $httpRequest = new HTTP\Request('GET', '/bar', ['If-None-Match' => '*']);
+        $httpRequest = new ServerRequest('GET', '/bar', ['If-None-Match' => '*']);
         $httpResponse = new HTTP\Response();
-        $this->assertTrue($server->checkPreconditions($httpRequest, $httpResponse));
+        $this->assertTrue($server->checkPreconditions(new Psr7RequestWrapper($httpRequest), $httpResponse));
 
     }
 
     /**
-     * @expectedException Sabre\DAV\Exception\PreconditionFailed
+     * @expectedException \Sabre\DAV\Exception\PreconditionFailed
      */
     function testIfNoneMatchHasNode() {
 
         $root = new SimpleCollection('root', [new ServerPreconditionsNode()]);
         $server = new Server($root);
-        $httpRequest = new HTTP\Request('POST', '/foo', ['If-None-Match' => '*']);
+        $httpRequest = new ServerRequest('POST', '/foo', ['If-None-Match' => '*']);
         $httpResponse = new HTTP\Response();
-        $server->checkPreconditions($httpRequest, $httpResponse);
+        $server->checkPreconditions(new Psr7RequestWrapper($httpRequest), $httpResponse);
 
     }
 
@@ -116,9 +117,9 @@ class ServerPreconditionsTest extends \PHPUnit_Framework_TestCase {
 
         $root = new SimpleCollection('root', [new ServerPreconditionsNode()]);
         $server = new Server($root);
-        $httpRequest = new HTTP\Request('POST', '/foo', ['If-None-Match' => '"1234"']);
+        $httpRequest = new ServerRequest('POST', '/foo', ['If-None-Match' => '"1234"']);
         $httpResponse = new HTTP\Response();
-        $this->assertTrue($server->checkPreconditions($httpRequest, $httpResponse));
+        $this->assertTrue($server->checkPreconditions(new Psr7RequestWrapper($httpRequest), $httpResponse));
 
     }
 
@@ -128,35 +129,35 @@ class ServerPreconditionsTest extends \PHPUnit_Framework_TestCase {
 
         $root = new SimpleCollection('root', [new ServerPreconditionsNode()]);
         $server = new Server($root);
-        $httpRequest = new HTTP\Request('POST', '/foo', ['If-None-Match' => '"1234", "5678"']);
+        $httpRequest = new ServerRequest('POST', '/foo', ['If-None-Match' => '"1234", "5678"']);
         $httpResponse = new HTTP\Response();
-        $this->assertTrue($server->checkPreconditions($httpRequest, $httpResponse));
+        $this->assertTrue($server->checkPreconditions(new Psr7RequestWrapper($httpRequest), $httpResponse));
 
     }
 
     /**
-     * @expectedException Sabre\DAV\Exception\PreconditionFailed
+     * @expectedException \Sabre\DAV\Exception\PreconditionFailed
      */
     function testIfNoneMatchCorrectEtag() {
 
         $root = new SimpleCollection('root', [new ServerPreconditionsNode()]);
         $server = new Server($root);
-        $httpRequest = new HTTP\Request('POST', '/foo', ['If-None-Match' => '"abc123"']);
+        $httpRequest = new ServerRequest('POST', '/foo', ['If-None-Match' => '"abc123"']);
         $httpResponse = new HTTP\Response();
-        $server->checkPreconditions($httpRequest, $httpResponse);
+        $server->checkPreconditions(new Psr7RequestWrapper($httpRequest), $httpResponse);
 
     }
 
     /**
-     * @expectedException Sabre\DAV\Exception\PreconditionFailed
+     * @expectedException \Sabre\DAV\Exception\PreconditionFailed
      */
     function testIfNoneMatchCorrectEtagMultiple() {
 
         $root = new SimpleCollection('root', [new ServerPreconditionsNode()]);
         $server = new Server($root);
-        $httpRequest = new HTTP\Request('POST', '/foo', ['If-None-Match' => '"1234, "abc123"']);
+        $httpRequest = new ServerRequest('POST', '/foo', ['If-None-Match' => '"1234, "abc123"']);
         $httpResponse = new HTTP\Response();
-        $server->checkPreconditions($httpRequest, $httpResponse);
+        $server->checkPreconditions(new Psr7RequestWrapper($httpRequest), $httpResponse);
 
     }
 
@@ -166,8 +167,8 @@ class ServerPreconditionsTest extends \PHPUnit_Framework_TestCase {
 
         $root = new SimpleCollection('root', [new ServerPreconditionsNode()]);
         $server = new Server($root);
-        $httpRequest = new HTTP\Request('GET', '/foo', ['If-None-Match' => '"abc123"']);
-        $this->assertFalse($server->checkPreconditions($httpRequest, $server->httpResponse));
+        $httpRequest = new ServerRequest('GET', '/foo', ['If-None-Match' => '"abc123"']);
+        $this->assertFalse($server->checkPreconditions(new Psr7RequestWrapper($httpRequest), $server->httpResponse));
 
 
         $this->assertEquals(304, $server->httpResponse->getResponse()->getStatusCode());
@@ -182,21 +183,17 @@ class ServerPreconditionsTest extends \PHPUnit_Framework_TestCase {
 
         $root = new SimpleCollection('root', [new ServerPreconditionsNode()]);
         $server = new Server($root);
-        $server->sapi = new HTTP\SapiMock();
-        HTTP\SapiMock::$sent = 0;
-        $httpRequest = new HTTP\Request('GET', '/foo', ['If-None-Match' => '"abc123"']);
-        $server->httpRequest = $httpRequest;
-        $server->start();
+        $httpRequest = new ServerRequest('GET', '/foo', ['If-None-Match' => '"abc123"']);
+        $this->assertFalse($server->checkPreconditions(new Psr7RequestWrapper($httpRequest), $server->httpResponse));
 
-        $this->assertFalse($server->checkPreconditions($httpRequest, $server->httpResponse));
-        $response = $server->httpResponse->getResponse();
+        $response = $server->handle($httpRequest);
 
         $this->assertEquals(304, $response->getStatusCode());
         $this->assertEquals([
             'ETag'            => ['"abc123"'],
             'X-Sabre-Version' => [Version::VERSION],
         ], $response->getHeaders());
-        $this->assertEquals(1, HTTP\SapiMock::$sent);
+        $this->markTestIncomplete('Need new SAPI test.');
 
     }
 
@@ -206,10 +203,10 @@ class ServerPreconditionsTest extends \PHPUnit_Framework_TestCase {
 
         $root = new SimpleCollection('root', [new ServerPreconditionsNode()]);
         $server = new Server($root);
-        $httpRequest = new HTTP\Request('GET', '/foo', [
+        $httpRequest = new ServerRequest('GET', '/foo', [
             'If-Modified-Since' => 'Sun, 06 Nov 1994 08:49:37 GMT',
         ]);
-        $this->assertFalse($server->checkPreconditions($httpRequest, $server->httpResponse));
+        $this->assertFalse($server->checkPreconditions(new Psr7RequestWrapper($httpRequest), $server->httpResponse));
 
         $response = $server->httpResponse->getResponse();
         $this->assertEquals(304, $response->getStatusCode());
@@ -226,12 +223,12 @@ class ServerPreconditionsTest extends \PHPUnit_Framework_TestCase {
 
         $root = new SimpleCollection('root', [new ServerPreconditionsNode()]);
         $server = new Server($root);
-        $httpRequest = new HTTP\Request('GET', '/foo', [
+        $httpRequest = new ServerRequest('GET', '/foo', [
             'If-Modified-Since' => 'Tue, 06 Nov 1984 08:49:37 GMT',
         ]);
 
         $httpResponse = new HTTP\ResponseMock();
-        $this->assertTrue($server->checkPreconditions($httpRequest, $httpResponse));
+        $this->assertTrue($server->checkPreconditions(new Psr7RequestWrapper($httpRequest), $httpResponse));
 
     }
 
@@ -241,13 +238,13 @@ class ServerPreconditionsTest extends \PHPUnit_Framework_TestCase {
 
         $root = new SimpleCollection('root', [new ServerPreconditionsNode()]);
         $server = new Server($root);
-        $httpRequest = new HTTP\Request('GET', '/foo', [
+        $httpRequest = new ServerRequest('GET', '/foo', [
             'If-Modified-Since' => 'Your mother',
         ]);
         $httpResponse = new HTTP\ResponseMock();
 
         // Invalid dates must be ignored, so this should return true
-        $this->assertTrue($server->checkPreconditions($httpRequest, $httpResponse));
+        $this->assertTrue($server->checkPreconditions(new Psr7RequestWrapper($httpRequest), $httpResponse));
 
     }
 
@@ -257,11 +254,11 @@ class ServerPreconditionsTest extends \PHPUnit_Framework_TestCase {
 
         $root = new SimpleCollection('root', [new ServerPreconditionsNode()]);
         $server = new Server($root);
-        $httpRequest = new HTTP\Request('GET', '/foo', [
+        $httpRequest = new ServerRequest('GET', '/foo', [
             'If-Unmodified-Since' => 'Sun, 06 Nov 1994 08:49:37 EST',
         ]);
         $httpResponse = new HTTP\ResponseMock();
-        $this->assertTrue($server->checkPreconditions($httpRequest, $httpResponse));
+        $this->assertTrue($server->checkPreconditions(new Psr7RequestWrapper($httpRequest), $httpResponse));
 
     }
 
@@ -272,27 +269,27 @@ class ServerPreconditionsTest extends \PHPUnit_Framework_TestCase {
 
         $root = new SimpleCollection('root', [new ServerPreconditionsNode()]);
         $server = new Server($root);
-        $httpRequest = new HTTP\Request('GET', '/foo', [
+        $httpRequest = new ServerRequest('GET', '/foo', [
             'If-Unmodified-Since' => 'Sun, 06 Nov 1994 08:49:37 GMT',
         ]);
         $httpResponse = new HTTP\Response();
-        $this->assertTrue($server->checkPreconditions($httpRequest, $httpResponse));
+        $this->assertTrue($server->checkPreconditions(new Psr7RequestWrapper($httpRequest), $httpResponse));
 
     }
 
 
     /**
-     * @expectedException Sabre\DAV\Exception\PreconditionFailed
+     * @expectedException \Sabre\DAV\Exception\PreconditionFailed
      */
     function testIfUnmodifiedSinceModified() {
 
         $root = new SimpleCollection('root', [new ServerPreconditionsNode()]);
         $server = new Server($root);
-        $httpRequest = new HTTP\Request('GET', '/foo', [
+        $httpRequest = new ServerRequest('GET', '/foo', [
             'If-Unmodified-Since' => 'Tue, 06 Nov 1984 08:49:37 GMT',
         ]);
         $httpResponse = new HTTP\ResponseMock();
-        $server->checkPreconditions($httpRequest, $httpResponse);
+        $server->checkPreconditions(new Psr7RequestWrapper($httpRequest), $httpResponse);
 
     }
 
@@ -302,11 +299,11 @@ class ServerPreconditionsTest extends \PHPUnit_Framework_TestCase {
 
         $root = new SimpleCollection('root', [new ServerPreconditionsNode()]);
         $server = new Server($root);
-        $httpRequest = new HTTP\Request('GET', '/foo', [
+        $httpRequest = new ServerRequest('GET', '/foo', [
             'If-Unmodified-Since' => 'Sun, 06 Nov 1984 08:49:37 CET',
         ]);
         $httpResponse = new HTTP\ResponseMock();
-        $this->assertTrue($server->checkPreconditions($httpRequest, $httpResponse));
+        $this->assertTrue($server->checkPreconditions(new Psr7RequestWrapper($httpRequest), $httpResponse));
 
     }
 

--- a/tests/Sabre/DAV/ServerPreconditionTest.php
+++ b/tests/Sabre/DAV/ServerPreconditionTest.php
@@ -167,11 +167,11 @@ class ServerPreconditionsTest extends \PHPUnit_Framework_TestCase {
         $root = new SimpleCollection('root', [new ServerPreconditionsNode()]);
         $server = new Server($root);
         $httpRequest = new HTTP\Request('GET', '/foo', ['If-None-Match' => '"abc123"']);
-        $server->httpResponse = new HTTP\ResponseMock();
-
         $this->assertFalse($server->checkPreconditions($httpRequest, $server->httpResponse));
-        $this->assertEquals(304, $server->httpResponse->getStatus());
-        $this->assertEquals(['ETag' => ['"abc123"']], $server->httpResponse->getHeaders());
+
+
+        $this->assertEquals(304, $server->httpResponse->getResponse()->getStatusCode());
+        $this->assertEquals(['ETag' => ['"abc123"']], $server->httpResponse->getResponse()->getHeaders());
 
     }
 
@@ -186,16 +186,16 @@ class ServerPreconditionsTest extends \PHPUnit_Framework_TestCase {
         HTTP\SapiMock::$sent = 0;
         $httpRequest = new HTTP\Request('GET', '/foo', ['If-None-Match' => '"abc123"']);
         $server->httpRequest = $httpRequest;
-        $server->httpResponse = new HTTP\ResponseMock();
-
-        $server->exec();
+        $server->start();
 
         $this->assertFalse($server->checkPreconditions($httpRequest, $server->httpResponse));
-        $this->assertEquals(304, $server->httpResponse->getStatus());
+        $response = $server->httpResponse->getResponse();
+
+        $this->assertEquals(304, $response->getStatusCode());
         $this->assertEquals([
             'ETag'            => ['"abc123"'],
             'X-Sabre-Version' => [Version::VERSION],
-        ], $server->httpResponse->getHeaders());
+        ], $response->getHeaders());
         $this->assertEquals(1, HTTP\SapiMock::$sent);
 
     }
@@ -209,13 +209,13 @@ class ServerPreconditionsTest extends \PHPUnit_Framework_TestCase {
         $httpRequest = new HTTP\Request('GET', '/foo', [
             'If-Modified-Since' => 'Sun, 06 Nov 1994 08:49:37 GMT',
         ]);
-        $server->httpResponse = new HTTP\ResponseMock();
         $this->assertFalse($server->checkPreconditions($httpRequest, $server->httpResponse));
 
-        $this->assertEquals(304, $server->httpResponse->status);
+        $response = $server->httpResponse->getResponse();
+        $this->assertEquals(304, $response->getStatusCode());
         $this->assertEquals([
             'Last-Modified' => ['Sat, 06 Apr 1985 23:30:00 GMT'],
-        ], $server->httpResponse->getHeaders());
+        ], $response->getHeaders());
 
     }
 

--- a/tests/Sabre/DAV/ServerPreconditionTest.php
+++ b/tests/Sabre/DAV/ServerPreconditionTest.php
@@ -193,8 +193,6 @@ class ServerPreconditionsTest extends \PHPUnit_Framework_TestCase {
             'ETag'            => ['"abc123"'],
             'X-Sabre-Version' => [Version::VERSION],
         ], $response->getHeaders());
-        $this->markTestIncomplete('Need new SAPI test.');
-
     }
 
     /**

--- a/tests/Sabre/DAV/ServerPropsInfiniteDepthTest.php
+++ b/tests/Sabre/DAV/ServerPropsInfiniteDepthTest.php
@@ -49,7 +49,7 @@ class ServerPropsInfiniteDepthTest extends AbstractServer {
         $this->assertEquals(207, $response->getStatusCode(), 'Incorrect status received. Full response body: ' . $responseBody);
 
         $this->assertEquals([
-                'X-Sabre-Version' => [Version::VERSION],
+
                 'Content-Type'    => ['application/xml; charset=utf-8'],
                 'DAV'             => ['1, 3, extended-mkcol, 2'],
                 'Vary'            => ['Brief,Prefer'],

--- a/tests/Sabre/DAV/ServerPropsInfiniteDepthTest.php
+++ b/tests/Sabre/DAV/ServerPropsInfiniteDepthTest.php
@@ -2,6 +2,7 @@
 
 namespace Sabre\DAV;
 
+use GuzzleHttp\Psr7\ServerRequest;
 use Sabre\HTTP;
 
 require_once 'Sabre/DAV/AbstractServer.php';
@@ -36,12 +37,8 @@ class ServerPropsInfiniteDepthTest extends AbstractServer {
 
     private function sendRequest($body) {
 
-        $request = new HTTP\Request('PROPFIND', '/', ['Depth' => 'infinity']);
-        $request->setBody($body);
-
-        $this->server->httpRequest = $request;
-        $this->server->start();
-        return $this->server->httpResponse->getResponse();
+        $request = new ServerRequest('PROPFIND', '/', ['Depth' => 'infinity'], $body);
+        return $this->server->handle($request);
     }
 
     function testPropFindEmptyBody() {
@@ -82,10 +79,10 @@ class ServerPropsInfiniteDepthTest extends AbstractServer {
   </d:prop>
 </d:propfind>';
 
-        $this->sendRequest($xml);
+        $response = $this->sendRequest($xml);
 
-        $body = $this->getResponse()->getBody()->getContents();
-        $this->assertEquals(207, $this->getResponse()->getStatusCode(), $body);
+        $body = $response->getBody()->getContents();
+        $this->assertEquals(207, $response->getStatusCode(), $body);
 
         $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", "xmlns\\1=\"urn:DAV\"", $body);
         $xml = simplexml_load_string($body);
@@ -119,9 +116,9 @@ class ServerPropsInfiniteDepthTest extends AbstractServer {
   </d:prop>
 </d:propfind>';
 
-        $this->sendRequest($xml);
+        $response = $this->sendRequest($xml);
 
-        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", "xmlns\\1=\"urn:DAV\"", $this->getResponse()->getBody()->getContents());
+        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", "xmlns\\1=\"urn:DAV\"", $response->getBody()->getContents());
         $xml = simplexml_load_string($body);
         $xml->registerXPathNamespace('d', 'urn:DAV');
 
@@ -139,8 +136,8 @@ class ServerPropsInfiniteDepthTest extends AbstractServer {
   </d:prop>
 </d:propfind>';
 
-        $this->sendRequest($xml);
-        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", "xmlns\\1=\"urn:DAV\"", $this->getResponse()->getBody()->getContents());
+        $response = $this->sendRequest($xml);
+        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", "xmlns\\1=\"urn:DAV\"", $response->getBody()->getContents());
         $xml = simplexml_load_string($body);
         $xml->registerXPathNamespace('d', 'urn:DAV');
         $pathTests = [
@@ -170,8 +167,8 @@ class ServerPropsInfiniteDepthTest extends AbstractServer {
   </d:prop>
 </d:propfind>';
 
-        $this->sendRequest($xml);
-        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", "xmlns\\1=\"urn:DAV\"", $this->getResponse()->getBody()->getContents());
+        $response = $this->sendRequest($xml);
+        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", "xmlns\\1=\"urn:DAV\"", $response->getBody()->getContents());
         $xml = simplexml_load_string($body);
         $xml->registerXPathNamespace('d', 'urn:DAV');
         $pathTests = [

--- a/tests/Sabre/DAV/ServerPropsInfiniteDepthTest.php
+++ b/tests/Sabre/DAV/ServerPropsInfiniteDepthTest.php
@@ -40,15 +40,16 @@ class ServerPropsInfiniteDepthTest extends AbstractServer {
         $request->setBody($body);
 
         $this->server->httpRequest = $request;
-        $this->server->exec();
-
+        $this->server->start();
+        return $this->server->httpResponse->getResponse();
     }
 
     function testPropFindEmptyBody() {
 
-        $this->sendRequest("");
+        $response = $this->sendRequest("");
 
-        $this->assertEquals(207, $this->response->status, 'Incorrect status received. Full response body: ' . $this->response->getBodyAsString());
+        $responseBody = $response->getBody()->getContents();
+        $this->assertEquals(207, $response->getStatusCode(), 'Incorrect status received. Full response body: ' . $responseBody);
 
         $this->assertEquals([
                 'X-Sabre-Version' => [Version::VERSION],
@@ -56,10 +57,10 @@ class ServerPropsInfiniteDepthTest extends AbstractServer {
                 'DAV'             => ['1, 3, extended-mkcol, 2'],
                 'Vary'            => ['Brief,Prefer'],
             ],
-            $this->response->getHeaders()
+            $response->getHeaders()
          );
 
-        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", "xmlns\\1=\"urn:DAV\"", $this->response->body);
+        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", "xmlns\\1=\"urn:DAV\"", $responseBody);
         $xml = simplexml_load_string($body);
         $xml->registerXPathNamespace('d', 'urn:DAV');
 
@@ -83,8 +84,8 @@ class ServerPropsInfiniteDepthTest extends AbstractServer {
 
         $this->sendRequest($xml);
 
-        $body = $this->response->getBodyAsString();
-        $this->assertEquals(207, $this->response->getStatus(), $body);
+        $body = $this->getResponse()->getBody()->getContents();
+        $this->assertEquals(207, $this->getResponse()->getStatusCode(), $body);
 
         $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", "xmlns\\1=\"urn:DAV\"", $body);
         $xml = simplexml_load_string($body);
@@ -120,7 +121,7 @@ class ServerPropsInfiniteDepthTest extends AbstractServer {
 
         $this->sendRequest($xml);
 
-        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", "xmlns\\1=\"urn:DAV\"", $this->response->body);
+        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", "xmlns\\1=\"urn:DAV\"", $this->getResponse()->getBody()->getContents());
         $xml = simplexml_load_string($body);
         $xml->registerXPathNamespace('d', 'urn:DAV');
 
@@ -139,7 +140,7 @@ class ServerPropsInfiniteDepthTest extends AbstractServer {
 </d:propfind>';
 
         $this->sendRequest($xml);
-        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", "xmlns\\1=\"urn:DAV\"", $this->response->body);
+        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", "xmlns\\1=\"urn:DAV\"", $this->getResponse()->getBody()->getContents());
         $xml = simplexml_load_string($body);
         $xml->registerXPathNamespace('d', 'urn:DAV');
         $pathTests = [
@@ -170,7 +171,7 @@ class ServerPropsInfiniteDepthTest extends AbstractServer {
 </d:propfind>';
 
         $this->sendRequest($xml);
-        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", "xmlns\\1=\"urn:DAV\"", $this->response->body);
+        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", "xmlns\\1=\"urn:DAV\"", $this->getResponse()->getBody()->getContents());
         $xml = simplexml_load_string($body);
         $xml->registerXPathNamespace('d', 'urn:DAV');
         $pathTests = [

--- a/tests/Sabre/DAV/ServerPropsTest.php
+++ b/tests/Sabre/DAV/ServerPropsTest.php
@@ -48,7 +48,7 @@ class ServerPropsTest extends AbstractServer {
         $this->assertEquals(207, $response->getStatusCode());
 
         $this->assertEquals([
-                'X-Sabre-Version' => [Version::VERSION],
+
                 'Content-Type'    => ['application/xml; charset=utf-8'],
                 'DAV'             => ['1, 3, extended-mkcol, 2'],
                 'Vary'            => ['Brief,Prefer'],
@@ -74,7 +74,7 @@ class ServerPropsTest extends AbstractServer {
         $this->assertEquals(207, $response->getStatusCode());
 
         $this->assertEquals([
-                'X-Sabre-Version' => [Version::VERSION],
+
                 'Content-Type'    => ['application/xml; charset=utf-8'],
                 'DAV'             => ['1, 3, extended-mkcol, 2'],
                 'Vary'            => ['Brief,Prefer'],

--- a/tests/Sabre/DAV/ServerPropsTest.php
+++ b/tests/Sabre/DAV/ServerPropsTest.php
@@ -38,14 +38,14 @@ class ServerPropsTest extends AbstractServer {
         $request = new HTTP\Request('PROPFIND', $path, $headers, $body);
 
         $this->server->httpRequest = $request;
-        $this->server->exec();
+        $this->server->start();
 
     }
 
     function testPropFindEmptyBody() {
 
         $this->sendRequest("");
-        $this->assertEquals(207, $this->response->status);
+        $this->assertEquals(207, $this->getResponse()->getStatusCode());
 
         $this->assertEquals([
                 'X-Sabre-Version' => [Version::VERSION],
@@ -53,10 +53,10 @@ class ServerPropsTest extends AbstractServer {
                 'DAV'             => ['1, 3, extended-mkcol, 2'],
                 'Vary'            => ['Brief,Prefer'],
             ],
-            $this->response->getHeaders()
+            $this->getResponse()->getHeaders()
          );
 
-        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", "xmlns\\1=\"urn:DAV\"", $this->response->body);
+        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", "xmlns\\1=\"urn:DAV\"", $this->getResponse()->getBody()->getContents());
         $xml = simplexml_load_string($body);
         $xml->registerXPathNamespace('d', 'urn:DAV');
 
@@ -71,7 +71,7 @@ class ServerPropsTest extends AbstractServer {
     function testPropFindEmptyBodyFile() {
 
         $this->sendRequest("", '/test2.txt', []);
-        $this->assertEquals(207, $this->response->status);
+        $this->assertEquals(207, $this->getResponse()->getStatusCode());
 
         $this->assertEquals([
                 'X-Sabre-Version' => [Version::VERSION],
@@ -79,10 +79,10 @@ class ServerPropsTest extends AbstractServer {
                 'DAV'             => ['1, 3, extended-mkcol, 2'],
                 'Vary'            => ['Brief,Prefer'],
             ],
-            $this->response->getHeaders()
+            $this->getResponse()->getHeaders()
          );
 
-        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", "xmlns\\1=\"urn:DAV\"", $this->response->body);
+        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", "xmlns\\1=\"urn:DAV\"", $this->getResponse()->getBody()->getContents());
         $xml = simplexml_load_string($body);
         $xml->registerXPathNamespace('d', 'urn:DAV');
 
@@ -105,7 +105,7 @@ class ServerPropsTest extends AbstractServer {
 
         $this->sendRequest($xml);
 
-        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", "xmlns\\1=\"urn:DAV\"", $this->response->body);
+        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", "xmlns\\1=\"urn:DAV\"", $this->getResponse()->getBody()->getContents());
         $xml = simplexml_load_string($body);
         $xml->registerXPathNamespace('d', 'urn:DAV');
 
@@ -139,7 +139,7 @@ class ServerPropsTest extends AbstractServer {
 
         $this->sendRequest($xml);
 
-        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", "xmlns\\1=\"urn:DAV\"", $this->response->body);
+        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", "xmlns\\1=\"urn:DAV\"", $this->getResponse()->getBody()->getContents());
         $xml = simplexml_load_string($body);
         $xml->registerXPathNamespace('d', 'urn:DAV');
 
@@ -158,7 +158,7 @@ class ServerPropsTest extends AbstractServer {
 </d:propfind>';
 
         $this->sendRequest($xml);
-        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", "xmlns\\1=\"urn:DAV\"", $this->response->body);
+        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", "xmlns\\1=\"urn:DAV\"", $this->getResponse()->getBody()->getContents());
         $xml = simplexml_load_string($body);
         $xml->registerXPathNamespace('d', 'urn:DAV');
         $pathTests = [

--- a/tests/Sabre/DAV/ServerPropsTest.php
+++ b/tests/Sabre/DAV/ServerPropsTest.php
@@ -2,6 +2,7 @@
 
 namespace Sabre\DAV;
 
+use GuzzleHttp\Psr7\ServerRequest;
 use Sabre\HTTP;
 
 require_once 'Sabre/HTTP/ResponseMock.php';
@@ -35,17 +36,16 @@ class ServerPropsTest extends AbstractServer {
 
     private function sendRequest($body, $path = '/', $headers = ['Depth' => '0']) {
 
-        $request = new HTTP\Request('PROPFIND', $path, $headers, $body);
+        $request = new ServerRequest('PROPFIND', $path, $headers, $body);
+        return $this->server->handle($request);
 
-        $this->server->httpRequest = $request;
-        $this->server->start();
 
     }
 
     function testPropFindEmptyBody() {
 
-        $this->sendRequest("");
-        $this->assertEquals(207, $this->getResponse()->getStatusCode());
+        $response = $this->sendRequest("");
+        $this->assertEquals(207, $response->getStatusCode());
 
         $this->assertEquals([
                 'X-Sabre-Version' => [Version::VERSION],
@@ -53,10 +53,10 @@ class ServerPropsTest extends AbstractServer {
                 'DAV'             => ['1, 3, extended-mkcol, 2'],
                 'Vary'            => ['Brief,Prefer'],
             ],
-            $this->getResponse()->getHeaders()
+            $response->getHeaders()
          );
 
-        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", "xmlns\\1=\"urn:DAV\"", $this->getResponse()->getBody()->getContents());
+        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", "xmlns\\1=\"urn:DAV\"", $response->getBody()->getContents());
         $xml = simplexml_load_string($body);
         $xml->registerXPathNamespace('d', 'urn:DAV');
 
@@ -70,8 +70,8 @@ class ServerPropsTest extends AbstractServer {
 
     function testPropFindEmptyBodyFile() {
 
-        $this->sendRequest("", '/test2.txt', []);
-        $this->assertEquals(207, $this->getResponse()->getStatusCode());
+        $response = $this->sendRequest("", '/test2.txt', []);
+        $this->assertEquals(207, $response->getStatusCode());
 
         $this->assertEquals([
                 'X-Sabre-Version' => [Version::VERSION],
@@ -79,10 +79,10 @@ class ServerPropsTest extends AbstractServer {
                 'DAV'             => ['1, 3, extended-mkcol, 2'],
                 'Vary'            => ['Brief,Prefer'],
             ],
-            $this->getResponse()->getHeaders()
+            $response->getHeaders()
          );
 
-        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", "xmlns\\1=\"urn:DAV\"", $this->getResponse()->getBody()->getContents());
+        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", "xmlns\\1=\"urn:DAV\"", $response->getBody()->getContents());
         $xml = simplexml_load_string($body);
         $xml->registerXPathNamespace('d', 'urn:DAV');
 
@@ -103,9 +103,9 @@ class ServerPropsTest extends AbstractServer {
   </d:prop>
 </d:propfind>';
 
-        $this->sendRequest($xml);
+        $response = $this->sendRequest($xml);
 
-        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", "xmlns\\1=\"urn:DAV\"", $this->getResponse()->getBody()->getContents());
+        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", "xmlns\\1=\"urn:DAV\"", $response->getBody()->getContents());
         $xml = simplexml_load_string($body);
         $xml->registerXPathNamespace('d', 'urn:DAV');
 
@@ -137,9 +137,9 @@ class ServerPropsTest extends AbstractServer {
   </d:prop>
 </d:propfind>';
 
-        $this->sendRequest($xml);
+        $response = $this->sendRequest($xml);
 
-        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", "xmlns\\1=\"urn:DAV\"", $this->getResponse()->getBody()->getContents());
+        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", "xmlns\\1=\"urn:DAV\"", $response->getBody()->getContents());
         $xml = simplexml_load_string($body);
         $xml->registerXPathNamespace('d', 'urn:DAV');
 
@@ -157,8 +157,8 @@ class ServerPropsTest extends AbstractServer {
   </d:prop>
 </d:propfind>';
 
-        $this->sendRequest($xml);
-        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", "xmlns\\1=\"urn:DAV\"", $this->getResponse()->getBody()->getContents());
+        $response = $this->sendRequest($xml);
+        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", "xmlns\\1=\"urn:DAV\"", $response->getBody()->getContents());
         $xml = simplexml_load_string($body);
         $xml->registerXPathNamespace('d', 'urn:DAV');
         $pathTests = [

--- a/tests/Sabre/DAV/ServerRangeTest.php
+++ b/tests/Sabre/DAV/ServerRangeTest.php
@@ -48,7 +48,7 @@ class ServerRangeTest extends \Sabre\DAVServerTest {
         $responseBody = $response->getBody()->read($response->getHeaderLine('Content-Length'));
 
         $this->assertEquals([
-            'X-Sabre-Version' => [Version::VERSION],
+
             'Content-Type'    => ['application/octet-stream'],
             'Content-Length'  => [4],
             'Content-Range'   => ['bytes 2-5/13'],
@@ -71,7 +71,7 @@ class ServerRangeTest extends \Sabre\DAVServerTest {
         $response = $this->request($request);
 
         $this->assertEquals([
-            'X-Sabre-Version' => [Version::VERSION],
+
             'Content-Type'    => ['application/octet-stream'],
             'Content-Length'  => [11],
             'Content-Range'   => ['bytes 2-12/13'],
@@ -95,7 +95,7 @@ class ServerRangeTest extends \Sabre\DAVServerTest {
         $response = $this->request($request);
 
         $this->assertEquals([
-            'X-Sabre-Version' => [Version::VERSION],
+
             'Content-Type'    => ['application/octet-stream'],
             'Content-Length'  => [8],
             'Content-Range'   => ['bytes 5-12/13'],
@@ -141,7 +141,7 @@ class ServerRangeTest extends \Sabre\DAVServerTest {
 
         $this->assertEquals(206, $response->getStatusCode());
         $this->assertEquals([
-            'X-Sabre-Version' => [Version::VERSION],
+
             'Content-Type'    => ['application/octet-stream'],
             'Content-Length'  => [4],
             'Content-Range'   => ['bytes 2-5/12'],
@@ -167,7 +167,7 @@ class ServerRangeTest extends \Sabre\DAVServerTest {
         $response = $this->request($request);
 
         $this->assertEquals([
-            'X-Sabre-Version' => [Version::VERSION],
+
             'Content-Type'    => ['application/octet-stream'],
             'Content-Length'  => [4],
             'Content-Range'   => ['bytes 2-5/13'],
@@ -194,7 +194,7 @@ class ServerRangeTest extends \Sabre\DAVServerTest {
         $response = $this->request($request);
 
         $this->assertEquals([
-            'X-Sabre-Version' => [Version::VERSION],
+
             'Content-Type'    => ['application/octet-stream'],
             'Content-Length'  => [13],
             'ETag'            => ['"' . md5('Test contents') . '"'],
@@ -220,7 +220,7 @@ class ServerRangeTest extends \Sabre\DAVServerTest {
         $response = $this->request($request);
 
         $this->assertEquals([
-            'X-Sabre-Version' => [Version::VERSION],
+
             'Content-Type'    => ['application/octet-stream'],
             'Content-Length'  => [4],
             'Content-Range'   => ['bytes 2-5/13'],
@@ -247,7 +247,7 @@ class ServerRangeTest extends \Sabre\DAVServerTest {
         $response = $this->request($request);
 
         $this->assertEquals([
-            'X-Sabre-Version' => [Version::VERSION],
+
             'Content-Type'    => ['application/octet-stream'],
             'Content-Length'  => [13],
             'ETag'            => ['"' . md5('Test contents') . '"'],

--- a/tests/Sabre/DAV/ServerRangeTest.php
+++ b/tests/Sabre/DAV/ServerRangeTest.php
@@ -44,6 +44,7 @@ class ServerRangeTest extends \Sabre\DAVServerTest {
 
         $request = new HTTP\Request('GET', '/files/test.txt', ['Range' => 'bytes=2-5']);
         $response = $this->request($request);
+        $responseBody = $response->getBody()->read($response->getHeaderLine('Content-Length'));
 
         $this->assertEquals([
             'X-Sabre-Version' => [Version::VERSION],
@@ -55,8 +56,8 @@ class ServerRangeTest extends \Sabre\DAVServerTest {
             ],
             $response->getHeaders()
         );
-        $this->assertEquals(206, $response->getStatus());
-        $this->assertEquals('st c', $response->getBodyAsString());
+        $this->assertEquals(206, $response->getStatusCode());
+        $this->assertEquals('st c', $responseBody);
 
     }
 
@@ -79,8 +80,8 @@ class ServerRangeTest extends \Sabre\DAVServerTest {
             $response->getHeaders()
         );
 
-        $this->assertEquals(206, $response->getStatus());
-        $this->assertEquals('st contents', $response->getBodyAsString());
+        $this->assertEquals(206, $response->getStatusCode());
+        $this->assertEquals('st contents', $response->getBody()->getContents());
 
     }
 
@@ -103,8 +104,8 @@ class ServerRangeTest extends \Sabre\DAVServerTest {
             $response->getHeaders()
         );
 
-        $this->assertEquals(206, $response->getStatus());
-        $this->assertEquals('contents', $response->getBodyAsString());
+        $this->assertEquals(206, $response->getStatusCode());
+        $this->assertEquals('contents', $response->getBody()->getContents());
 
     }
 
@@ -116,7 +117,7 @@ class ServerRangeTest extends \Sabre\DAVServerTest {
         $request = new HTTP\Request('GET', '/files/test.txt', ['Range' => 'bytes=100-200']);
         $response = $this->request($request);
 
-        $this->assertEquals(416, $response->getStatus());
+        $this->assertEquals(416, $response->getStatusCode());
 
     }
 
@@ -128,7 +129,7 @@ class ServerRangeTest extends \Sabre\DAVServerTest {
         $request = new HTTP\Request('GET', '/files/test.txt', ['Range' => 'bytes=8-4']);
         $response = $this->request($request);
 
-        $this->assertEquals(416, $response->getStatus());
+        $this->assertEquals(416, $response->getStatusCode());
 
     }
 
@@ -137,7 +138,7 @@ class ServerRangeTest extends \Sabre\DAVServerTest {
         $request = new HTTP\Request('GET', '/files/no-seeking.txt', ['Range' => 'bytes=2-5']);
         $response = $this->request($request);
 
-        $this->assertEquals(206, $response->getStatus(), $response);
+        $this->assertEquals(206, $response->getStatusCode(), $response);
         $this->assertEquals([
             'X-Sabre-Version' => [Version::VERSION],
             'Content-Type'    => ['application/octet-stream'],
@@ -149,7 +150,7 @@ class ServerRangeTest extends \Sabre\DAVServerTest {
             $response->getHeaders()
         );
 
-        $this->assertEquals('st c', $response->getBodyAsString());
+        $this->assertEquals('st c', $response->getBody()->read($response->getHeaderLine('Content-Length')));
 
     }
 
@@ -175,8 +176,8 @@ class ServerRangeTest extends \Sabre\DAVServerTest {
             $response->getHeaders()
         );
 
-        $this->assertEquals(206, $response->getStatus());
-        $this->assertEquals('st c', $response->getBodyAsString());
+        $this->assertEquals(206, $response->getStatusCode());
+        $this->assertEquals('st c', $response->getBody()->read($response->getHeaderLine('Content-Length')));
 
     }
 
@@ -201,8 +202,8 @@ class ServerRangeTest extends \Sabre\DAVServerTest {
             $response->getHeaders()
         );
 
-        $this->assertEquals(200, $response->getStatus());
-        $this->assertEquals('Test contents', $response->getBodyAsString());
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('Test contents', $response->getBody()->getContents());
 
     }
 
@@ -228,8 +229,8 @@ class ServerRangeTest extends \Sabre\DAVServerTest {
             $response->getHeaders()
         );
 
-        $this->assertEquals(206, $response->getStatus());
-        $this->assertEquals('st c', $response->getBodyAsString());
+        $this->assertEquals(206, $response->getStatusCode());
+        $this->assertEquals('st c', $response->getBody()->read($response->getHeaderLine('Content-Length')));
 
     }
 
@@ -254,8 +255,8 @@ class ServerRangeTest extends \Sabre\DAVServerTest {
             $response->getHeaders()
         );
 
-        $this->assertEquals(200, $response->getStatus());
-        $this->assertEquals('Test contents', $response->getBodyAsString());
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('Test contents', $response->getBody()->getContents());
 
     }
 

--- a/tests/Sabre/DAV/ServerRangeTest.php
+++ b/tests/Sabre/DAV/ServerRangeTest.php
@@ -139,7 +139,7 @@ class ServerRangeTest extends \Sabre\DAVServerTest {
         $request = new ServerRequest('GET', '/files/no-seeking.txt', ['Range' => 'bytes=2-5']);
         $response = $this->request($request);
 
-        $this->assertEquals(206, $response->getStatusCode(), $response);
+        $this->assertEquals(206, $response->getStatusCode());
         $this->assertEquals([
             'X-Sabre-Version' => [Version::VERSION],
             'Content-Type'    => ['application/octet-stream'],

--- a/tests/Sabre/DAV/ServerRangeTest.php
+++ b/tests/Sabre/DAV/ServerRangeTest.php
@@ -3,6 +3,7 @@
 namespace Sabre\DAV;
 
 use DateTime;
+use GuzzleHttp\Psr7\ServerRequest;
 use Sabre\HTTP;
 
 /**
@@ -42,7 +43,7 @@ class ServerRangeTest extends \Sabre\DAVServerTest {
 
     function testRange() {
 
-        $request = new HTTP\Request('GET', '/files/test.txt', ['Range' => 'bytes=2-5']);
+        $request = new ServerRequest('GET', '/files/test.txt', ['Range' => 'bytes=2-5']);
         $response = $this->request($request);
         $responseBody = $response->getBody()->read($response->getHeaderLine('Content-Length'));
 
@@ -66,7 +67,7 @@ class ServerRangeTest extends \Sabre\DAVServerTest {
      */
     function testStartRange() {
 
-        $request = new HTTP\Request('GET', '/files/test.txt', ['Range' => 'bytes=2-']);
+        $request = new ServerRequest('GET', '/files/test.txt', ['Range' => 'bytes=2-']);
         $response = $this->request($request);
 
         $this->assertEquals([
@@ -90,7 +91,7 @@ class ServerRangeTest extends \Sabre\DAVServerTest {
      */
     function testEndRange() {
 
-        $request = new HTTP\Request('GET', '/files/test.txt', ['Range' => 'bytes=-8']);
+        $request = new ServerRequest('GET', '/files/test.txt', ['Range' => 'bytes=-8']);
         $response = $this->request($request);
 
         $this->assertEquals([
@@ -114,7 +115,7 @@ class ServerRangeTest extends \Sabre\DAVServerTest {
      */
     function testTooHighRange() {
 
-        $request = new HTTP\Request('GET', '/files/test.txt', ['Range' => 'bytes=100-200']);
+        $request = new ServerRequest('GET', '/files/test.txt', ['Range' => 'bytes=100-200']);
         $response = $this->request($request);
 
         $this->assertEquals(416, $response->getStatusCode());
@@ -126,7 +127,7 @@ class ServerRangeTest extends \Sabre\DAVServerTest {
      */
     function testCrazyRange() {
 
-        $request = new HTTP\Request('GET', '/files/test.txt', ['Range' => 'bytes=8-4']);
+        $request = new ServerRequest('GET', '/files/test.txt', ['Range' => 'bytes=8-4']);
         $response = $this->request($request);
 
         $this->assertEquals(416, $response->getStatusCode());
@@ -135,7 +136,7 @@ class ServerRangeTest extends \Sabre\DAVServerTest {
 
     function testNonSeekableStream() {
 
-        $request = new HTTP\Request('GET', '/files/no-seeking.txt', ['Range' => 'bytes=2-5']);
+        $request = new ServerRequest('GET', '/files/no-seeking.txt', ['Range' => 'bytes=2-5']);
         $response = $this->request($request);
 
         $this->assertEquals(206, $response->getStatusCode(), $response);
@@ -159,7 +160,7 @@ class ServerRangeTest extends \Sabre\DAVServerTest {
      */
     function testIfRangeEtag() {
 
-        $request = new HTTP\Request('GET', '/files/test.txt', [
+        $request = new ServerRequest('GET', '/files/test.txt', [
             'Range'    => 'bytes=2-5',
             'If-Range' => '"' . md5('Test contents') . '"',
         ]);
@@ -186,7 +187,7 @@ class ServerRangeTest extends \Sabre\DAVServerTest {
      */
     function testIfRangeEtagIncorrect() {
 
-        $request = new HTTP\Request('GET', '/files/test.txt', [
+        $request = new ServerRequest('GET', '/files/test.txt', [
             'Range'    => 'bytes=2-5',
             'If-Range' => '"foobar"',
         ]);
@@ -212,7 +213,7 @@ class ServerRangeTest extends \Sabre\DAVServerTest {
      */
     function testIfRangeModificationDate() {
 
-        $request = new HTTP\Request('GET', '/files/test.txt', [
+        $request = new ServerRequest('GET', '/files/test.txt', [
             'Range'    => 'bytes=2-5',
             'If-Range' => 'tomorrow',
         ]);
@@ -239,7 +240,7 @@ class ServerRangeTest extends \Sabre\DAVServerTest {
      */
     function testIfRangeModificationDateModified() {
 
-        $request = new HTTP\Request('GET', '/files/test.txt', [
+        $request = new ServerRequest('GET', '/files/test.txt', [
             'Range'    => 'bytes=2-5',
             'If-Range' => '-2 years',
         ]);

--- a/tests/Sabre/DAV/ServerSimpleTest.php
+++ b/tests/Sabre/DAV/ServerSimpleTest.php
@@ -13,7 +13,7 @@ class ServerSimpleTest extends AbstractServer{
             new SimpleCollection('hello')
         ];
 
-        $server = new Server($nodes);
+        $server = new Server($nodes, null, null, function() {});
         $this->assertEquals($nodes[0], $server->tree->getNodeForPath('hello'));
 
     }
@@ -23,9 +23,7 @@ class ServerSimpleTest extends AbstractServer{
      * @expectedException \Sabre\DAV\Exception
      */
     function testConstructInvalidArg() {
-
-        $server = new Server(1);
-
+        $server = new Server(1, null,  null, function() {});
     }
 
     function testOptions() {
@@ -40,7 +38,7 @@ class ServerSimpleTest extends AbstractServer{
             'Allow'           => ['OPTIONS, GET, HEAD, DELETE, PROPFIND, PUT, PROPPATCH, COPY, MOVE, REPORT'],
             'Accept-Ranges'   => ['bytes'],
             'Content-Length'  => ['0'],
-            'X-Sabre-Version' => [Version::VERSION],
+
         ], $response->getHeaders());
 
         $this->assertEquals(200, $response->getStatusCode());
@@ -61,7 +59,7 @@ class ServerSimpleTest extends AbstractServer{
             'Allow'           => ['OPTIONS, GET, HEAD, DELETE, PROPFIND, PUT, PROPPATCH, COPY, MOVE, REPORT, MKCOL'],
             'Accept-Ranges'   => ['bytes'],
             'Content-Length'  => ['0'],
-            'X-Sabre-Version' => [Version::VERSION],
+
         ], $response->getHeaders());
 
         $this->assertEquals(200, $response->getStatusCode());
@@ -74,7 +72,7 @@ class ServerSimpleTest extends AbstractServer{
         $response = $this->server->handle(new ServerRequest('BLABLA', '/'));
 
         $this->assertEquals([
-            'X-Sabre-Version' => [Version::VERSION],
+
             'Content-Type'    => ['application/xml; charset=utf-8'],
         ], $response->getHeaders());
 
@@ -95,7 +93,7 @@ class ServerSimpleTest extends AbstractServer{
 
 
         $this->assertEquals([
-            'X-Sabre-Version' => [Version::VERSION],
+
             'Content-Type'    => ['application/octet-stream'],
             'Content-Length'  => [13],
             'Last-Modified'   => [HTTP\toDate(new \DateTime('@' . filemtime($filename)))],
@@ -220,7 +218,7 @@ class ServerSimpleTest extends AbstractServer{
             'PATH_INFO'      => '/root',
             'REQUEST_URI' => '/index.php/root'
         ]);
-        $server = new Server();
+        $server = new Server(null, null, null, function(){});
 
         $this->assertEquals('/index.php/', $server->guessBaseUri($httpRequest));
 
@@ -236,7 +234,7 @@ class ServerSimpleTest extends AbstractServer{
             'REQUEST_URI' => '/index.php/dir/path2/path%20with%20spaces',
         ]);
 
-        $server = new Server();
+        $server = new Server(null, null, null, function(){});
         $this->assertEquals('/index.php/', $server->guessBaseUri($httpRequest));
 
     }
@@ -254,7 +252,7 @@ class ServerSimpleTest extends AbstractServer{
         ];
 
         $httpRequest = new ServerRequest($serverVars);
-        $server = new Server();
+        $server = new Server(null, null, null, function(){});
         $server->httpRequest = $httpRequest;
 
         $this->assertEquals('/some%20directory+mixed/index.php/', $server->guessBaseUri());
@@ -267,7 +265,7 @@ class ServerSimpleTest extends AbstractServer{
             'REQUEST_URI' => '/index.php/root/'
         ]);
 
-        $server = new Server();
+        $server = new Server(null, null, null, function(){});
         $this->assertEquals('/index.php/', $server->guessBaseUri($httpRequest));
 
     }
@@ -275,7 +273,7 @@ class ServerSimpleTest extends AbstractServer{
     function testGuessBaseUriNoPathInfo() {
 
         $httpRequest = new ServerRequest('GET', '/index.php/root');
-        $server = new Server();
+        $server = new Server(null, null, null, function(){});
         $this->assertEquals('/', $server->guessBaseUri($httpRequest));
 
     }
@@ -283,7 +281,7 @@ class ServerSimpleTest extends AbstractServer{
     function testGuessBaseUriNoPathInfo2() {
 
         $httpRequest = new ServerRequest('GET', '/a/b/c/test.php');
-        $server = new Server();
+        $server = new Server(null, null, null, function(){});
         $this->assertEquals('/', $server->guessBaseUri($httpRequest));
 
     }
@@ -297,7 +295,7 @@ class ServerSimpleTest extends AbstractServer{
             'REQUEST_URI' => '/index.php/root?query_string=blabla',
             'PATH_INFO'      => '/root',
         ]);
-        $server = new Server();
+        $server = new Server(null, null, null, function(){});
 
         $this->assertEquals('/index.php/', $server->guessBaseUri($httpRequest));
 
@@ -312,7 +310,7 @@ class ServerSimpleTest extends AbstractServer{
             'PATH_INFO'      => '/root',
             'REQUEST_URI' => '/index.php/root/heyyy',
         ]);
-        $server = new Server();
+        $server = new Server(null, null, null, function(){});
         $server->guessBaseUri($httpRequest);
 
     }
@@ -339,7 +337,7 @@ class ServerSimpleTest extends AbstractServer{
 
         $response = $this->server->handle($request);
         $this->assertEquals([
-            'X-Sabre-Version' => [Version::VERSION],
+
             'Content-Type'    => ['application/xml; charset=utf-8'],
             ],
             $response->getHeaders()
@@ -363,7 +361,7 @@ class ServerSimpleTest extends AbstractServer{
         $response = $this->server->handle($request);
 
         $this->assertEquals([
-            'X-Sabre-Version' => [Version::VERSION],
+
             'testheader'      => ['testvalue'],
             ],
             $response->getHeaders()

--- a/tests/Sabre/DAV/ServerSimpleTest.php
+++ b/tests/Sabre/DAV/ServerSimpleTest.php
@@ -268,7 +268,7 @@ class ServerSimpleTest extends AbstractServer{
         ]);
 
         $server = new Server();
-        $this->assertEquals('/index.php/', $server->guessBaseUri(new Psr7RequestWrapper($httpRequest)));
+        $this->assertEquals('/index.php/', $server->guessBaseUri($httpRequest));
 
     }
 
@@ -276,7 +276,7 @@ class ServerSimpleTest extends AbstractServer{
 
         $httpRequest = new ServerRequest('GET', '/index.php/root');
         $server = new Server();
-        $this->assertEquals('/', $server->guessBaseUri(new Psr7RequestWrapper($httpRequest)));
+        $this->assertEquals('/', $server->guessBaseUri($httpRequest));
 
     }
 
@@ -284,7 +284,7 @@ class ServerSimpleTest extends AbstractServer{
 
         $httpRequest = new ServerRequest('GET', '/a/b/c/test.php');
         $server = new Server();
-        $this->assertEquals('/', $server->guessBaseUri(new Psr7RequestWrapper($httpRequest)));
+        $this->assertEquals('/', $server->guessBaseUri($httpRequest));
 
     }
 
@@ -299,7 +299,7 @@ class ServerSimpleTest extends AbstractServer{
         ]);
         $server = new Server();
 
-        $this->assertEquals('/index.php/', $server->guessBaseUri(new Psr7RequestWrapper($httpRequest)));
+        $this->assertEquals('/index.php/', $server->guessBaseUri($httpRequest));
 
     }
 
@@ -313,7 +313,7 @@ class ServerSimpleTest extends AbstractServer{
             'REQUEST_URI' => '/index.php/root/heyyy',
         ]);
         $server = new Server();
-        $server->guessBaseUri(new Psr7RequestWrapper($httpRequest));
+        $server->guessBaseUri($httpRequest);
 
     }
 

--- a/tests/Sabre/DAV/ServerSimpleTest.php
+++ b/tests/Sabre/DAV/ServerSimpleTest.php
@@ -222,7 +222,7 @@ class ServerSimpleTest extends AbstractServer{
         ]);
         $server = new Server();
 
-        $this->assertEquals('/index.php/', $server->guessBaseUri(new Psr7RequestWrapper($httpRequest)));
+        $this->assertEquals('/index.php/', $server->guessBaseUri($httpRequest));
 
     }
 
@@ -237,7 +237,7 @@ class ServerSimpleTest extends AbstractServer{
         ]);
 
         $server = new Server();
-        $this->assertEquals('/index.php/', $server->guessBaseUri(new Psr7RequestWrapper($httpRequest)));
+        $this->assertEquals('/index.php/', $server->guessBaseUri($httpRequest));
 
     }
 

--- a/tests/Sabre/DAV/ServerUpdatePropertiesTest.php
+++ b/tests/Sabre/DAV/ServerUpdatePropertiesTest.php
@@ -9,7 +9,7 @@ class ServerUpdatePropertiesTest extends \PHPUnit_Framework_TestCase {
         $tree = [
             new SimpleCollection('foo'),
         ];
-        $server = new Server($tree);
+        $server = new Server($tree,null, null, function(){});
 
         $result = $server->updateProperties('foo', [
             '{DAV:}foo' => 'bar'
@@ -27,7 +27,7 @@ class ServerUpdatePropertiesTest extends \PHPUnit_Framework_TestCase {
         $tree = [
             new SimpleCollection('foo'),
         ];
-        $server = new Server($tree);
+        $server = new Server($tree, null, null, function(){});
 
         $server->on('propPatch', function($path, PropPatch $propPatch) {
             $propPatch->handleRemaining(function() { return true; });
@@ -50,7 +50,7 @@ class ServerUpdatePropertiesTest extends \PHPUnit_Framework_TestCase {
         $tree = [
             new SimpleCollection('foo'),
         ];
-        $server = new Server($tree);
+        $server = new Server($tree, null, null, function(){});
         $server->on('propPatch', function($path, PropPatch $propPatch) {
             $propPatch->setResultCode('{DAV:}foo', 404);
             $propPatch->handleRemaining(function() { return true; });
@@ -74,7 +74,7 @@ class ServerUpdatePropertiesTest extends \PHPUnit_Framework_TestCase {
         $tree = [
             new SimpleCollection('foo'),
         ];
-        $server = new Server($tree);
+        $server = new Server($tree, null, null, function(){});
         $server->on('propPatch', function($path, PropPatch $propPatch) {
 
             $propPatch->handle(['{DAV:}foo', '{DAV:}foo2'], function() {

--- a/tests/Sabre/DAV/Sharing/ShareResourceTest.php
+++ b/tests/Sabre/DAV/Sharing/ShareResourceTest.php
@@ -2,9 +2,9 @@
 
 namespace Sabre\DAV\Sharing;
 
+use GuzzleHttp\Psr7\ServerRequest;
 use Sabre\DAV\Mock;
 use Sabre\DAV\Xml\Element\Sharee;
-use Sabre\HTTP\Request;
 
 class ShareResourceTest extends \Sabre\DAVServerTest {
 
@@ -37,7 +37,7 @@ class ShareResourceTest extends \Sabre\DAVServerTest {
  </D:sharee>
 </D:share-resource>
 XML;
-        $request = new Request('POST', '/shareable', ['Content-Type' => 'application/davsharing+xml; charset="utf-8"'], $body);
+        $request = new ServerRequest('POST', '/shareable', ['Content-Type' => 'application/davsharing+xml; charset="utf-8"'], $body);
 
         $response = $this->request($request);
         $this->assertEquals(200, $response->getStatusCode(), $response->getBody()->getContents());
@@ -81,10 +81,9 @@ XML;
  </D:sharee>
 </D:share-resource>
 XML;
-        $request = new Request('POST', '/shareable', ['Content-Type' => 'application/davsharing+xml; charset="utf-8"'], $body);
+        $request = new ServerRequest('POST', '/shareable', ['Content-Type' => 'application/davsharing+xml; charset="utf-8"'], $body);
 
-        $response = $this->request($request);
-        $this->assertEquals(200, $response->getStatusCode(), $response->getBody()->getContents());
+        $this->request($request, 200);
 
         $expected = [];
 
@@ -115,11 +114,13 @@ XML;
   </D:prop>
 </D:propfind>
 XML;
-        $request = new Request('PROPFIND', '/shareable', ['Content-Type' => 'application/xml'], $body);
-        $response = $this->request($request);
 
-        $this->assertEquals(207, $response->getStatusCode());
-
+        $request = new ServerRequest('PROPFIND', '/shareable', [
+            'Content-Type' => 'application/xml'
+        ], $body);
+        $response = $this->request($request, 207);
+        $responseBody = $response->getBody()->getContents();
+        $this->assertNotEmpty($responseBody);
         $expected = <<<XML
 <?xml version="1.0" encoding="utf-8" ?>
 <d:multistatus xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns">
@@ -146,7 +147,7 @@ XML;
 </d:multistatus>
 XML;
 
-        $this->assertXmlStringEqualsXmlString($expected, $response->getBody()->getContents());
+        $this->assertXmlStringEqualsXmlString($expected, $responseBody);
 
     }
 
@@ -167,9 +168,9 @@ XML;
  </D:sharee>
 </D:share-resource>
 XML;
-        $request = new Request('POST', '/not-found', ['Content-Type' => 'application/davsharing+xml; charset="utf-8"'], $body);
+        $request = new ServerRequest('POST', '/not-found', ['Content-Type' => 'application/davsharing+xml; charset="utf-8"'], $body);
 
-        $response = $this->request($request, 404);
+        $this->request($request, 404);
 
     }
 
@@ -190,9 +191,9 @@ XML;
  </D:sharee>
 </D:share-resource>
 XML;
-        $request = new Request('POST', '/', ['Content-Type' => 'application/davsharing+xml; charset="utf-8"'], $body);
+        $request = new ServerRequest('POST', '/', ['Content-Type' => 'application/davsharing+xml; charset="utf-8"'], $body);
 
-        $response = $this->request($request, 403);
+        $this->request($request, 403);
 
     }
 
@@ -202,8 +203,8 @@ XML;
 <?xml version="1.0" encoding="utf-8" ?>
 <D:blablabla xmlns:D="DAV:" />
 XML;
-        $request = new Request('POST', '/shareable', ['Content-Type' => 'application/davsharing+xml; charset="utf-8"'], $body);
-        $response = $this->request($request, 400);
+        $request = new ServerRequest('POST', '/shareable', ['Content-Type' => 'application/davsharing+xml; charset="utf-8"'], $body);
+        $this->request($request, 400);
 
     }
 

--- a/tests/Sabre/DAV/Sharing/ShareResourceTest.php
+++ b/tests/Sabre/DAV/Sharing/ShareResourceTest.php
@@ -40,7 +40,7 @@ XML;
         $request = new Request('POST', '/shareable', ['Content-Type' => 'application/davsharing+xml; charset="utf-8"'], $body);
 
         $response = $this->request($request);
-        $this->assertEquals(200, $response->getStatus(), (string)$response->getBodyAsString());
+        $this->assertEquals(200, $response->getStatusCode(), $response->getBody()->getContents());
 
         $expected = [
             new Sharee([
@@ -84,7 +84,7 @@ XML;
         $request = new Request('POST', '/shareable', ['Content-Type' => 'application/davsharing+xml; charset="utf-8"'], $body);
 
         $response = $this->request($request);
-        $this->assertEquals(200, $response->getStatus(), (string)$response->getBodyAsString());
+        $this->assertEquals(200, $response->getStatusCode(), $response->getBody()->getContents());
 
         $expected = [];
 
@@ -118,7 +118,7 @@ XML;
         $request = new Request('PROPFIND', '/shareable', ['Content-Type' => 'application/xml'], $body);
         $response = $this->request($request);
 
-        $this->assertEquals(207, $response->getStatus());
+        $this->assertEquals(207, $response->getStatusCode());
 
         $expected = <<<XML
 <?xml version="1.0" encoding="utf-8" ?>
@@ -146,7 +146,7 @@ XML;
 </d:multistatus>
 XML;
 
-        $this->assertXmlStringEqualsXmlString($expected, $response->getBodyAsString());
+        $this->assertXmlStringEqualsXmlString($expected, $response->getBody()->getContents());
 
     }
 

--- a/tests/Sabre/DAV/StringUtilTest.php
+++ b/tests/Sabre/DAV/StringUtilTest.php
@@ -72,7 +72,7 @@ class StringUtilTest extends \PHPUnit_Framework_TestCase {
     }
 
     /**
-     * @expectedException Sabre\DAV\Exception\BadRequest
+     * @expectedException \Sabre\DAV\Exception\BadRequest
      */
     function testBadCollation() {
 
@@ -82,7 +82,7 @@ class StringUtilTest extends \PHPUnit_Framework_TestCase {
 
 
     /**
-     * @expectedException Sabre\DAV\Exception\BadRequest
+     * @expectedException \Sabre\DAV\Exception\BadRequest
      */
     function testBadMatchType() {
 

--- a/tests/Sabre/DAV/Sync/PluginTest.php
+++ b/tests/Sabre/DAV/Sync/PluginTest.php
@@ -93,10 +93,11 @@ BLA;
         $request->setBody($body);
 
         $response = $this->request($request);
+        $responseBody = $response->getBody()->getContents();
 
-        $this->assertEquals(207, $response->status, 'Full response body:' . $response->body);
+        $this->assertEquals(207, $response->getStatusCode(), 'Full response body:' . $responseBody);
 
-        $multiStatus = $this->server->xml->parse($response->getBodyAsString());
+        $multiStatus = $this->server->xml->parse($responseBody);
 
         // Checking the sync-token
         $this->assertEquals(
@@ -156,10 +157,10 @@ BLA;
         $request->setBody($body);
 
         $response = $this->request($request);
+        $responseBody =  $response->getBody()->getContents();
+        $this->assertEquals(207, $response->getStatusCode(), 'Full response body:' . $responseBody);
 
-        $this->assertEquals(207, $response->status, 'Full response body:' . $response->body);
-
-        $multiStatus = $this->server->xml->parse($response->getBodyAsString());
+        $multiStatus = $this->server->xml->parse($responseBody);
 
         // Checking the sync-token
         $this->assertEquals(
@@ -216,12 +217,10 @@ BLA;
         $request->setBody($body);
 
         $response = $this->request($request);
+        $responseBody = $response->getBody()->getContents();
+        $this->assertEquals(207, $response->getStatusCode(), 'Full response body:' . $responseBody);
 
-        $this->assertEquals(207, $response->status, 'Full response body:' . $response->body);
-
-        $multiStatus = $this->server->xml->parse(
-            $response->getBodyAsString()
-        );
+        $multiStatus = $this->server->xml->parse($responseBody);
 
         // Checking the sync-token
         $this->assertEquals(
@@ -267,12 +266,11 @@ BLA;
         $request->setBody($body);
 
         $response = $this->request($request);
+        $responseBody = $response->getBody()->getContents();
 
-        $this->assertEquals(207, $response->status, 'Full response body:' . $response->body);
+        $this->assertEquals(207, $response->getStatusCode(), 'Full response body:' . $responseBody);
 
-        $multiStatus = $this->server->xml->parse(
-            $response->getBodyAsString()
-        );
+        $multiStatus = $this->server->xml->parse($responseBody);
 
         // Checking the sync-token
         $this->assertEquals(
@@ -326,7 +324,7 @@ BLA;
 
         // The default state has no sync-token, so this report should not yet
         // be supported.
-        $this->assertEquals(415, $response->status, 'Full response body:' . $response->body);
+        $this->assertEquals(415, $response->getStatusCode(), 'Full response body:' . $response->getBody()->getContents());
 
     }
 
@@ -355,7 +353,7 @@ BLA;
 
         // The default state has no sync-token, so this report should not yet
         // be supported.
-        $this->assertEquals(415, $response->status, 'Full response body:' . $response->body);
+        $this->assertEquals(415, $response->getStatusCode(), 'Full response body:' . $response->getBody()->getContents());
 
     }
 
@@ -385,7 +383,7 @@ BLA;
 
         // The default state has no sync-token, so this report should not yet
         // be supported.
-        $this->assertEquals(403, $response->status, 'Full response body:' . $response->body);
+        $this->assertEquals(403, $response->getStatusCode(), 'Full response body:' . $response->getBody()->getContents());
 
     }
     function testSyncInvalidTokenNoPrefix() {
@@ -414,7 +412,7 @@ BLA;
 
         // The default state has no sync-token, so this report should not yet
         // be supported.
-        $this->assertEquals(403, $response->status, 'Full response body:' . $response->body);
+        $this->assertEquals(403, $response->getStatusCode(), 'Full response body:' . $response->getBody()->getContents());
 
     }
 
@@ -442,7 +440,7 @@ BLA;
 
         // The default state has no sync-token, so this report should not yet
         // be supported.
-        $this->assertEquals(400, $response->status, 'Full response body:' . $response->body);
+        $this->assertEquals(400, $response->getStatusCode(), 'Full response body:' . $response->getBody()->getContents());
 
     }
 
@@ -469,7 +467,7 @@ BLA;
 
         // The default state has no sync-token, so this report should not yet
         // be supported.
-        $this->assertEquals(400, $response->status, 'Full response body:' . $response->body);
+        $this->assertEquals(400, $response->getStatusCode(), 'Full response body:' . $response->getBody()->getContents());
 
     }
 
@@ -481,13 +479,7 @@ BLA;
             'REQUEST_URI'    => '/coll/file1.txt',
             'HTTP_IF'        => '</coll> (<http://sabre.io/ns/sync/1>)',
         ]);
-        $response = $this->request($request);
-
-        // If a 403 is thrown this works correctly. The file in questions
-        // doesn't allow itself to be deleted.
-        // If the If conditions failed, it would have been a 412 instead.
-        $this->assertEquals(403, $response->status);
-
+        $this->request($request, 403);
     }
 
     function testIfConditionsNot() {
@@ -498,13 +490,7 @@ BLA;
             'REQUEST_URI'    => '/coll/file1.txt',
             'HTTP_IF'        => '</coll> (Not <http://sabre.io/ns/sync/2>)',
         ]);
-        $response = $this->request($request);
-
-        // If a 403 is thrown this works correctly. The file in questions
-        // doesn't allow itself to be deleted.
-        // If the If conditions failed, it would have been a 412 instead.
-        $this->assertEquals(403, $response->status);
-
+        $this->request($request, 403);
     }
 
     function testIfConditionsNoSyncToken() {
@@ -515,9 +501,6 @@ BLA;
             'REQUEST_URI'    => '/coll/file1.txt',
             'HTTP_IF'        => '</coll> (<opaquelocktoken:foo>)',
         ]);
-        $response = $this->request($request);
-
-        $this->assertEquals(412, $response->status);
-
+        $this->request($request, 412);
     }
 }

--- a/tests/Sabre/DAV/Sync/PluginTest.php
+++ b/tests/Sabre/DAV/Sync/PluginTest.php
@@ -2,6 +2,7 @@
 
 namespace Sabre\DAV\Sync;
 
+use GuzzleHttp\Psr7\ServerRequest;
 use Sabre\DAV;
 use Sabre\HTTP;
 
@@ -77,7 +78,7 @@ class PluginTest extends \Sabre\DAVServerTest {
         // Making a change
         $this->collection->addChange(['file1.txt'], [], []);
 
-        $request = new HTTP\Request('REPORT', '/coll/', ['Content-Type' => 'application/xml']);
+
 
         $body = <<<BLA
 <?xml version="1.0" encoding="utf-8" ?>
@@ -90,7 +91,7 @@ class PluginTest extends \Sabre\DAVServerTest {
 </D:sync-collection>
 BLA;
 
-        $request->setBody($body);
+        $request = new ServerRequest('REPORT', '/coll/', ['Content-Type' => 'application/xml'], $body);
 
         $response = $this->request($request);
         $responseBody = $response->getBody()->getContents();
@@ -137,13 +138,9 @@ BLA;
         // Making another change
         $this->collection->addChange([], ['file2.txt'], ['file3.txt']);
 
-        $request = HTTP\Sapi::createFromServerArray([
-            'REQUEST_METHOD' => 'REPORT',
-            'REQUEST_URI'    => '/coll/',
-            'CONTENT_TYPE'   => 'application/xml',
-        ]);
-
-        $body = <<<BLA
+        $request = new ServerRequest('REPORT', '/coll/',
+            ['Content-Type' => 'application/xml'],
+            <<<BLA
 <?xml version="1.0" encoding="utf-8" ?>
 <D:sync-collection xmlns:D="DAV:">
      <D:sync-token>http://sabre.io/ns/sync/1</D:sync-token>
@@ -152,9 +149,9 @@ BLA;
         <D:getcontentlength/>
       </D:prop>
 </D:sync-collection>
-BLA;
+BLA
+        );
 
-        $request->setBody($body);
 
         $response = $this->request($request);
         $responseBody =  $response->getBody()->getContents();
@@ -196,11 +193,7 @@ BLA;
         // Making another change
         $this->collection->addChange([], ['file2.txt'], ['file3.txt']);
 
-        $request = HTTP\Sapi::createFromServerArray([
-            'REQUEST_METHOD' => 'REPORT',
-            'REQUEST_URI'    => '/coll/',
-            'CONTENT_TYPE'   => 'application/xml',
-        ]);
+
 
         $body = <<<BLA
 <?xml version="1.0" encoding="utf-8" ?>
@@ -214,7 +207,10 @@ BLA;
 </D:sync-collection>
 BLA;
 
-        $request->setBody($body);
+        $request = new ServerRequest('REPORT', '/coll/',
+            ['Content-Type' => 'application/xml'],
+            $body
+        );
 
         $response = $this->request($request);
         $responseBody = $response->getBody()->getContents();
@@ -246,12 +242,7 @@ BLA;
         // Making another change
         $this->collection->addChange([], ['file2.txt'], ['file3.txt']);
 
-        $request = HTTP\Sapi::createFromServerArray([
-            'REQUEST_METHOD' => 'REPORT',
-            'REQUEST_URI'    => '/coll/',
-            'CONTENT_TYPE'   => 'application/xml',
-            'HTTP_DEPTH'     => "1",
-        ]);
+
 
         $body = <<<BLA
 <?xml version="1.0" encoding="utf-8" ?>
@@ -263,7 +254,11 @@ BLA;
 </D:sync-collection>
 BLA;
 
-        $request->setBody($body);
+        $request = new ServerRequest('REPORT',
+            '/coll/',
+            ['Content-Type' => 'application/xml', 'Depth' => 1],
+            $body
+        );
 
         $response = $this->request($request);
         $responseBody = $response->getBody()->getContents();
@@ -301,11 +296,7 @@ BLA;
 
     function testSyncNoSyncInfo() {
 
-        $request = HTTP\Sapi::createFromServerArray([
-            'REQUEST_METHOD' => 'REPORT',
-            'REQUEST_URI'    => '/coll/',
-            'CONTENT_TYPE'   => 'application/xml',
-        ]);
+
 
         $body = <<<BLA
 <?xml version="1.0" encoding="utf-8" ?>
@@ -318,7 +309,12 @@ BLA;
 </D:sync-collection>
 BLA;
 
-        $request->setBody($body);
+        $request = new ServerRequest(
+            'REPORT',
+            '/coll/',
+            ['Content-Type' => 'application/xml'],
+            $body
+        );
 
         $response = $this->request($request);
 
@@ -330,12 +326,6 @@ BLA;
 
     function testSyncNoSyncCollection() {
 
-        $request = HTTP\Sapi::createFromServerArray([
-            'REQUEST_METHOD' => 'REPORT',
-            'REQUEST_URI'    => '/normalcoll/',
-            'CONTENT_TYPE'   => 'application/xml',
-        ]);
-
         $body = <<<BLA
 <?xml version="1.0" encoding="utf-8" ?>
 <D:sync-collection xmlns:D="DAV:">
@@ -347,7 +337,12 @@ BLA;
 </D:sync-collection>
 BLA;
 
-        $request->setBody($body);
+        $request = new ServerRequest(
+            'REPORT',
+            '/normalcoll/',
+            ['Content-Type' => 'application/xml'],
+            $body
+        );
 
         $response = $this->request($request);
 
@@ -360,11 +355,7 @@ BLA;
     function testSyncInvalidToken() {
 
         $this->collection->addChange(['file1.txt'], [], []);
-        $request = HTTP\Sapi::createFromServerArray([
-            'REQUEST_METHOD' => 'REPORT',
-            'REQUEST_URI'    => '/coll/',
-            'CONTENT_TYPE'   => 'application/xml',
-        ]);
+
 
         $body = <<<BLA
 <?xml version="1.0" encoding="utf-8" ?>
@@ -377,7 +368,12 @@ BLA;
 </D:sync-collection>
 BLA;
 
-        $request->setBody($body);
+        $request = new ServerRequest(
+            'REPORT',
+            '/coll/',
+            ['Content-Type' => 'application/xml'],
+            $body
+        );
 
         $response = $this->request($request);
 
@@ -389,11 +385,7 @@ BLA;
     function testSyncInvalidTokenNoPrefix() {
 
         $this->collection->addChange(['file1.txt'], [], []);
-        $request = HTTP\Sapi::createFromServerArray([
-            'REQUEST_METHOD' => 'REPORT',
-            'REQUEST_URI'    => '/coll/',
-            'CONTENT_TYPE'   => 'application/xml',
-        ]);
+
 
         $body = <<<BLA
 <?xml version="1.0" encoding="utf-8" ?>
@@ -406,7 +398,12 @@ BLA;
 </D:sync-collection>
 BLA;
 
-        $request->setBody($body);
+        $request = new ServerRequest(
+            'REPORT',
+            '/coll/',
+            ['Content-Type' => 'application/xml'],
+            $body
+        );
 
         $response = $this->request($request);
 
@@ -418,11 +415,7 @@ BLA;
 
     function testSyncNoSyncToken() {
 
-        $request = HTTP\Sapi::createFromServerArray([
-            'REQUEST_METHOD' => 'REPORT',
-            'REQUEST_URI'    => '/coll/',
-            'CONTENT_TYPE'   => 'application/xml',
-        ]);
+
 
         $body = <<<BLA
 <?xml version="1.0" encoding="utf-8" ?>
@@ -434,7 +427,12 @@ BLA;
 </D:sync-collection>
 BLA;
 
-        $request->setBody($body);
+        $request = new ServerRequest(
+            'REPORT',
+            '/coll/',
+            ['Content-Type' => 'application/xml'],
+            $body
+        );
 
         $response = $this->request($request);
 
@@ -447,11 +445,7 @@ BLA;
     function testSyncNoProp() {
 
         $this->collection->addChange(['file1.txt'], [], []);
-        $request = HTTP\Sapi::createFromServerArray([
-            'REQUEST_METHOD' => 'REPORT',
-            'REQUEST_URI'    => '/coll/',
-            'CONTENT_TYPE'   => 'application/xml',
-        ]);
+
 
         $body = <<<BLA
 <?xml version="1.0" encoding="utf-8" ?>
@@ -461,7 +455,12 @@ BLA;
 </D:sync-collection>
 BLA;
 
-        $request->setBody($body);
+        $request = new ServerRequest(
+            'REPORT',
+            '/coll/',
+            ['Content-Type' => 'application/xml'],
+            $body
+        );
 
         $response = $this->request($request);
 
@@ -474,21 +473,20 @@ BLA;
     function testIfConditions() {
 
         $this->collection->addChange(['file1.txt'], [], []);
-        $request = HTTP\Sapi::createFromServerArray([
-            'REQUEST_METHOD' => 'DELETE',
-            'REQUEST_URI'    => '/coll/file1.txt',
-            'HTTP_IF'        => '</coll> (<http://sabre.io/ns/sync/1>)',
-        ]);
+        $request = new ServerRequest(
+            'DELETE',
+            '/coll/file1.txt',
+            ['If' => '</coll> (<http://sabre.io/ns/sync/1>)']);
         $this->request($request, 403);
     }
 
     function testIfConditionsNot() {
 
         $this->collection->addChange(['file1.txt'], [], []);
-        $request = HTTP\Sapi::createFromServerArray([
-            'REQUEST_METHOD' => 'DELETE',
-            'REQUEST_URI'    => '/coll/file1.txt',
-            'HTTP_IF'        => '</coll> (Not <http://sabre.io/ns/sync/2>)',
+        $request = new ServerRequest(
+            'DELETE',
+            '/coll/file1.txt',
+            ['If'        => '</coll> (Not <http://sabre.io/ns/sync/2>)'
         ]);
         $this->request($request, 403);
     }
@@ -496,10 +494,10 @@ BLA;
     function testIfConditionsNoSyncToken() {
 
         $this->collection->addChange(['file1.txt'], [], []);
-        $request = HTTP\Sapi::createFromServerArray([
-            'REQUEST_METHOD' => 'DELETE',
-            'REQUEST_URI'    => '/coll/file1.txt',
-            'HTTP_IF'        => '</coll> (<opaquelocktoken:foo>)',
+        $request = new ServerRequest(
+            'DELETE',
+            '/coll/file1.txt',
+            ['If'=> '</coll> (<opaquelocktoken:foo>)'
         ]);
         $this->request($request, 412);
     }

--- a/tests/Sabre/DAV/TemporaryFileFilterTest.php
+++ b/tests/Sabre/DAV/TemporaryFileFilterTest.php
@@ -47,7 +47,8 @@ class TemporaryFileFilterTest extends AbstractServer {
         // mimicking an OS/X resource fork
         $request = new ServerRequest('PUT', '/._testput.txt', ['If-None-Match' => '*'], 'Testing new file');
 
-        $response = $this->server->handle($request, 201);
+        $response = $this->server->handle($request);
+        $this->assertEquals(201, $response->getStatusCode());
         $responseBody = $response->getBody()->getContents();
 
         $this->assertEquals('', $responseBody);
@@ -58,7 +59,8 @@ class TemporaryFileFilterTest extends AbstractServer {
 
         $this->assertFalse(file_exists(SABRE_TEMPDIR . '/._testput.txt'), '._testput.txt should not exist in the regular file structure.');
 
-        $response = $this->server->handle($request, 412);
+        $response = $this->server->handle($request);
+        $this->assertEquals(412, $response->getStatusCode());
         $this->assertEquals([
             'X-Sabre-Temp' => ['true'],
             'Content-Type' => ['application/xml; charset=utf-8'],

--- a/tests/Sabre/DAV/TemporaryFileFilterTest.php
+++ b/tests/Sabre/DAV/TemporaryFileFilterTest.php
@@ -19,11 +19,11 @@ class TemporaryFileFilterTest extends AbstractServer {
         $request = new HTTP\Request('PUT', '/testput.txt', [], 'Testing new file');
 
         $this->server->httpRequest = ($request);
-        $this->server->exec();
+        $this->server->start();
 
-        $this->assertEquals('', $this->response->body);
-        $this->assertEquals(201, $this->response->status);
-        $this->assertEquals('0', $this->response->getHeader('Content-Length'));
+        $this->assertEquals('', $this->getResponse()->getBody()->getContents());
+        $this->assertEquals(201, $this->getResponse()->getStatusCode());
+        $this->assertEquals('0', $this->getResponse()->getHeaderLine('Content-Length'));
 
         $this->assertEquals('Testing new file', file_get_contents(SABRE_TEMPDIR . '/testput.txt'));
 
@@ -35,13 +35,13 @@ class TemporaryFileFilterTest extends AbstractServer {
         $request = new HTTP\Request('PUT', '/._testput.txt', [], 'Testing new file');
 
         $this->server->httpRequest = ($request);
-        $this->server->exec();
+        $this->server->start();
 
-        $this->assertEquals('', $this->response->body);
-        $this->assertEquals(201, $this->response->status);
+        $this->assertEquals('', $this->getResponse()->getBody()->getContents());
+        $this->assertEquals(201, $this->getResponse()->getStatusCode());
         $this->assertEquals([
             'X-Sabre-Temp' => ['true'],
-        ], $this->response->getHeaders());
+        ], $this->getResponse()->getHeaders());
 
         $this->assertFalse(file_exists(SABRE_TEMPDIR . '/._testput.txt'), '._testput.txt should not exist in the regular file structure.');
 
@@ -53,24 +53,24 @@ class TemporaryFileFilterTest extends AbstractServer {
         $request = new HTTP\Request('PUT', '/._testput.txt', ['If-None-Match' => '*'], 'Testing new file');
 
         $this->server->httpRequest = ($request);
-        $this->server->exec();
+        $this->server->start();
 
-        $this->assertEquals('', $this->response->body);
-        $this->assertEquals(201, $this->response->status);
+        $this->assertEquals('', $this->getResponse()->getBody()->getContents());
+        $this->assertEquals(201, $this->getResponse()->getStatusCode());
         $this->assertEquals([
             'X-Sabre-Temp' => ['true'],
-        ], $this->response->getHeaders());
+        ], $this->getResponse()->getHeaders());
 
         $this->assertFalse(file_exists(SABRE_TEMPDIR . '/._testput.txt'), '._testput.txt should not exist in the regular file structure.');
 
 
-        $this->server->exec();
+        $this->server->start();
 
-        $this->assertEquals(412, $this->response->status);
+        $this->assertEquals(412, $this->getResponse()->getStatusCode());
         $this->assertEquals([
             'X-Sabre-Temp' => ['true'],
             'Content-Type' => ['application/xml; charset=utf-8'],
-        ], $this->response->getHeaders());
+        ], $this->getResponse()->getHeaders());
 
     }
 
@@ -79,27 +79,29 @@ class TemporaryFileFilterTest extends AbstractServer {
         // mimicking an OS/X resource fork
         $request = new HTTP\Request('PUT', '/._testput.txt', [], 'Testing new file');
         $this->server->httpRequest = ($request);
-        $this->server->exec();
+        $this->server->start();
 
-        $this->assertEquals('', $this->response->body);
-        $this->assertEquals(201, $this->response->status);
+        $this->assertEquals('', $this->getResponse()->getBody()->getContents());
+        $this->assertEquals(201, $this->getResponse()->getStatusCode());
         $this->assertEquals([
             'X-Sabre-Temp' => ['true'],
-        ], $this->response->getHeaders());
+        ], $this->getResponse()->getHeaders());
 
         $request = new HTTP\Request('GET', '/._testput.txt');
 
         $this->server->httpRequest = $request;
-        $this->server->exec();
+        $this->server->start();
 
-        $this->assertEquals(200, $this->response->status);
+
+
+        $this->assertEquals(200, $this->getResponse()->getStatusCode());
         $this->assertEquals([
             'X-Sabre-Temp'   => ['true'],
             'Content-Length' => [16],
             'Content-Type'   => ['application/octet-stream'],
-        ], $this->response->getHeaders());
+        ], $this->getResponse()->getHeaders());
 
-        $this->assertEquals('Testing new file', stream_get_contents($this->response->body));
+        $this->assertEquals('Testing new file', $this->getResponse()->getBody()->getContents());
 
     }
 
@@ -122,12 +124,12 @@ class TemporaryFileFilterTest extends AbstractServer {
 </D:lockinfo>');
 
         $this->server->httpRequest = ($request);
-        $this->server->exec();
+        $this->server->start();
 
-        $this->assertEquals(201, $this->response->status);
-        $this->assertEquals('application/xml; charset=utf-8', $this->response->getHeader('Content-Type'));
-        $this->assertTrue(preg_match('/^<opaquelocktoken:(.*)>$/', $this->response->getHeader('Lock-Token')) === 1, 'We did not get a valid Locktoken back (' . $this->response->getHeader('Lock-Token') . ')');
-        $this->assertEquals('true', $this->response->getHeader('X-Sabre-Temp'));
+        $this->assertEquals(201, $this->getResponse()->getStatusCode());
+        $this->assertEquals('application/xml; charset=utf-8', $this->getResponse()->getHeaderLine('Content-Type'));
+        $this->assertTrue(preg_match('/^<opaquelocktoken:(.*)>$/', $this->getResponse()->getHeaderLine('Lock-Token')) === 1, 'We did not get a valid Locktoken back (' . $this->getResponse()->getHeaderLine('Lock-Token') . ')');
+        $this->assertEquals('true', $this->getResponse()->getHeaderLine('X-Sabre-Temp'));
 
         $this->assertFalse(file_exists(SABRE_TEMPDIR . '/._testlock.txt'), '._testlock.txt should not exist in the regular file structure.');
 
@@ -139,24 +141,24 @@ class TemporaryFileFilterTest extends AbstractServer {
         $request = new HTTP\Request('PUT', '/._testput.txt', [], 'Testing new file');
 
         $this->server->httpRequest = $request;
-        $this->server->exec();
+        $this->server->start();
 
-        $this->assertEquals('', $this->response->body);
-        $this->assertEquals(201, $this->response->status);
+        $this->assertEquals('', $this->getResponse()->getBody()->getContents());
+        $this->assertEquals(201, $this->getResponse()->getStatusCode());
         $this->assertEquals([
             'X-Sabre-Temp' => ['true'],
-        ], $this->response->getHeaders());
+        ], $this->getResponse()->getHeaders());
 
         $request = new HTTP\Request('DELETE', '/._testput.txt');
         $this->server->httpRequest = $request;
-        $this->server->exec();
+        $this->server->start();
 
-        $this->assertEquals(204, $this->response->status, "Incorrect status code received. Full body:\n" . $this->response->body);
+        $this->assertEquals(204, $this->getResponse()->getStatusCode(), "Incorrect status code received. Full body:\n" . $this->getResponse()->getBody()->getContents());
         $this->assertEquals([
             'X-Sabre-Temp' => ['true'],
-        ], $this->response->getHeaders());
+        ], $this->getResponse()->getHeaders());
 
-        $this->assertEquals('', $this->response->body);
+        $this->assertEquals('', $this->getResponse()->getBody()->getContents());
 
     }
 
@@ -165,26 +167,27 @@ class TemporaryFileFilterTest extends AbstractServer {
         // mimicking an OS/X resource fork
         $request = new HTTP\Request('PUT', '/._testput.txt', [], 'Testing new file');
         $this->server->httpRequest = $request;
-        $this->server->exec();
+        $this->server->start();
 
-        $this->assertEquals('', $this->response->body);
-        $this->assertEquals(201, $this->response->status);
+        $this->assertEquals('', $this->getResponse()->getBody()->getContents());
+        $this->assertEquals(201, $this->getResponse()->getStatusCode());
         $this->assertEquals([
             'X-Sabre-Temp' => ['true'],
-        ], $this->response->getHeaders());
+        ], $this->getResponse()->getHeaders());
 
         $request = new HTTP\Request('PROPFIND', '/._testput.txt');
 
         $this->server->httpRequest = ($request);
-        $this->server->exec();
+        $this->server->start();
 
-        $this->assertEquals(207, $this->response->status, 'Incorrect status code returned. Body: ' . $this->response->body);
+        $responseBody = $this->getResponse()->getBody()->getContents();
+        $this->assertEquals(207, $this->getResponse()->getStatusCode(), 'Incorrect status code returned. Body: ' . $responseBody);
         $this->assertEquals([
             'X-Sabre-Temp' => ['true'],
             'Content-Type' => ['application/xml; charset=utf-8'],
-        ], $this->response->getHeaders());
+        ], $this->getResponse()->getHeaders());
 
-        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", "xmlns\\1=\"urn:DAV\"", $this->response->body);
+        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", "xmlns\\1=\"urn:DAV\"", $responseBody);
         $xml = simplexml_load_string($body);
         $xml->registerXPathNamespace('d', 'urn:DAV');
 

--- a/tests/Sabre/DAV/Xml/Property/SupportedReportSetTest.php
+++ b/tests/Sabre/DAV/Xml/Property/SupportedReportSetTest.php
@@ -22,7 +22,7 @@ class SupportedReportSetTest extends DAV\AbstractServer {
         $request->setBody($body);
 
         $this->server->httpRequest = ($request);
-        $this->server->exec();
+        $this->server->start();
 
     }
 
@@ -39,9 +39,11 @@ class SupportedReportSetTest extends DAV\AbstractServer {
 
         $this->sendPROPFIND($xml);
 
-        $this->assertEquals(207, $this->response->status, 'We expected a multi-status response. Full response body: ' . $this->response->body);
+        $responseBody = $this->getResponse()->getBody()->getContents();
+        $this->assertEquals(207, $this->getResponse()->getStatusCode(), 'We expected a multi-status response. Full response body: ' . $responseBody);
 
-        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", "xmlns\\1=\"urn:DAV\"", $this->response->body);
+
+        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", "xmlns\\1=\"urn:DAV\"", $responseBody);
         $xml = simplexml_load_string($body);
         $xml->registerXPathNamespace('d', 'urn:DAV');
 
@@ -79,10 +81,11 @@ class SupportedReportSetTest extends DAV\AbstractServer {
 </d:propfind>';
 
         $this->sendPROPFIND($xml);
+        $responseBody = $this->getResponse()->getBody()->getContents();
 
-        $this->assertEquals(207, $this->response->status, 'We expected a multi-status response. Full response body: ' . $this->response->body);
+        $this->assertEquals(207, $this->getResponse()->getStatusCode(), 'We expected a multi-status response. Full response body: ' . $responseBody);
 
-        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", "xmlns\\1=\"urn:DAV\"", $this->response->body);
+        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", "xmlns\\1=\"urn:DAV\"", $responseBody);
         $xml = simplexml_load_string($body);
         $xml->registerXPathNamespace('d', 'urn:DAV');
         $xml->registerXPathNamespace('x', 'http://www.rooftopsolutions.nl/testnamespace');
@@ -100,10 +103,10 @@ class SupportedReportSetTest extends DAV\AbstractServer {
         $this->assertEquals(2, count($data), 'We expected 2 \'d:report\' elements');
 
         $data = $xml->xpath('/d:multistatus/d:response/d:propstat/d:prop/d:supported-report-set/d:supported-report/d:report/x:myreport');
-        $this->assertEquals(1, count($data), 'We expected 1 \'x:myreport\' element. Full body: ' . $this->response->body);
+        $this->assertEquals(1, count($data), 'We expected 1 \'x:myreport\' element. Full body: ' . $responseBody);
 
         $data = $xml->xpath('/d:multistatus/d:response/d:propstat/d:prop/d:supported-report-set/d:supported-report/d:report/d:anotherreport');
-        $this->assertEquals(1, count($data), 'We expected 1 \'d:anotherreport\' element. Full body: ' . $this->response->body);
+        $this->assertEquals(1, count($data), 'We expected 1 \'d:anotherreport\' element. Full body: ' . $responseBody);
 
         $data = $xml->xpath('/d:multistatus/d:response/d:propstat/d:status');
         $this->assertEquals(1, count($data), 'We expected 1 \'d:status\' element');

--- a/tests/Sabre/DAV/Xml/Property/SupportedReportSetTest.php
+++ b/tests/Sabre/DAV/Xml/Property/SupportedReportSetTest.php
@@ -2,6 +2,7 @@
 
 namespace Sabre\DAV\Property;
 
+use GuzzleHttp\Psr7\ServerRequest;
 use Sabre\DAV;
 use Sabre\HTTP;
 
@@ -11,18 +12,10 @@ require_once 'Sabre/DAV/AbstractServer.php';
 class SupportedReportSetTest extends DAV\AbstractServer {
 
     function sendPROPFIND($body) {
+        $request = new ServerRequest('PROPFIND', '/', ['Depth' => '0'], $body);
 
-        $serverVars = [
-            'REQUEST_URI'    => '/',
-            'REQUEST_METHOD' => 'PROPFIND',
-            'HTTP_DEPTH'     => '0',
-        ];
+        return $this->server->handle($request);
 
-        $request = HTTP\Sapi::createFromServerArray($serverVars);
-        $request->setBody($body);
-
-        $this->server->httpRequest = ($request);
-        $this->server->start();
 
     }
 
@@ -37,10 +30,10 @@ class SupportedReportSetTest extends DAV\AbstractServer {
   </d:prop>
 </d:propfind>';
 
-        $this->sendPROPFIND($xml);
+        $response = $this->sendPROPFIND($xml);
 
-        $responseBody = $this->getResponse()->getBody()->getContents();
-        $this->assertEquals(207, $this->getResponse()->getStatusCode(), 'We expected a multi-status response. Full response body: ' . $responseBody);
+        $responseBody = $response->getBody()->getContents();
+        $this->assertEquals(207, $response->getStatusCode(), 'We expected a multi-status response. Full response body: ' . $responseBody);
 
 
         $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", "xmlns\\1=\"urn:DAV\"", $responseBody);
@@ -80,10 +73,10 @@ class SupportedReportSetTest extends DAV\AbstractServer {
   </d:prop>
 </d:propfind>';
 
-        $this->sendPROPFIND($xml);
-        $responseBody = $this->getResponse()->getBody()->getContents();
+        $response = $this->sendPROPFIND($xml);
+        $responseBody = $response->getBody()->getContents();
 
-        $this->assertEquals(207, $this->getResponse()->getStatusCode(), 'We expected a multi-status response. Full response body: ' . $responseBody);
+        $this->assertEquals(207, $response->getStatusCode(), 'We expected a multi-status response. Full response body: ' . $responseBody);
 
         $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", "xmlns\\1=\"urn:DAV\"", $responseBody);
         $xml = simplexml_load_string($body);

--- a/tests/Sabre/DAVACL/ACLMethodTest.php
+++ b/tests/Sabre/DAVACL/ACLMethodTest.php
@@ -40,7 +40,7 @@ class ACLMethodTest extends \PHPUnit_Framework_TestCase {
         $request = new ServerRequest('GET', '/', [], $body);
         $server->addPlugin(new DAV\Auth\Plugin());
         $server->addPlugin($acl);
-
+        $server->handle($request);
         $acl->httpACL(new DAV\Psr7RequestWrapper($request), $server->httpResponse);
 
     }
@@ -61,7 +61,7 @@ class ACLMethodTest extends \PHPUnit_Framework_TestCase {
 
         $server->addPlugin(new DAV\Auth\Plugin());
         $server->addPlugin($acl);
-
+        $server->handle($request);
         $this->assertFalse($acl->httpACL(new DAV\Psr7RequestWrapper($request), $server->httpResponse));
 
     }
@@ -87,7 +87,7 @@ class ACLMethodTest extends \PHPUnit_Framework_TestCase {
         $request = new ServerRequest('ACL', '/test', [], $body);
         $server->addPlugin(new DAV\Auth\Plugin());
         $server->addPlugin($acl);
-
+        $server->handle($request);
         $acl->httpACL(new DAV\Psr7RequestWrapper($request), $server->httpResponse);
 
     }
@@ -116,7 +116,7 @@ class ACLMethodTest extends \PHPUnit_Framework_TestCase {
         $request = new ServerRequest('ACL', '/test', [], $body);
         $server->addPlugin(new DAV\Auth\Plugin());
         $server->addPlugin($acl);
-
+        $server->handle($request);
         $acl->httpACL(new DAV\Psr7RequestWrapper($request), $server->httpResponse);
 
     }
@@ -142,7 +142,7 @@ class ACLMethodTest extends \PHPUnit_Framework_TestCase {
         $request = new ServerRequest('ACL', '/test', [], $body);
         $server->addPlugin(new DAV\Auth\Plugin());
         $server->addPlugin($acl);
-
+        $server->handle($request);
         $acl->httpACL(new DAV\Psr7RequestWrapper($request), $server->httpResponse);
 
     }
@@ -171,7 +171,7 @@ class ACLMethodTest extends \PHPUnit_Framework_TestCase {
         $request = new ServerRequest('ACL', '/test', [], $body);
         $server->addPlugin(new DAV\Auth\Plugin());
         $server->addPlugin($acl);
-
+        $server->handle($request);
         $acl->httpACL(new DAV\Psr7RequestWrapper($request), $server->httpResponse);
 
     }
@@ -205,7 +205,7 @@ class ACLMethodTest extends \PHPUnit_Framework_TestCase {
         $request = new ServerRequest('ACL', '/test', [], $body);
         $server->addPlugin(new DAV\Auth\Plugin());
         $server->addPlugin($acl);
-
+        $server->handle($request);
         $acl->httpACL(new DAV\Psr7RequestWrapper($request), $server->httpResponse);
 
     }
@@ -239,7 +239,7 @@ class ACLMethodTest extends \PHPUnit_Framework_TestCase {
         $request = new ServerRequest('ACL', '/test', [], $body);
         $server->addPlugin(new DAV\Auth\Plugin());
         $server->addPlugin($acl);
-
+        $server->handle($request);
         $acl->httpACL(new DAV\Psr7RequestWrapper($request), $server->httpResponse);
 
     }
@@ -273,7 +273,7 @@ class ACLMethodTest extends \PHPUnit_Framework_TestCase {
         $request = new ServerRequest('ACL', '/test', [], $body);
         $server->addPlugin(new DAV\Auth\Plugin());
         $server->addPlugin($acl);
-
+        $server->handle($request);
         $acl->httpACL(new DAV\Psr7RequestWrapper($request), $server->httpResponse);
 
     }

--- a/tests/Sabre/DAVACL/ACLMethodTest.php
+++ b/tests/Sabre/DAVACL/ACLMethodTest.php
@@ -14,7 +14,7 @@ class ACLMethodTest extends \PHPUnit_Framework_TestCase {
     function testCallback() {
 
         $acl = new Plugin();
-        $server = new DAV\Server();
+        $server = new DAV\Server(null, null, null, function(){});
         $server->addPlugin(new DAV\Auth\Plugin());
         $server->addPlugin($acl);
 
@@ -32,7 +32,7 @@ class ACLMethodTest extends \PHPUnit_Framework_TestCase {
             new DAV\SimpleCollection('test'),
         ];
         $acl = new Plugin();
-        $server = new DAV\Server($tree);
+        $server = new DAV\Server($tree, null, null, function() {});
 
         $body = '<?xml version="1.0"?>
 <d:acl xmlns:d="DAV:">
@@ -51,7 +51,7 @@ class ACLMethodTest extends \PHPUnit_Framework_TestCase {
             new MockACLNode('test', []),
         ];
         $acl = new Plugin();
-        $server = new DAV\Server($tree);
+        $server = new DAV\Server($tree, null, null, function() {});
 
 
         $body = '<?xml version="1.0"?>
@@ -75,7 +75,7 @@ class ACLMethodTest extends \PHPUnit_Framework_TestCase {
             new MockACLNode('test', []),
         ];
         $acl = new Plugin();
-        $server = new DAV\Server($tree);
+        $server = new DAV\Server($tree, null, null, function() {});
 
         $body = '<?xml version="1.0"?>
 <d:acl xmlns:d="DAV:">
@@ -104,7 +104,7 @@ class ACLMethodTest extends \PHPUnit_Framework_TestCase {
             ]),
         ];
         $acl = new Plugin();
-        $server = new DAV\Server($tree);
+        $server = new DAV\Server($tree, null, null, function() {});
 
         $body = '<?xml version="1.0"?>
 <d:acl xmlns:d="DAV:">
@@ -130,7 +130,7 @@ class ACLMethodTest extends \PHPUnit_Framework_TestCase {
             new MockACLNode('test', []),
         ];
         $acl = new Plugin();
-        $server = new DAV\Server($tree);
+        $server = new DAV\Server($tree, null, null, function() {});
 
         $body = '<?xml version="1.0"?>
 <d:acl xmlns:d="DAV:">
@@ -156,7 +156,7 @@ class ACLMethodTest extends \PHPUnit_Framework_TestCase {
             new MockACLNode('test', []),
         ];
         $acl = new Plugin();
-        $server = new DAV\Server($tree);
+        $server = new DAV\Server($tree, null, null, function() {});
         $server->on('getSupportedPrivilegeSet', function($node, &$supportedPrivilegeSet) {
             $supportedPrivilegeSet['{DAV:}foo'] = ['abstract' => true];
         });
@@ -193,7 +193,7 @@ class ACLMethodTest extends \PHPUnit_Framework_TestCase {
             new MockACLNode('test', $oldACL),
         ];
         $acl = new Plugin();
-        $server = new DAV\Server($tree);
+        $server = new DAV\Server($tree, null, null, function() {});
 
         $body = '<?xml version="1.0"?>
 <d:acl xmlns:d="DAV:">
@@ -227,7 +227,7 @@ class ACLMethodTest extends \PHPUnit_Framework_TestCase {
             new MockACLNode('test', $oldACL),
         ];
         $acl = new Plugin();
-        $server = new DAV\Server($tree);
+        $server = new DAV\Server($tree, null, null, function() {});
 
         $body = '<?xml version="1.0"?>
 <d:acl xmlns:d="DAV:">
@@ -261,7 +261,7 @@ class ACLMethodTest extends \PHPUnit_Framework_TestCase {
             new MockACLNode('test', $oldACL),
         ];
         $acl = new Plugin();
-        $server = new DAV\Server($tree);
+        $server = new DAV\Server($tree, null, null, function() {});
 
         $body = '<?xml version="1.0"?>
 <d:acl xmlns:d="DAV:">
@@ -300,7 +300,7 @@ class ACLMethodTest extends \PHPUnit_Framework_TestCase {
             ]),
         ];
         $acl = new Plugin();
-        $server = new DAV\Server($tree);
+        $server = new DAV\Server($tree, null, null, function() {});
 
         $body = '<?xml version="1.0"?>
 <d:acl xmlns:d="DAV:">

--- a/tests/Sabre/DAVACL/ACLMethodTest.php
+++ b/tests/Sabre/DAVACL/ACLMethodTest.php
@@ -2,13 +2,14 @@
 
 namespace Sabre\DAVACL;
 
+use GuzzleHttp\Psr7\ServerRequest;
 use Sabre\DAV;
 use Sabre\HTTP;
 
 class ACLMethodTest extends \PHPUnit_Framework_TestCase {
 
     /**
-     * @expectedException Sabre\DAV\Exception\BadRequest
+     * @expectedException \Sabre\DAV\Exception\BadRequest
      */
     function testCallback() {
 
@@ -17,13 +18,13 @@ class ACLMethodTest extends \PHPUnit_Framework_TestCase {
         $server->addPlugin(new DAV\Auth\Plugin());
         $server->addPlugin($acl);
 
-        $acl->httpAcl($server->httpRequest, $server->httpResponse);
+        $acl->httpACL(new DAV\Psr7RequestWrapper(new ServerRequest('GET', '/')), $server->httpResponse);
 
     }
 
     /**
      /**
-     * @expectedException Sabre\DAV\Exception\MethodNotAllowed
+     * @expectedException \Sabre\DAV\Exception\MethodNotAllowed
      */
     function testNotSupportedByNode() {
 
@@ -32,15 +33,15 @@ class ACLMethodTest extends \PHPUnit_Framework_TestCase {
         ];
         $acl = new Plugin();
         $server = new DAV\Server($tree);
-        $server->httpRequest = new HTTP\Request('GET', '/');
+
         $body = '<?xml version="1.0"?>
 <d:acl xmlns:d="DAV:">
 </d:acl>';
-        $server->httpRequest->setBody($body);
+        $request = new ServerRequest('GET', '/', [], $body);
         $server->addPlugin(new DAV\Auth\Plugin());
         $server->addPlugin($acl);
 
-        $acl->httpACL($server->httpRequest, $server->httpResponse);
+        $acl->httpACL(new DAV\Psr7RequestWrapper($request), $server->httpResponse);
 
     }
 
@@ -51,22 +52,22 @@ class ACLMethodTest extends \PHPUnit_Framework_TestCase {
         ];
         $acl = new Plugin();
         $server = new DAV\Server($tree);
-        $server->httpRequest = new HTTP\Request('GET', '/');
-        $server->httpRequest->setUrl('/test');
+
 
         $body = '<?xml version="1.0"?>
 <d:acl xmlns:d="DAV:">
 </d:acl>';
-        $server->httpRequest->setBody($body);
+        $request = new ServerRequest('GET', '/test', [], $body);
+
         $server->addPlugin(new DAV\Auth\Plugin());
         $server->addPlugin($acl);
 
-        $this->assertFalse($acl->httpACL($server->httpRequest, $server->httpResponse));
+        $this->assertFalse($acl->httpACL(new DAV\Psr7RequestWrapper($request), $server->httpResponse));
 
     }
 
     /**
-     * @expectedException Sabre\DAVACL\Exception\NotRecognizedPrincipal
+     * @expectedException \Sabre\DAVACL\Exception\NotRecognizedPrincipal
      */
     function testUnrecognizedPrincipal() {
 
@@ -75,7 +76,7 @@ class ACLMethodTest extends \PHPUnit_Framework_TestCase {
         ];
         $acl = new Plugin();
         $server = new DAV\Server($tree);
-        $server->httpRequest = new HTTP\Request('ACL', '/test');
+
         $body = '<?xml version="1.0"?>
 <d:acl xmlns:d="DAV:">
     <d:ace>
@@ -83,16 +84,16 @@ class ACLMethodTest extends \PHPUnit_Framework_TestCase {
         <d:principal><d:href>/principals/notfound</d:href></d:principal>
     </d:ace>
 </d:acl>';
-        $server->httpRequest->setBody($body);
+        $request = new ServerRequest('ACL', '/test', [], $body);
         $server->addPlugin(new DAV\Auth\Plugin());
         $server->addPlugin($acl);
 
-        $acl->httpACL($server->httpRequest, $server->httpResponse);
+        $acl->httpACL(new DAV\Psr7RequestWrapper($request), $server->httpResponse);
 
     }
 
     /**
-     * @expectedException Sabre\DAVACL\Exception\NotRecognizedPrincipal
+     * @expectedException \Sabre\DAVACL\Exception\NotRecognizedPrincipal
      */
     function testUnrecognizedPrincipal2() {
 
@@ -104,7 +105,7 @@ class ACLMethodTest extends \PHPUnit_Framework_TestCase {
         ];
         $acl = new Plugin();
         $server = new DAV\Server($tree);
-        $server->httpRequest = new HTTP\Request('ACL', '/test');
+
         $body = '<?xml version="1.0"?>
 <d:acl xmlns:d="DAV:">
     <d:ace>
@@ -112,16 +113,16 @@ class ACLMethodTest extends \PHPUnit_Framework_TestCase {
         <d:principal><d:href>/principals/notaprincipal</d:href></d:principal>
     </d:ace>
 </d:acl>';
-        $server->httpRequest->setBody($body);
+        $request = new ServerRequest('ACL', '/test', [], $body);
         $server->addPlugin(new DAV\Auth\Plugin());
         $server->addPlugin($acl);
 
-        $acl->httpACL($server->httpRequest, $server->httpResponse);
+        $acl->httpACL(new DAV\Psr7RequestWrapper($request), $server->httpResponse);
 
     }
 
     /**
-     * @expectedException Sabre\DAVACL\Exception\NotSupportedPrivilege
+     * @expectedException \Sabre\DAVACL\Exception\NotSupportedPrivilege
      */
     function testUnknownPrivilege() {
 
@@ -130,7 +131,7 @@ class ACLMethodTest extends \PHPUnit_Framework_TestCase {
         ];
         $acl = new Plugin();
         $server = new DAV\Server($tree);
-        $server->httpRequest = new HTTP\Request('ACL', '/test');
+
         $body = '<?xml version="1.0"?>
 <d:acl xmlns:d="DAV:">
     <d:ace>
@@ -138,16 +139,16 @@ class ACLMethodTest extends \PHPUnit_Framework_TestCase {
         <d:principal><d:href>/principals/notfound</d:href></d:principal>
     </d:ace>
 </d:acl>';
-        $server->httpRequest->setBody($body);
+        $request = new ServerRequest('ACL', '/test', [], $body);
         $server->addPlugin(new DAV\Auth\Plugin());
         $server->addPlugin($acl);
 
-        $acl->httpACL($server->httpRequest, $server->httpResponse);
+        $acl->httpACL(new DAV\Psr7RequestWrapper($request), $server->httpResponse);
 
     }
 
     /**
-     * @expectedException Sabre\DAVACL\Exception\NoAbstract
+     * @expectedException \Sabre\DAVACL\Exception\NoAbstract
      */
     function testAbstractPrivilege() {
 
@@ -159,7 +160,7 @@ class ACLMethodTest extends \PHPUnit_Framework_TestCase {
         $server->on('getSupportedPrivilegeSet', function($node, &$supportedPrivilegeSet) {
             $supportedPrivilegeSet['{DAV:}foo'] = ['abstract' => true];
         });
-        $server->httpRequest = new HTTP\Request('ACL', '/test');
+
         $body = '<?xml version="1.0"?>
 <d:acl xmlns:d="DAV:">
     <d:ace>
@@ -167,16 +168,16 @@ class ACLMethodTest extends \PHPUnit_Framework_TestCase {
         <d:principal><d:href>/principals/foo/</d:href></d:principal>
     </d:ace>
 </d:acl>';
-        $server->httpRequest->setBody($body);
+        $request = new ServerRequest('ACL', '/test', [], $body);
         $server->addPlugin(new DAV\Auth\Plugin());
         $server->addPlugin($acl);
 
-        $acl->httpACL($server->httpRequest, $server->httpResponse);
+        $acl->httpACL(new DAV\Psr7RequestWrapper($request), $server->httpResponse);
 
     }
 
     /**
-     * @expectedException Sabre\DAVACL\Exception\AceConflict
+     * @expectedException \Sabre\DAVACL\Exception\AceConflict
      */
     function testUpdateProtectedPrivilege() {
 
@@ -193,7 +194,7 @@ class ACLMethodTest extends \PHPUnit_Framework_TestCase {
         ];
         $acl = new Plugin();
         $server = new DAV\Server($tree);
-        $server->httpRequest = new HTTP\Request('ACL', '/test');
+
         $body = '<?xml version="1.0"?>
 <d:acl xmlns:d="DAV:">
     <d:ace>
@@ -201,16 +202,16 @@ class ACLMethodTest extends \PHPUnit_Framework_TestCase {
         <d:principal><d:href>/principals/notfound</d:href></d:principal>
     </d:ace>
 </d:acl>';
-        $server->httpRequest->setBody($body);
+        $request = new ServerRequest('ACL', '/test', [], $body);
         $server->addPlugin(new DAV\Auth\Plugin());
         $server->addPlugin($acl);
 
-        $acl->httpACL($server->httpRequest, $server->httpResponse);
+        $acl->httpACL(new DAV\Psr7RequestWrapper($request), $server->httpResponse);
 
     }
 
     /**
-     * @expectedException Sabre\DAVACL\Exception\AceConflict
+     * @expectedException \Sabre\DAVACL\Exception\AceConflict
      */
     function testUpdateProtectedPrivilege2() {
 
@@ -227,7 +228,7 @@ class ACLMethodTest extends \PHPUnit_Framework_TestCase {
         ];
         $acl = new Plugin();
         $server = new DAV\Server($tree);
-        $server->httpRequest = new HTTP\Request('ACL', '/test');
+
         $body = '<?xml version="1.0"?>
 <d:acl xmlns:d="DAV:">
     <d:ace>
@@ -235,16 +236,16 @@ class ACLMethodTest extends \PHPUnit_Framework_TestCase {
         <d:principal><d:href>/principals/foo</d:href></d:principal>
     </d:ace>
 </d:acl>';
-        $server->httpRequest->setBody($body);
+        $request = new ServerRequest('ACL', '/test', [], $body);
         $server->addPlugin(new DAV\Auth\Plugin());
         $server->addPlugin($acl);
 
-        $acl->httpACL($server->httpRequest, $server->httpResponse);
+        $acl->httpACL(new DAV\Psr7RequestWrapper($request), $server->httpResponse);
 
     }
 
     /**
-     * @expectedException Sabre\DAVACL\Exception\AceConflict
+     * @expectedException \Sabre\DAVACL\Exception\AceConflict
      */
     function testUpdateProtectedPrivilege3() {
 
@@ -261,7 +262,7 @@ class ACLMethodTest extends \PHPUnit_Framework_TestCase {
         ];
         $acl = new Plugin();
         $server = new DAV\Server($tree);
-        $server->httpRequest = new HTTP\Request('ACL', '/test');
+
         $body = '<?xml version="1.0"?>
 <d:acl xmlns:d="DAV:">
     <d:ace>
@@ -269,11 +270,11 @@ class ACLMethodTest extends \PHPUnit_Framework_TestCase {
         <d:principal><d:href>/principals/notfound</d:href></d:principal>
     </d:ace>
 </d:acl>';
-        $server->httpRequest->setBody($body);
+        $request = new ServerRequest('ACL', '/test', [], $body);
         $server->addPlugin(new DAV\Auth\Plugin());
         $server->addPlugin($acl);
 
-        $acl->httpACL($server->httpRequest, $server->httpResponse);
+        $acl->httpACL(new DAV\Psr7RequestWrapper($request), $server->httpResponse);
 
     }
 
@@ -300,7 +301,7 @@ class ACLMethodTest extends \PHPUnit_Framework_TestCase {
         ];
         $acl = new Plugin();
         $server = new DAV\Server($tree);
-        $server->httpRequest = new HTTP\Request('ACL', '/test');
+
         $body = '<?xml version="1.0"?>
 <d:acl xmlns:d="DAV:">
     <d:ace>
@@ -313,12 +314,12 @@ class ACLMethodTest extends \PHPUnit_Framework_TestCase {
         <d:principal><d:href>/principals/baz</d:href></d:principal>
     </d:ace>
 </d:acl>';
-        $server->httpRequest->setBody($body);
+        $request = new ServerRequest('ACL', '/test', [], $body);
         $server->addPlugin(new DAV\Auth\Plugin());
         $server->addPlugin($acl);
 
 
-        $this->assertFalse($acl->httpAcl($server->httpRequest, $server->httpResponse));
+        $this->assertFalse($acl->httpAcl(new DAV\Psr7RequestWrapper($request), $server->httpResponse));
 
         $this->assertEquals([
             [

--- a/tests/Sabre/DAVACL/AclPrincipalPropSetReportTest.php
+++ b/tests/Sabre/DAVACL/AclPrincipalPropSetReportTest.php
@@ -44,7 +44,7 @@ XML;
 
         $this->assertXmlStringEqualsXmlString(
             $expected,
-            $response->getBodyAsString()
+            $response->getBody()->getContents()
         );
 
     }

--- a/tests/Sabre/DAVACL/AclPrincipalPropSetReportTest.php
+++ b/tests/Sabre/DAVACL/AclPrincipalPropSetReportTest.php
@@ -2,6 +2,7 @@
 
 namespace Sabre\DAVACL;
 
+use GuzzleHttp\Psr7\ServerRequest;
 use Sabre\HTTP\Request;
 
 class AclPrincipalPropSetReportTest extends \Sabre\DAVServerTest {
@@ -21,8 +22,7 @@ class AclPrincipalPropSetReportTest extends \Sabre\DAVServerTest {
 </acl-principal-prop-set>
 XML;
 
-        $request = new Request('REPORT', '/principals/user1', ['Content-Type' => 'application/xml', 'Depth' => 0]);
-        $request->setBody($xml);
+        $request = new ServerRequest('REPORT', '/principals/user1', ['Content-Type' => 'application/xml', 'Depth' => 0], $xml);
 
         $response = $this->request($request, 207);
 
@@ -59,8 +59,7 @@ XML;
 </acl-principal-prop-set>
 XML;
 
-        $request = new Request('REPORT', '/principals/user1', ['Content-Type' => 'application/xml', 'Depth' => 1]);
-        $request->setBody($xml);
+        $request = new ServerRequest('REPORT', '/principals/user1', ['Content-Type' => 'application/xml', 'Depth' => 1], $xml);
 
         $this->request($request, 400);
 

--- a/tests/Sabre/DAVACL/AllowAccessTest.php
+++ b/tests/Sabre/DAVACL/AllowAccessTest.php
@@ -2,7 +2,9 @@
 
 namespace Sabre\DAVACL;
 
+use GuzzleHttp\Psr7\ServerRequest;
 use Sabre\DAV;
+use Sabre\DAV\Psr7RequestWrapper;
 
 class AllowAccessTest extends \PHPUnit_Framework_TestCase {
 
@@ -36,83 +38,52 @@ class AllowAccessTest extends \PHPUnit_Framework_TestCase {
     }
 
     function testGet() {
-
-        $this->server->httpRequest->setMethod('GET');
-        $this->server->httpRequest->setUrl('/testdir');
-
-        $this->assertTrue($this->server->emit('beforeMethod:GET', [$this->server->httpRequest, $this->server->httpResponse]));
-
+        $request = new ServerRequest('GET', '/testdir');
+        $this->assertTrue($this->server->emit('beforeMethod:GET', [new Psr7RequestWrapper($request), $this->server->httpResponse]));
     }
 
     function testGetDoesntExist() {
-
-        $this->server->httpRequest->setMethod('GET');
-        $this->server->httpRequest->setUrl('/foo');
-
-        $this->assertTrue($this->server->emit('beforeMethod:GET', [$this->server->httpRequest, $this->server->httpResponse]));
-
+        $request = new ServerRequest('GET', '/foo');
+        $this->assertTrue($this->server->emit('beforeMethod:GET', [new Psr7RequestWrapper($request), $this->server->httpResponse]));
     }
 
     function testHEAD() {
-
-        $this->server->httpRequest->setMethod('HEAD');
-        $this->server->httpRequest->setUrl('/testdir');
-
-        $this->assertTrue($this->server->emit('beforeMethod:HEAD', [$this->server->httpRequest, $this->server->httpResponse]));
+        $request = new ServerRequest('GET', '/testdir');
+        $this->assertTrue($this->server->emit('beforeMethod:HEAD', [new Psr7RequestWrapper($request), $this->server->httpResponse]));
 
     }
 
     function testOPTIONS() {
-
-        $this->server->httpRequest->setMethod('OPTIONS');
-        $this->server->httpRequest->setUrl('/testdir');
-
-        $this->assertTrue($this->server->emit('beforeMethod:OPTIONS', [$this->server->httpRequest, $this->server->httpResponse]));
+        $request = new ServerRequest('OPTIONS', '/testdir');
+        $this->assertTrue($this->server->emit('beforeMethod:OPTIONS', [new Psr7RequestWrapper($request), $this->server->httpResponse]));
 
     }
 
     function testPUT() {
-
-        $this->server->httpRequest->setMethod('PUT');
-        $this->server->httpRequest->setUrl('/testdir/file1.txt');
-
-        $this->assertTrue($this->server->emit('beforeMethod:PUT', [$this->server->httpRequest, $this->server->httpResponse]));
-
+        $request = new ServerRequest('PUT', '/testdir/file1.txt');
+        $this->assertTrue($this->server->emit('beforeMethod:PUT', [new Psr7RequestWrapper($request), $this->server->httpResponse]));
     }
 
     function testPROPPATCH() {
-
-        $this->server->httpRequest->setMethod('PROPPATCH');
-        $this->server->httpRequest->setUrl('/testdir');
-
-        $this->assertTrue($this->server->emit('beforeMethod:PROPPATCH', [$this->server->httpRequest, $this->server->httpResponse]));
+        $request = new ServerRequest('PROPPATCH', '/testdir');
+        $this->assertTrue($this->server->emit('beforeMethod:PROPPATCH', [new Psr7RequestWrapper($request), $this->server->httpResponse]));
 
     }
 
     function testCOPY() {
-
-        $this->server->httpRequest->setMethod('COPY');
-        $this->server->httpRequest->setUrl('/testdir');
-
-        $this->assertTrue($this->server->emit('beforeMethod:COPY', [$this->server->httpRequest, $this->server->httpResponse]));
-
+        $request = new ServerRequest('COPY', '/testdir');
+        $this->assertTrue($this->server->emit('beforeMethod:COPY', [new Psr7RequestWrapper($request), $this->server->httpResponse]));
     }
 
     function testMOVE() {
-
-        $this->server->httpRequest->setMethod('MOVE');
-        $this->server->httpRequest->setUrl('/testdir');
-
-        $this->assertTrue($this->server->emit('beforeMethod:MOVE', [$this->server->httpRequest, $this->server->httpResponse]));
+        $request = new ServerRequest('MOVE', '/testdir');
+        $this->assertTrue($this->server->emit('beforeMethod:MOVE', [new Psr7RequestWrapper($request), $this->server->httpResponse]));
 
     }
 
     function testLOCK() {
-
-        $this->server->httpRequest->setMethod('LOCK');
-        $this->server->httpRequest->setUrl('/testdir');
-
-        $this->assertTrue($this->server->emit('beforeMethod:LOCK', [$this->server->httpRequest, $this->server->httpResponse]));
+        $request = new ServerRequest('LOCK', '/testdir');
+        $this->assertTrue($this->server->emit('beforeMethod:LOCK', [new Psr7RequestWrapper($request), $this->server->httpResponse]));
 
     }
 

--- a/tests/Sabre/DAVACL/AllowAccessTest.php
+++ b/tests/Sabre/DAVACL/AllowAccessTest.php
@@ -21,7 +21,7 @@ class AllowAccessTest extends \PHPUnit_Framework_TestCase {
             ]),
         ];
 
-        $this->server = new DAV\Server($nodes);
+        $this->server = new DAV\Server($nodes, null, null, function(){});
         $this->server->addPlugin(
             new DAV\Auth\Plugin(
                 new DAV\Auth\Backend\Mock()

--- a/tests/Sabre/DAVACL/BlockAccessTest.php
+++ b/tests/Sabre/DAVACL/BlockAccessTest.php
@@ -2,7 +2,9 @@
 
 namespace Sabre\DAVACL;
 
+use GuzzleHttp\Psr7\ServerRequest;
 use Sabre\DAV;
+use Sabre\DAV\Psr7RequestWrapper;
 
 class BlockAccessTest extends \PHPUnit_Framework_TestCase {
 
@@ -40,19 +42,16 @@ class BlockAccessTest extends \PHPUnit_Framework_TestCase {
      */
     function testGet() {
 
-        $this->server->httpRequest->setMethod('GET');
-        $this->server->httpRequest->setUrl('/testdir');
-
-        $this->server->emit('beforeMethod:GET', [$this->server->httpRequest, $this->server->httpResponse]);
+        $request = new ServerRequest('GET', '/testdir');
+        $this->server->emit('beforeMethod:GET', [new Psr7RequestWrapper($request), $this->server->httpResponse]);
 
     }
 
     function testGetDoesntExist() {
 
-        $this->server->httpRequest->setMethod('GET');
-        $this->server->httpRequest->setUrl('/foo');
-
-        $r = $this->server->emit('beforeMethod:GET', [$this->server->httpRequest, $this->server->httpResponse]);
+        $request = new ServerRequest('GET', '/foo');
+        
+        $r = $this->server->emit('beforeMethod:GET', [new Psr7RequestWrapper($request), $this->server->httpResponse]);
         $this->assertTrue($r);
 
     }
@@ -61,11 +60,8 @@ class BlockAccessTest extends \PHPUnit_Framework_TestCase {
      * @expectedException \Sabre\DAVACL\Exception\NeedPrivileges
      */
     function testHEAD() {
-
-        $this->server->httpRequest->setMethod('HEAD');
-        $this->server->httpRequest->setUrl('/testdir');
-
-        $this->server->emit('beforeMethod:GET', [$this->server->httpRequest, $this->server->httpResponse]);
+        $request = new ServerRequest('HEAD', '/testdir');
+        $this->server->emit('beforeMethod:GET', [new Psr7RequestWrapper($request), $this->server->httpResponse]);
 
     }
 
@@ -74,10 +70,8 @@ class BlockAccessTest extends \PHPUnit_Framework_TestCase {
      */
     function testOPTIONS() {
 
-        $this->server->httpRequest->setMethod('OPTIONS');
-        $this->server->httpRequest->setUrl('/testdir');
-
-        $this->server->emit('beforeMethod:GET', [$this->server->httpRequest, $this->server->httpResponse]);
+        $request = new ServerRequest('OPTIONS', '/testdir');
+        $this->server->emit('beforeMethod:GET', [new Psr7RequestWrapper($request), $this->server->httpResponse]);
 
     }
 
@@ -86,10 +80,8 @@ class BlockAccessTest extends \PHPUnit_Framework_TestCase {
      */
     function testPUT() {
 
-        $this->server->httpRequest->setMethod('PUT');
-        $this->server->httpRequest->setUrl('/testdir');
-
-        $this->server->emit('beforeMethod:GET', [$this->server->httpRequest, $this->server->httpResponse]);
+        $request = new ServerRequest('PUT', '/testdir');
+        $this->server->emit('beforeMethod:GET', [new Psr7RequestWrapper($request), $this->server->httpResponse]);
 
     }
 
@@ -97,36 +89,24 @@ class BlockAccessTest extends \PHPUnit_Framework_TestCase {
      * @expectedException \Sabre\DAVACL\Exception\NeedPrivileges
      */
     function testPROPPATCH() {
-
-        $this->server->httpRequest->setMethod('PROPPATCH');
-        $this->server->httpRequest->setUrl('/testdir');
-
-        $this->server->emit('beforeMethod:GET', [$this->server->httpRequest, $this->server->httpResponse]);
-
+        $request = new ServerRequest('PROPPATCH', '/testdir');
+        $this->server->emit('beforeMethod:GET', [new Psr7RequestWrapper($request), $this->server->httpResponse]);
     }
 
     /**
      * @expectedException \Sabre\DAVACL\Exception\NeedPrivileges
      */
     function testCOPY() {
-
-        $this->server->httpRequest->setMethod('COPY');
-        $this->server->httpRequest->setUrl('/testdir');
-
-        $this->server->emit('beforeMethod:GET', [$this->server->httpRequest, $this->server->httpResponse]);
-
+        $request = new ServerRequest('COPY', '/testdir');
+        $this->server->emit('beforeMethod:GET', [new Psr7RequestWrapper($request), $this->server->httpResponse]);
     }
 
     /**
      * @expectedException \Sabre\DAVACL\Exception\NeedPrivileges
      */
     function testMOVE() {
-
-        $this->server->httpRequest->setMethod('MOVE');
-        $this->server->httpRequest->setUrl('/testdir');
-
-        $this->server->emit('beforeMethod:GET', [$this->server->httpRequest, $this->server->httpResponse]);
-
+        $request = new ServerRequest('MOVE', '/testdir');
+        $this->server->emit('beforeMethod:GET', [new Psr7RequestWrapper($request), $this->server->httpResponse]);
     }
 
     /**
@@ -134,10 +114,8 @@ class BlockAccessTest extends \PHPUnit_Framework_TestCase {
      */
     function testACL() {
 
-        $this->server->httpRequest->setMethod('ACL');
-        $this->server->httpRequest->setUrl('/testdir');
-
-        $this->server->emit('beforeMethod:GET', [$this->server->httpRequest, $this->server->httpResponse]);
+        $request = new ServerRequest('ACL', '/testdir');
+        $this->server->emit('beforeMethod:GET', [new Psr7RequestWrapper($request), $this->server->httpResponse]);
 
     }
 
@@ -146,10 +124,8 @@ class BlockAccessTest extends \PHPUnit_Framework_TestCase {
      */
     function testLOCK() {
 
-        $this->server->httpRequest->setMethod('LOCK');
-        $this->server->httpRequest->setUrl('/testdir');
-
-        $this->server->emit('beforeMethod:GET', [$this->server->httpRequest, $this->server->httpResponse]);
+        $request = new ServerRequest('LOCK', '/testdir');
+        $this->server->emit('beforeMethod:GET', [new Psr7RequestWrapper($request), $this->server->httpResponse]);
 
     }
 

--- a/tests/Sabre/DAVACL/BlockAccessTest.php
+++ b/tests/Sabre/DAVACL/BlockAccessTest.php
@@ -20,7 +20,7 @@ class BlockAccessTest extends \PHPUnit_Framework_TestCase {
             new DAV\SimpleCollection('testdir'),
         ];
 
-        $this->server = new DAV\Server($nodes);
+        $this->server = new DAV\Server($nodes, null, null, function(){});
         $this->plugin = new Plugin();
         $this->plugin->setDefaultAcl([]);
         $this->server->addPlugin(

--- a/tests/Sabre/DAVACL/BlockAccessTest.php
+++ b/tests/Sabre/DAVACL/BlockAccessTest.php
@@ -36,7 +36,7 @@ class BlockAccessTest extends \PHPUnit_Framework_TestCase {
     }
 
     /**
-     * @expectedException Sabre\DAVACL\Exception\NeedPrivileges
+     * @expectedException \Sabre\DAVACL\Exception\NeedPrivileges
      */
     function testGet() {
 
@@ -58,7 +58,7 @@ class BlockAccessTest extends \PHPUnit_Framework_TestCase {
     }
 
     /**
-     * @expectedException Sabre\DAVACL\Exception\NeedPrivileges
+     * @expectedException \Sabre\DAVACL\Exception\NeedPrivileges
      */
     function testHEAD() {
 
@@ -70,7 +70,7 @@ class BlockAccessTest extends \PHPUnit_Framework_TestCase {
     }
 
     /**
-     * @expectedException Sabre\DAVACL\Exception\NeedPrivileges
+     * @expectedException \Sabre\DAVACL\Exception\NeedPrivileges
      */
     function testOPTIONS() {
 
@@ -82,7 +82,7 @@ class BlockAccessTest extends \PHPUnit_Framework_TestCase {
     }
 
     /**
-     * @expectedException Sabre\DAVACL\Exception\NeedPrivileges
+     * @expectedException \Sabre\DAVACL\Exception\NeedPrivileges
      */
     function testPUT() {
 
@@ -94,7 +94,7 @@ class BlockAccessTest extends \PHPUnit_Framework_TestCase {
     }
 
     /**
-     * @expectedException Sabre\DAVACL\Exception\NeedPrivileges
+     * @expectedException \Sabre\DAVACL\Exception\NeedPrivileges
      */
     function testPROPPATCH() {
 
@@ -106,7 +106,7 @@ class BlockAccessTest extends \PHPUnit_Framework_TestCase {
     }
 
     /**
-     * @expectedException Sabre\DAVACL\Exception\NeedPrivileges
+     * @expectedException \Sabre\DAVACL\Exception\NeedPrivileges
      */
     function testCOPY() {
 
@@ -118,7 +118,7 @@ class BlockAccessTest extends \PHPUnit_Framework_TestCase {
     }
 
     /**
-     * @expectedException Sabre\DAVACL\Exception\NeedPrivileges
+     * @expectedException \Sabre\DAVACL\Exception\NeedPrivileges
      */
     function testMOVE() {
 
@@ -130,7 +130,7 @@ class BlockAccessTest extends \PHPUnit_Framework_TestCase {
     }
 
     /**
-     * @expectedException Sabre\DAVACL\Exception\NeedPrivileges
+     * @expectedException \Sabre\DAVACL\Exception\NeedPrivileges
      */
     function testACL() {
 
@@ -142,7 +142,7 @@ class BlockAccessTest extends \PHPUnit_Framework_TestCase {
     }
 
     /**
-     * @expectedException Sabre\DAVACL\Exception\NeedPrivileges
+     * @expectedException \Sabre\DAVACL\Exception\NeedPrivileges
      */
     function testLOCK() {
 
@@ -154,7 +154,7 @@ class BlockAccessTest extends \PHPUnit_Framework_TestCase {
     }
 
     /**
-     * @expectedException Sabre\DAVACL\Exception\NeedPrivileges
+     * @expectedException \Sabre\DAVACL\Exception\NeedPrivileges
      */
     function testBeforeBind() {
 
@@ -163,7 +163,7 @@ class BlockAccessTest extends \PHPUnit_Framework_TestCase {
     }
 
     /**
-     * @expectedException Sabre\DAVACL\Exception\NeedPrivileges
+     * @expectedException \Sabre\DAVACL\Exception\NeedPrivileges
      */
     function testBeforeUnbind() {
 

--- a/tests/Sabre/DAVACL/Exception/AceConflictTest.php
+++ b/tests/Sabre/DAVACL/Exception/AceConflictTest.php
@@ -10,7 +10,7 @@ class AceConflictTest extends \PHPUnit_Framework_TestCase {
 
         $ex = new AceConflict('message');
 
-        $server = new DAV\Server();
+        $server = new DAV\Server(null, null, null, function(){});
         $dom = new \DOMDocument('1.0', 'utf-8');
         $root = $dom->createElementNS('DAV:', 'd:root');
         $dom->appendChild($root);

--- a/tests/Sabre/DAVACL/Exception/NeedPrivilegesExceptionTest.php
+++ b/tests/Sabre/DAVACL/Exception/NeedPrivilegesExceptionTest.php
@@ -15,7 +15,7 @@ class NeedPrivilegesExceptionTest extends \PHPUnit_Framework_TestCase {
         ];
         $ex = new NeedPrivileges($uri, $privileges);
 
-        $server = new DAV\Server();
+        $server = new DAV\Server(null, null, null, function(){});
         $dom = new \DOMDocument('1.0', 'utf-8');
         $root = $dom->createElementNS('DAV:', 'd:root');
         $dom->appendChild($root);

--- a/tests/Sabre/DAVACL/Exception/NoAbstractTest.php
+++ b/tests/Sabre/DAVACL/Exception/NoAbstractTest.php
@@ -10,7 +10,7 @@ class NoAbstractTest extends \PHPUnit_Framework_TestCase {
 
         $ex = new NoAbstract('message');
 
-        $server = new DAV\Server();
+        $server = new DAV\Server(null, null, null, function(){});
         $dom = new \DOMDocument('1.0', 'utf-8');
         $root = $dom->createElementNS('DAV:', 'd:root');
         $dom->appendChild($root);

--- a/tests/Sabre/DAVACL/Exception/NotRecognizedPrincipalTest.php
+++ b/tests/Sabre/DAVACL/Exception/NotRecognizedPrincipalTest.php
@@ -10,7 +10,7 @@ class NotRecognizedPrincipalTest extends \PHPUnit_Framework_TestCase {
 
         $ex = new NotRecognizedPrincipal('message');
 
-        $server = new DAV\Server();
+        $server = new DAV\Server(null, null, null, function(){});
         $dom = new \DOMDocument('1.0', 'utf-8');
         $root = $dom->createElementNS('DAV:', 'd:root');
         $dom->appendChild($root);

--- a/tests/Sabre/DAVACL/Exception/NotSupportedPrivilegeTest.php
+++ b/tests/Sabre/DAVACL/Exception/NotSupportedPrivilegeTest.php
@@ -10,7 +10,7 @@ class NotSupportedPrivilegeTest extends \PHPUnit_Framework_TestCase {
 
         $ex = new NotSupportedPrivilege('message');
 
-        $server = new DAV\Server();
+        $server = new DAV\Server(null, null, null, function(){});
         $dom = new \DOMDocument('1.0', 'utf-8');
         $root = $dom->createElementNS('DAV:', 'd:root');
         $dom->appendChild($root);

--- a/tests/Sabre/DAVACL/ExpandPropertiesTest.php
+++ b/tests/Sabre/DAVACL/ExpandPropertiesTest.php
@@ -29,7 +29,7 @@ class ExpandPropertiesTest extends \PHPUnit_Framework_TestCase {
             ]),
         ];
 
-        $fakeServer = new DAV\Server($tree);
+        $fakeServer = new DAV\Server($tree, null, null, function(){});
         $fakeServer->debugExceptions = true;
         $plugin = new Plugin();
         $plugin->allowUnauthenticatedAccess = false;
@@ -75,7 +75,7 @@ class ExpandPropertiesTest extends \PHPUnit_Framework_TestCase {
         $responseBody = $response->getBody()->getContents();
         $this->assertEquals(207, $response->getStatusCode(), 'Incorrect status code received. Full body: ' . $responseBody);
         $this->assertEquals([
-            'X-Sabre-Version' => [DAV\Version::VERSION],
+
             'Content-Type'    => ['application/xml; charset=utf-8'],
         ], $response->getHeaders());
 
@@ -129,7 +129,7 @@ class ExpandPropertiesTest extends \PHPUnit_Framework_TestCase {
         $responseBody = $response->getBody()->getContents();
         $this->assertEquals(207, $response->getStatusCode(), 'Incorrect response status received. Full response body: ' . $responseBody);
         $this->assertEquals([
-            'X-Sabre-Version' => [DAV\Version::VERSION],
+
             'Content-Type'    => ['application/xml; charset=utf-8'],
         ], $response->getHeaders());
 
@@ -190,7 +190,7 @@ class ExpandPropertiesTest extends \PHPUnit_Framework_TestCase {
         $responseBody = $response->getBody()->getContents();
         $this->assertEquals(207, $response->getStatusCode());
         $this->assertEquals([
-            'X-Sabre-Version' => [DAV\Version::VERSION],
+
             'Content-Type'    => ['application/xml; charset=utf-8'],
         ], $response->getHeaders());
 
@@ -256,7 +256,7 @@ class ExpandPropertiesTest extends \PHPUnit_Framework_TestCase {
 
         $this->assertEquals(207, $response->getStatusCode());
         $this->assertEquals([
-            'X-Sabre-Version' => [DAV\Version::VERSION],
+
             'Content-Type'    => ['application/xml; charset=utf-8'],
         ], $response->getHeaders());
 

--- a/tests/Sabre/DAVACL/ExpandPropertiesTest.php
+++ b/tests/Sabre/DAVACL/ExpandPropertiesTest.php
@@ -31,7 +31,6 @@ class ExpandPropertiesTest extends \PHPUnit_Framework_TestCase {
         $fakeServer = new DAV\Server($tree);
         $fakeServer->sapi = new HTTP\SapiMock();
         $fakeServer->debugExceptions = true;
-        $fakeServer->httpResponse = new HTTP\ResponseMock();
         $plugin = new Plugin();
         $plugin->allowUnauthenticatedAccess = false;
         // Anyone can do anything
@@ -72,13 +71,14 @@ class ExpandPropertiesTest extends \PHPUnit_Framework_TestCase {
         $server = $this->getServer();
         $server->httpRequest = $request;
 
-        $server->exec();
-
-        $this->assertEquals(207, $server->httpResponse->status, 'Incorrect status code received. Full body: ' . $server->httpResponse->body);
+        $server->start();
+        $response = $server->httpResponse->getResponse();
+        $responseBody = $response->getBody()->getContents();
+        $this->assertEquals(207, $response->getStatusCode(), 'Incorrect status code received. Full body: ' . $responseBody);
         $this->assertEquals([
             'X-Sabre-Version' => [DAV\Version::VERSION],
             'Content-Type'    => ['application/xml; charset=utf-8'],
-        ], $server->httpResponse->getHeaders());
+        ], $response->getHeaders());
 
 
         $check = [
@@ -93,7 +93,7 @@ class ExpandPropertiesTest extends \PHPUnit_Framework_TestCase {
             '/d:multistatus/d:response/d:propstat/d:prop/s:href/d:href' => 1,
         ];
 
-        $xml = simplexml_load_string($server->httpResponse->body);
+        $xml = simplexml_load_string($responseBody);
         $xml->registerXPathNamespace('d', 'DAV:');
         $xml->registerXPathNamespace('s', 'http://sabredav.org/ns');
         foreach ($check as $v1 => $v2) {
@@ -105,7 +105,7 @@ class ExpandPropertiesTest extends \PHPUnit_Framework_TestCase {
             $count = 1;
             if (!is_int($v1)) $count = $v2;
 
-            $this->assertEquals($count, count($result), 'we expected ' . $count . ' appearances of ' . $xpath . ' . We found ' . count($result) . '. Full response: ' . $server->httpResponse->body);
+            $this->assertEquals($count, count($result), 'we expected ' . $count . ' appearances of ' . $xpath . ' . We found ' . count($result) . '. Full response: ' . $responseBody);
 
         }
 
@@ -135,13 +135,15 @@ class ExpandPropertiesTest extends \PHPUnit_Framework_TestCase {
         $server = $this->getServer();
         $server->httpRequest = $request;
 
-        $server->exec();
+        $server->start();
 
-        $this->assertEquals(207, $server->httpResponse->status, 'Incorrect response status received. Full response body: ' . $server->httpResponse->body);
+        $response = $server->httpResponse->getResponse();
+        $responseBody = $response->getBody()->getContents();
+        $this->assertEquals(207, $response->getStatusCode(), 'Incorrect response status received. Full response body: ' . $responseBody);
         $this->assertEquals([
             'X-Sabre-Version' => [DAV\Version::VERSION],
             'Content-Type'    => ['application/xml; charset=utf-8'],
-        ], $server->httpResponse->getHeaders());
+        ], $response->getHeaders());
 
 
         $check = [
@@ -158,7 +160,7 @@ class ExpandPropertiesTest extends \PHPUnit_Framework_TestCase {
             '/d:multistatus/d:response/d:propstat/d:prop/s:href/d:response/d:propstat/d:prop/d:displayname' => 1,
         ];
 
-        $xml = simplexml_load_string($server->httpResponse->body);
+        $xml = simplexml_load_string($responseBody);
         $xml->registerXPathNamespace('d', 'DAV:');
         $xml->registerXPathNamespace('s', 'http://sabredav.org/ns');
         foreach ($check as $v1 => $v2) {
@@ -170,7 +172,7 @@ class ExpandPropertiesTest extends \PHPUnit_Framework_TestCase {
             $count = 1;
             if (!is_int($v1)) $count = $v2;
 
-            $this->assertEquals($count, count($result), 'we expected ' . $count . ' appearances of ' . $xpath . ' . We found ' . count($result) . ' Full response body: ' . $server->httpResponse->getBodyAsString());
+            $this->assertEquals($count, count($result), 'we expected ' . $count . ' appearances of ' . $xpath . ' . We found ' . count($result) . ' Full response body: ' . $responseBody);
 
         }
 
@@ -200,13 +202,15 @@ class ExpandPropertiesTest extends \PHPUnit_Framework_TestCase {
         $server = $this->getServer();
         $server->httpRequest = $request;
 
-        $server->exec();
+        $server->start();
 
-        $this->assertEquals(207, $server->httpResponse->status);
+        $response = $server->httpResponse->getResponse();
+        $responseBody = $response->getBody()->getContents();
+        $this->assertEquals(207, $response->getStatusCode());
         $this->assertEquals([
             'X-Sabre-Version' => [DAV\Version::VERSION],
             'Content-Type'    => ['application/xml; charset=utf-8'],
-        ], $server->httpResponse->getHeaders());
+        ], $response->getHeaders());
 
 
         $check = [
@@ -223,7 +227,7 @@ class ExpandPropertiesTest extends \PHPUnit_Framework_TestCase {
             '/d:multistatus/d:response/d:propstat/d:prop/s:hreflist/d:response/d:propstat/d:prop/d:displayname' => 2,
         ];
 
-        $xml = simplexml_load_string($server->httpResponse->body);
+        $xml = simplexml_load_string($responseBody);
         $xml->registerXPathNamespace('d', 'DAV:');
         $xml->registerXPathNamespace('s', 'http://sabredav.org/ns');
         foreach ($check as $v1 => $v2) {
@@ -268,13 +272,15 @@ class ExpandPropertiesTest extends \PHPUnit_Framework_TestCase {
         $server = $this->getServer();
         $server->httpRequest = $request;
 
-        $server->exec();
+        $server->start();
+        $response = $server->httpResponse->getResponse();
+        $responseBody = $response->getBody()->getContents();
 
-        $this->assertEquals(207, $server->httpResponse->status);
+        $this->assertEquals(207, $response->getStatusCode());
         $this->assertEquals([
             'X-Sabre-Version' => [DAV\Version::VERSION],
             'Content-Type'    => ['application/xml; charset=utf-8'],
-        ], $server->httpResponse->getHeaders());
+        ], $response->getHeaders());
 
 
         $check = [
@@ -297,7 +303,7 @@ class ExpandPropertiesTest extends \PHPUnit_Framework_TestCase {
             '/d:multistatus/d:response/d:propstat/d:prop/s:hreflist/d:response/d:propstat/d:prop/s:href/d:response/d:propstat/d:prop/d:displayname' => 1,
         ];
 
-        $xml = simplexml_load_string($server->httpResponse->body);
+        $xml = simplexml_load_string($responseBody);
         $xml->registerXPathNamespace('d', 'DAV:');
         $xml->registerXPathNamespace('s', 'http://sabredav.org/ns');
         foreach ($check as $v1 => $v2) {

--- a/tests/Sabre/DAVACL/ExpandPropertiesTest.php
+++ b/tests/Sabre/DAVACL/ExpandPropertiesTest.php
@@ -2,6 +2,7 @@
 
 namespace Sabre\DAVACL;
 
+use GuzzleHttp\Psr7\ServerRequest;
 use Sabre\DAV;
 use Sabre\HTTP;
 
@@ -29,7 +30,6 @@ class ExpandPropertiesTest extends \PHPUnit_Framework_TestCase {
         ];
 
         $fakeServer = new DAV\Server($tree);
-        $fakeServer->sapi = new HTTP\SapiMock();
         $fakeServer->debugExceptions = true;
         $plugin = new Plugin();
         $plugin->allowUnauthenticatedAccess = false;
@@ -61,18 +61,17 @@ class ExpandPropertiesTest extends \PHPUnit_Framework_TestCase {
 
         $serverVars = [
             'REQUEST_METHOD' => 'REPORT',
-            'HTTP_DEPTH'     => '0',
-            'REQUEST_URI'    => '/node1',
+            'Depth'     => '0',
+            '/node1',
         ];
 
-        $request = HTTP\Sapi::createFromServerArray($serverVars);
-        $request->setBody($xml);
+        $request = new ServerRequest('REPORT', '/node1', [
+            'Depth' => '0'
+        ], $xml);
 
         $server = $this->getServer();
-        $server->httpRequest = $request;
 
-        $server->start();
-        $response = $server->httpResponse->getResponse();
+        $response = $server->handle($request);
         $responseBody = $response->getBody()->getContents();
         $this->assertEquals(207, $response->getStatusCode(), 'Incorrect status code received. Full body: ' . $responseBody);
         $this->assertEquals([
@@ -123,21 +122,10 @@ class ExpandPropertiesTest extends \PHPUnit_Framework_TestCase {
   </d:property>
 </d:expand-property>';
 
-        $serverVars = [
-            'REQUEST_METHOD' => 'REPORT',
-            'HTTP_DEPTH'     => '0',
-            'REQUEST_URI'    => '/node1',
-        ];
-
-        $request = HTTP\Sapi::createFromServerArray($serverVars);
-        $request->setBody($xml);
+        $request = new ServerRequest('REPORT','/node1',['Depth' => '0'], $xml);
 
         $server = $this->getServer();
-        $server->httpRequest = $request;
-
-        $server->start();
-
-        $response = $server->httpResponse->getResponse();
+        $response = $server->handle($request);
         $responseBody = $response->getBody()->getContents();
         $this->assertEquals(207, $response->getStatusCode(), 'Incorrect response status received. Full response body: ' . $responseBody);
         $this->assertEquals([
@@ -192,19 +180,13 @@ class ExpandPropertiesTest extends \PHPUnit_Framework_TestCase {
 
         $serverVars = [
             'REQUEST_METHOD' => 'REPORT',
-            'HTTP_DEPTH'     => '0',
-            'REQUEST_URI'    => '/node2',
+            'Depth'     => '0',
+            '/node2',
         ];
 
-        $request = HTTP\Sapi::createFromServerArray($serverVars);
-        $request->setBody($xml);
-
+        $request = new ServerRequest('REPORT', '/node2', ['Depth' => '0'], $xml);
         $server = $this->getServer();
-        $server->httpRequest = $request;
-
-        $server->start();
-
-        $response = $server->httpResponse->getResponse();
+        $response = $server->handle($request);
         $responseBody = $response->getBody()->getContents();
         $this->assertEquals(207, $response->getStatusCode());
         $this->assertEquals([
@@ -262,18 +244,14 @@ class ExpandPropertiesTest extends \PHPUnit_Framework_TestCase {
 
         $serverVars = [
             'REQUEST_METHOD' => 'REPORT',
-            'HTTP_DEPTH'     => '0',
-            'REQUEST_URI'    => '/node2',
+            'Depth'     => '0',
+            '/node2',
         ];
 
-        $request = HTTP\Sapi::createFromServerArray($serverVars);
-        $request->setBody($xml);
+        $request = new ServerRequest('REPORT', '/node2', ['Depth' => '0'], $xml);
 
         $server = $this->getServer();
-        $server->httpRequest = $request;
-
-        $server->start();
-        $response = $server->httpResponse->getResponse();
+        $response = $server->handle($request);
         $responseBody = $response->getBody()->getContents();
 
         $this->assertEquals(207, $response->getStatusCode());

--- a/tests/Sabre/DAVACL/PluginAdminTest.php
+++ b/tests/Sabre/DAVACL/PluginAdminTest.php
@@ -25,7 +25,7 @@ class PluginAdminTest extends \PHPUnit_Framework_TestCase {
             new PrincipalCollection($principalBackend),
         ];
 
-        $this->server = new DAV\Server($tree);
+        $this->server = new DAV\Server($tree, null, null, function(){});
 
         $plugin = new DAV\Auth\Plugin(new DAV\Auth\Backend\Mock());
         $this->server->addPlugin($plugin);

--- a/tests/Sabre/DAVACL/PluginAdminTest.php
+++ b/tests/Sabre/DAVACL/PluginAdminTest.php
@@ -2,6 +2,7 @@
 
 namespace Sabre\DAVACL;
 
+use GuzzleHttp\Psr7\ServerRequest;
 use Sabre\DAV;
 use Sabre\HTTP;
 
@@ -10,6 +11,9 @@ require_once 'Sabre/HTTP/ResponseMock.php';
 
 class PluginAdminTest extends \PHPUnit_Framework_TestCase {
 
+    /**
+     * @var DAV\Server
+     */
     public $server;
 
     function setUp() {
@@ -22,7 +26,7 @@ class PluginAdminTest extends \PHPUnit_Framework_TestCase {
         ];
 
         $this->server = new DAV\Server($tree);
-        $this->server->sapi = new HTTP\SapiMock();
+
         $plugin = new DAV\Auth\Plugin(new DAV\Auth\Backend\Mock());
         $this->server->addPlugin($plugin);
     }
@@ -32,20 +36,14 @@ class PluginAdminTest extends \PHPUnit_Framework_TestCase {
         $plugin = new Plugin();
         $this->server->addPlugin($plugin);
 
-        $request = HTTP\Sapi::createFromServerArray([
-            'REQUEST_METHOD' => 'OPTIONS',
-            'HTTP_DEPTH'     => 1,
-            'REQUEST_URI'    => '/adminonly',
-        ]);
+        $request = new ServerRequest('OPTIONS', '/adminonly', ['Depth' => '1']);
 
-        $response = new HTTP\ResponseMock();
 
-        $this->server->httpRequest = $request;
-        $response = $this->server->httpResponse;
+        $response = $this->server->handle($request);
 
-        $this->server->start();
 
-        $this->assertEquals(403, $response->getResponse()->getStatusCode());
+
+        $this->assertEquals(403, $response->getStatusCode());
 
     }
 
@@ -60,20 +58,12 @@ class PluginAdminTest extends \PHPUnit_Framework_TestCase {
         ];
         $this->server->addPlugin($plugin);
 
-        $request = HTTP\Sapi::createFromServerArray([
-            'REQUEST_METHOD' => 'OPTIONS',
-            'HTTP_DEPTH'     => 1,
-            'REQUEST_URI'    => '/adminonly',
-        ]);
+        $request = new ServerRequest('OPTIONS', '/adminonly', ['Depth'     => 1]);
 
-        $response = new HTTP\ResponseMock();
+        $response = $this->server->handle($request);
 
-        $this->server->httpRequest = $request;
-        $response = $this->server->httpResponse;
 
-        $this->server->start();
-
-        $this->assertEquals(200, $response->getResponse()->getStatusCode());
+        $this->assertEquals(200, $response->getStatusCode());
 
     }
 }

--- a/tests/Sabre/DAVACL/PluginAdminTest.php
+++ b/tests/Sabre/DAVACL/PluginAdminTest.php
@@ -41,11 +41,11 @@ class PluginAdminTest extends \PHPUnit_Framework_TestCase {
         $response = new HTTP\ResponseMock();
 
         $this->server->httpRequest = $request;
-        $this->server->httpResponse = $response;
+        $response = $this->server->httpResponse;
 
-        $this->server->exec();
+        $this->server->start();
 
-        $this->assertEquals(403, $response->status);
+        $this->assertEquals(403, $response->getResponse()->getStatusCode());
 
     }
 
@@ -69,11 +69,11 @@ class PluginAdminTest extends \PHPUnit_Framework_TestCase {
         $response = new HTTP\ResponseMock();
 
         $this->server->httpRequest = $request;
-        $this->server->httpResponse = $response;
+        $response = $this->server->httpResponse;
 
-        $this->server->exec();
+        $this->server->start();
 
-        $this->assertEquals(200, $response->status);
+        $this->assertEquals(200, $response->getResponse()->getStatusCode());
 
     }
 }

--- a/tests/Sabre/DAVACL/PluginPropertiesTest.php
+++ b/tests/Sabre/DAVACL/PluginPropertiesTest.php
@@ -77,7 +77,8 @@ class PluginPropertiesTest extends \PHPUnit_Framework_TestCase {
         $this->assertEquals(Xml\Property\Principal::UNAUTHENTICATED, $result[200]['{DAV:}current-user-principal']->getType());
 
         // This will force the login
-        $fakeServer->emit('beforeMethod:PROPFIND', [$fakeServer->httpRequest, $fakeServer->httpResponse]);
+        $request = new DAV\Psr7RequestWrapper(new ServerRequest('GET', '/'));
+        $fakeServer->emit('beforeMethod:PROPFIND', [$request, $fakeServer->httpResponse]);
 
         $result = $fakeServer->getPropertiesForPath('', $requestedProperties);
         $result = $result[0];

--- a/tests/Sabre/DAVACL/PluginPropertiesTest.php
+++ b/tests/Sabre/DAVACL/PluginPropertiesTest.php
@@ -4,6 +4,8 @@ namespace Sabre\DAVACL;
 
 use GuzzleHttp\Psr7\ServerRequest;
 use Sabre\DAV;
+use Sabre\DAV\Server;
+use Sabre\DAV\SimpleCollection;
 use Sabre\HTTP;
 
 class PluginPropertiesTest extends \PHPUnit_Framework_TestCase {
@@ -28,7 +30,7 @@ class PluginPropertiesTest extends \PHPUnit_Framework_TestCase {
             '{DAV:}principal-collection-set',
         ];
 
-        $server = new DAV\Server(new DAV\SimpleCollection('root'));
+        $server = new Server(new SimpleCollection('root'), null, null, function(){});
         $server->addPlugin($plugin);
 
         $result = $server->getPropertiesForPath('', $requestedProperties);
@@ -51,7 +53,7 @@ class PluginPropertiesTest extends \PHPUnit_Framework_TestCase {
 
     function testCurrentUserPrincipal() {
 
-        $fakeServer = new DAV\Server();
+        $fakeServer = new Server(null, null, null, function(){});
         $plugin = new DAV\Auth\Plugin(new DAV\Auth\Backend\Mock());
         $fakeServer->addPlugin($plugin);
         $plugin = new Plugin();
@@ -101,7 +103,7 @@ class PluginPropertiesTest extends \PHPUnit_Framework_TestCase {
                 'privilege' => '{DAV:}all',
             ],
         ]);
-        $server = new DAV\Server();
+        $server = new Server(null, null, null, function(){});
         $server->addPlugin($plugin);
 
         $requestedProperties = [
@@ -115,7 +117,7 @@ class PluginPropertiesTest extends \PHPUnit_Framework_TestCase {
         $this->assertArrayHasKey('{DAV:}supported-privilege-set', $result[200]);
         $this->assertInstanceOf('Sabre\\DAVACL\\Xml\\Property\\SupportedPrivilegeSet', $result[200]['{DAV:}supported-privilege-set']);
 
-        $server = new DAV\Server();
+        $server = new Server(null, null, null, function(){});
 
         $prop = $result[200]['{DAV:}supported-privilege-set'];
         $result = $server->xml->write('{DAV:}root', $prop);
@@ -175,13 +177,13 @@ class PluginPropertiesTest extends \PHPUnit_Framework_TestCase {
                     'privilege' => '{DAV:}read',
                 ]
             ]),
-            new DAV\SimpleCollection('principals', [
+            new SimpleCollection('principals', [
                 $principal = new MockPrincipal('admin', 'principals/admin'),
             ]),
 
         ];
 
-        $server = new DAV\Server($nodes);
+        $server = new Server($nodes, null, null, function(){});
         $server->addPlugin($plugin);
         $authPlugin = new DAV\Auth\Plugin(new DAV\Auth\Backend\Mock());
         $server->addPlugin($authPlugin);
@@ -214,13 +216,13 @@ class PluginPropertiesTest extends \PHPUnit_Framework_TestCase {
                     'privilege' => '{DAV:}read',
                 ]
             ]),
-            new DAV\SimpleCollection('principals', [
+            new SimpleCollection('principals', [
                 $principal = new MockPrincipal('admin', 'principals/admin'),
             ]),
 
         ];
 
-        $server = new DAV\Server($nodes);
+        $server = new Server($nodes, null, null, function(){});
         $server->addPlugin($plugin);
         $authPlugin = new DAV\Auth\Plugin(new DAV\Auth\Backend\Mock());
         $server->addPlugin($authPlugin);
@@ -244,12 +246,12 @@ class PluginPropertiesTest extends \PHPUnit_Framework_TestCase {
     function testAlternateUriSet() {
 
         $tree = [
-            new DAV\SimpleCollection('principals', [
+            new SimpleCollection('principals', [
                 $principal = new MockPrincipal('user', 'principals/user'),
             ])
         ];
 
-        $fakeServer = new DAV\Server($tree);
+        $fakeServer = new Server($tree, null, null, function(){});
         //$plugin = new DAV\Auth\Plugin(new DAV\Auth\MockBackend())
         //$fakeServer->addPlugin($plugin);
         $plugin = new Plugin();
@@ -279,12 +281,12 @@ class PluginPropertiesTest extends \PHPUnit_Framework_TestCase {
     function testPrincipalURL() {
 
         $tree = [
-            new DAV\SimpleCollection('principals', [
+            new SimpleCollection('principals', [
                 $principal = new MockPrincipal('user', 'principals/user'),
             ]),
         ];
 
-        $fakeServer = new DAV\Server($tree);
+        $fakeServer = new Server($tree, null, null, function(){});
         //$plugin = new DAV\Auth\Plugin(new DAV\Auth\MockBackend());
         //$fakeServer->addPlugin($plugin);
         $plugin = new Plugin();
@@ -315,12 +317,12 @@ class PluginPropertiesTest extends \PHPUnit_Framework_TestCase {
     function testGroupMemberSet() {
 
         $tree = [
-            new DAV\SimpleCollection('principals', [
+            new SimpleCollection('principals', [
                 $principal = new MockPrincipal('user', 'principals/user'),
             ]),
         ];
 
-        $fakeServer = new DAV\Server($tree);
+        $fakeServer = new Server($tree, null, null, function(){});
         //$plugin = new DAV\Auth\Plugin(new DAV\Auth\MockBackend());
         //$fakeServer->addPlugin($plugin);
         $plugin = new Plugin();
@@ -351,12 +353,12 @@ class PluginPropertiesTest extends \PHPUnit_Framework_TestCase {
     function testGroupMemberShip() {
 
         $tree = [
-            new DAV\SimpleCollection('principals', [
+            new SimpleCollection('principals', [
                 $principal = new MockPrincipal('user', 'principals/user'),
             ]),
         ];
 
-        $fakeServer = new DAV\Server($tree);
+        $fakeServer = new Server($tree, null, null, function(){});
         $plugin = new Plugin();
         $plugin->allowUnauthenticatedAccess = false;
         $fakeServer->addPlugin($plugin);
@@ -385,12 +387,12 @@ class PluginPropertiesTest extends \PHPUnit_Framework_TestCase {
     function testGetDisplayName() {
 
         $tree = [
-            new DAV\SimpleCollection('principals', [
+            new SimpleCollection('principals', [
                 $principal = new MockPrincipal('user', 'principals/user'),
             ]),
         ];
 
-        $fakeServer = new DAV\Server($tree);
+        $fakeServer = new Server($tree, null, null, function(){});
         $plugin = new Plugin();
         $plugin->allowUnauthenticatedAccess = false;
         $fakeServer->addPlugin($plugin);

--- a/tests/Sabre/DAVACL/PluginPropertiesTest.php
+++ b/tests/Sabre/DAVACL/PluginPropertiesTest.php
@@ -2,6 +2,7 @@
 
 namespace Sabre\DAVACL;
 
+use GuzzleHttp\Psr7\ServerRequest;
 use Sabre\DAV;
 use Sabre\HTTP;
 
@@ -185,7 +186,7 @@ class PluginPropertiesTest extends \PHPUnit_Framework_TestCase {
         $server->addPlugin($authPlugin);
 
         // Force login
-        $authPlugin->beforeMethod(new HTTP\Request('GET', '/'), new HTTP\Response());
+        $authPlugin->beforeMethod(new DAV\Psr7RequestWrapper(new ServerRequest('GET', '/')), new HTTP\Response());
 
         $requestedProperties = [
             '{DAV:}acl',
@@ -224,7 +225,7 @@ class PluginPropertiesTest extends \PHPUnit_Framework_TestCase {
         $server->addPlugin($authPlugin);
 
         // Force login
-        $authPlugin->beforeMethod(new HTTP\Request('GET', '/'), new HTTP\Response());
+        $authPlugin->beforeMethod(new DAV\Psr7RequestWrapper(new ServerRequest('GET', '/')), new HTTP\Response());
 
         $requestedProperties = [
             '{DAV:}acl-restrictions',

--- a/tests/Sabre/DAVACL/PluginUpdatePropertiesTest.php
+++ b/tests/Sabre/DAVACL/PluginUpdatePropertiesTest.php
@@ -11,7 +11,7 @@ class PluginUpdatePropertiesTest extends \PHPUnit_Framework_TestCase {
         $tree = [
             new DAV\SimpleCollection('foo'),
         ];
-        $server = new DAV\Server($tree);
+        $server = new DAV\Server($tree, null, null, function(){});
         $server->addPlugin(new DAV\Auth\Plugin());
         $server->addPlugin(new Plugin());
 
@@ -32,7 +32,7 @@ class PluginUpdatePropertiesTest extends \PHPUnit_Framework_TestCase {
         $tree = [
             new MockPrincipal('foo', 'foo'),
         ];
-        $server = new DAV\Server($tree);
+        $server = new DAV\Server($tree, null, null, function(){});
         $plugin = new Plugin();
         $plugin->allowUnauthenticatedAccess = false;
         $server->addPlugin($plugin);
@@ -55,7 +55,7 @@ class PluginUpdatePropertiesTest extends \PHPUnit_Framework_TestCase {
         $tree = [
             new MockPrincipal('foo', 'foo'),
         ];
-        $server = new DAV\Server($tree);
+        $server = new DAV\Server($tree, null, null, function(){});
         $plugin = new Plugin();
         $plugin->allowUnauthenticatedAccess = false;
         $server->addPlugin($plugin);
@@ -81,7 +81,7 @@ class PluginUpdatePropertiesTest extends \PHPUnit_Framework_TestCase {
         $tree = [
             new MockPrincipal('foo', 'foo'),
         ];
-        $server = new DAV\Server($tree);
+        $server = new DAV\Server($tree, null, null, function(){});
         $plugin = new Plugin();
         $plugin->allowUnauthenticatedAccess = false;
         $server->addPlugin($plugin);
@@ -97,7 +97,7 @@ class PluginUpdatePropertiesTest extends \PHPUnit_Framework_TestCase {
         $tree = [
             new DAV\SimpleCollection('foo'),
         ];
-        $server = new DAV\Server($tree);
+        $server = new DAV\Server($tree, null, null, function(){});
         $plugin = new Plugin();
         $plugin->allowUnauthenticatedAccess = false;
         $server->addPlugin($plugin);

--- a/tests/Sabre/DAVACL/PluginUpdatePropertiesTest.php
+++ b/tests/Sabre/DAVACL/PluginUpdatePropertiesTest.php
@@ -74,7 +74,7 @@ class PluginUpdatePropertiesTest extends \PHPUnit_Framework_TestCase {
     }
 
     /**
-     * @expectedException Sabre\DAV\Exception
+     * @expectedException \Sabre\DAV\Exception
      */
     function testSetBadValue() {
 

--- a/tests/Sabre/DAVACL/PrincipalCollectionTest.php
+++ b/tests/Sabre/DAVACL/PrincipalCollectionTest.php
@@ -33,7 +33,7 @@ class PrincipalCollectionTest extends \PHPUnit_Framework_TestCase {
 
     /**
      * @depends testBasic
-     * @expectedException Sabre\DAV\Exception\MethodNotAllowed
+     * @expectedException \Sabre\DAV\Exception\MethodNotAllowed
      */
     function testGetChildrenDisable() {
 

--- a/tests/Sabre/DAVACL/PrincipalMatchTest.php
+++ b/tests/Sabre/DAVACL/PrincipalMatchTest.php
@@ -2,6 +2,7 @@
 
 namespace Sabre\DAVACL;
 
+use GuzzleHttp\Psr7\ServerRequest;
 use Sabre\HTTP\Request;
 
 class PrincipalMatchTest extends \Sabre\DAVServerTest {
@@ -18,9 +19,7 @@ class PrincipalMatchTest extends \Sabre\DAVServerTest {
 </principal-match>
 XML;
 
-        $request = new Request('REPORT', '/principals', ['Content-Type' => 'application/xml']);
-        $request->setBody($xml);
-
+        $request = new ServerRequest('REPORT', '/principals', ['Content-Type' => 'application/xml'], $xml);
         $response = $this->request($request, 207);
 
         $expected = <<<XML
@@ -54,9 +53,7 @@ XML;
 </principal-match>
 XML;
 
-        $request = new Request('REPORT', '/principals', ['Content-Type' => 'application/xml']);
-        $request->setBody($xml);
-
+        $request = new ServerRequest('REPORT', '/principals', ['Content-Type' => 'application/xml'], $xml);
         $response = $this->request($request, 207);
 
         $expected = <<<XML
@@ -94,9 +91,7 @@ XML;
 </principal-match>
 XML;
 
-        $request = new Request('REPORT', '/principals', ['Content-Type' => 'application/xml']);
-        $request->setBody($xml);
-
+        $request = new ServerRequest('REPORT', '/principals', ['Content-Type' => 'application/xml'], $xml);
         $response = $this->request($request, 207);
 
         $expected = <<<XML

--- a/tests/Sabre/DAVACL/PrincipalMatchTest.php
+++ b/tests/Sabre/DAVACL/PrincipalMatchTest.php
@@ -37,7 +37,7 @@ XML;
 
         $this->assertXmlStringEqualsXmlString(
             $expected,
-            $response->getBodyAsString()
+            $response->getBody()->getContents()
         );
 
     }
@@ -75,7 +75,7 @@ XML;
 
         $this->assertXmlStringEqualsXmlString(
             $expected,
-            $response->getBodyAsString()
+            $response->getBody()->getContents()
         );
 
     }
@@ -115,7 +115,7 @@ XML;
 
         $this->assertXmlStringEqualsXmlString(
             $expected,
-            $response->getBodyAsString()
+            $response->getBody()->getContents()
         );
 
     }

--- a/tests/Sabre/DAVACL/PrincipalPropertySearchTest.php
+++ b/tests/Sabre/DAVACL/PrincipalPropertySearchTest.php
@@ -4,6 +4,7 @@ namespace Sabre\DAVACL;
 
 use GuzzleHttp\Psr7\ServerRequest;
 use Sabre\DAV;
+use Sabre\DAV\Server;
 use Sabre\HTTP;
 
 require_once 'Sabre/HTTP/ResponseMock.php';
@@ -18,7 +19,7 @@ class PrincipalPropertySearchTest extends \PHPUnit_Framework_TestCase {
         $principals = new PrincipalCollection($backend);
         $dir->addChild($principals);
 
-        $fakeServer = new DAV\Server($dir);
+        $fakeServer = new Server($dir, null, null, function() {});
         $fakeServer->debugExceptions = true;
         $plugin = new MockPlugin();
         $plugin->allowAccessToNodesWithoutACL = true;
@@ -56,7 +57,7 @@ class PrincipalPropertySearchTest extends \PHPUnit_Framework_TestCase {
         $response = $server->handle($request);
         $this->assertEquals(400, $response->getStatusCode(), $response->getBody()->getContents());
         $this->assertEquals([
-            'X-Sabre-Version' => [DAV\Version::VERSION],
+
             'Content-Type'    => ['application/xml; charset=utf-8'],
         ], $response->getHeaders());
 
@@ -90,7 +91,7 @@ class PrincipalPropertySearchTest extends \PHPUnit_Framework_TestCase {
 
         $this->assertEquals(207, $response->getStatusCode(), "Full body: " . $responseBody);
         $this->assertEquals([
-            'X-Sabre-Version' => [DAV\Version::VERSION],
+
             'Content-Type'    => ['application/xml; charset=utf-8'],
             'Vary'            => ['Brief,Prefer'],
         ], $response->getHeaders());
@@ -131,7 +132,7 @@ class PrincipalPropertySearchTest extends \PHPUnit_Framework_TestCase {
         $responseBody = $response->getBody()->getContents();
         $this->assertEquals(207, $response->getStatusCode(), $responseBody);
         $this->assertEquals([
-            'X-Sabre-Version' => [DAV\Version::VERSION],
+
             'Content-Type'    => ['application/xml; charset=utf-8'],
             'Vary'            => ['Brief,Prefer'],
         ], $response->getHeaders());
@@ -196,7 +197,7 @@ class PrincipalPropertySearchTest extends \PHPUnit_Framework_TestCase {
 
         $this->assertEquals(207, $response->getStatusCode(), $responseBody);
         $this->assertEquals([
-            'X-Sabre-Version' => [DAV\Version::VERSION],
+
             'Content-Type'    => ['application/xml; charset=utf-8'],
             'Vary'            => ['Brief,Prefer'],
         ], $response->getHeaders());
@@ -260,7 +261,7 @@ class PrincipalPropertySearchTest extends \PHPUnit_Framework_TestCase {
 
         $this->assertEquals(207, $response->getStatusCode(), $responseBody);
         $this->assertEquals([
-            'X-Sabre-Version' => [DAV\Version::VERSION],
+
             'Content-Type'    => ['application/xml; charset=utf-8'],
             'Vary'            => ['Brief,Prefer'],
         ], $response->getHeaders());
@@ -321,7 +322,7 @@ class PrincipalPropertySearchTest extends \PHPUnit_Framework_TestCase {
 
         $this->assertEquals(207, $response->getStatusCode(), $responseBody);
         $this->assertEquals([
-            'X-Sabre-Version' => [DAV\Version::VERSION],
+
             'Content-Type'    => ['application/xml; charset=utf-8'],
             'Vary'            => ['Brief,Prefer'],
         ], $response->getHeaders());

--- a/tests/Sabre/DAVACL/PrincipalPropertySearchTest.php
+++ b/tests/Sabre/DAVACL/PrincipalPropertySearchTest.php
@@ -2,6 +2,7 @@
 
 namespace Sabre\DAVACL;
 
+use GuzzleHttp\Psr7\ServerRequest;
 use Sabre\DAV;
 use Sabre\HTTP;
 
@@ -18,7 +19,6 @@ class PrincipalPropertySearchTest extends \PHPUnit_Framework_TestCase {
         $dir->addChild($principals);
 
         $fakeServer = new DAV\Server($dir);
-        $fakeServer->sapi = new HTTP\SapiMock();
         $fakeServer->debugExceptions = true;
         $plugin = new MockPlugin();
         $plugin->allowAccessToNodesWithoutACL = true;
@@ -48,21 +48,12 @@ class PrincipalPropertySearchTest extends \PHPUnit_Framework_TestCase {
   </d:prop>
 </d:principal-property-search>';
 
-        $serverVars = [
-            'REQUEST_METHOD' => 'REPORT',
-            'HTTP_DEPTH'     => '1',
-            'REQUEST_URI'    => '/principals',
-        ];
-
-        $request = HTTP\Sapi::createFromServerArray($serverVars);
-        $request->setBody($xml);
+        $request = new ServerRequest('REPORT', '/principals', [
+            'Depth' => '1'
+        ], $xml);
 
         $server = $this->getServer();
-        $server->httpRequest = $request;
-
-        $server->start();
-
-        $response = $server->httpResponse->getResponse();
+        $response = $server->handle($request);
         $this->assertEquals(400, $response->getStatusCode(), $response->getBody()->getContents());
         $this->assertEquals([
             'X-Sabre-Version' => [DAV\Version::VERSION],
@@ -88,20 +79,13 @@ class PrincipalPropertySearchTest extends \PHPUnit_Framework_TestCase {
   </d:prop>
 </d:principal-property-search>';
 
-        $serverVars = [
-            'REQUEST_METHOD' => 'REPORT',
-            'HTTP_DEPTH'     => '0',
-            'REQUEST_URI'    => '/principals',
-        ];
-
-        $request = HTTP\Sapi::createFromServerArray($serverVars);
-        $request->setBody($xml);
+        $request = new ServerRequest('REPort', '/principals', ['Depth' => '0'], $xml);
 
         $server = $this->getServer();
-        $server->httpRequest = $request;
+        
 
-        $server->start();
-        $response = $server->httpResponse->getResponse();
+        
+        $response = $server->handle($request);
         $responseBody = $response->getBody()->getContents();
 
         $this->assertEquals(207, $response->getStatusCode(), "Full body: " . $responseBody);
@@ -132,19 +116,18 @@ class PrincipalPropertySearchTest extends \PHPUnit_Framework_TestCase {
 
         $serverVars = [
             'REQUEST_METHOD' => 'REPORT',
-            'HTTP_DEPTH'     => '0',
-            'REQUEST_URI'    => '/',
+            'Depth'     => '0',
+            '/',
         ];
 
-        $request = HTTP\Sapi::createFromServerArray($serverVars);
-        $request->setBody($xml);
+        $request = new ServerRequest('REPORT', '/', ['Depth' => '0'], $xml);
 
         $server = $this->getServer();
-        $server->httpRequest = $request;
+        
 
-        $server->start();
+        
 
-        $response = $server->httpResponse->getResponse();
+        $response = $server->handle($request);
         $responseBody = $response->getBody()->getContents();
         $this->assertEquals(207, $response->getStatusCode(), $responseBody);
         $this->assertEquals([
@@ -204,21 +187,11 @@ class PrincipalPropertySearchTest extends \PHPUnit_Framework_TestCase {
     <d:getcontentlength />
   </d:prop>
 </d:principal-property-search>';
-
-        $serverVars = [
-            'REQUEST_METHOD' => 'REPORT',
-            'HTTP_DEPTH'     => '0',
-            'REQUEST_URI'    => '/',
-        ];
-
-        $request = HTTP\Sapi::createFromServerArray($serverVars);
-        $request->setBody($xml);
+        $request = new ServerRequest('REPORT', '/' , ['Depth' => '0'], $xml);
 
         $server = $this->getServer();
-        $server->httpRequest = $request;
 
-        $server->start();
-        $response = $server->httpResponse->getResponse();
+        $response = $server->handle($request);
         $responseBody = $response->getBody()->getContents();
 
         $this->assertEquals(207, $response->getStatusCode(), $responseBody);
@@ -279,20 +252,10 @@ class PrincipalPropertySearchTest extends \PHPUnit_Framework_TestCase {
   </d:prop>
 </d:principal-property-search>';
 
-        $serverVars = [
-            'REQUEST_METHOD' => 'REPORT',
-            'HTTP_DEPTH'     => '0',
-            'REQUEST_URI'    => '/',
-        ];
-
-        $request = HTTP\Sapi::createFromServerArray($serverVars);
-        $request->setBody($xml);
+        $request = new ServerRequest('REPORT', '/', ['Depth' => '0'], $xml);
 
         $server = $this->getServer();
-        $server->httpRequest = $request;
-
-        $server->start();
-        $response = $server->httpResponse->getResponse();
+        $response = $server->handle($request);
         $responseBody = $response->getBody()->getContents();
 
         $this->assertEquals(207, $response->getStatusCode(), $responseBody);
@@ -346,20 +309,13 @@ class PrincipalPropertySearchTest extends \PHPUnit_Framework_TestCase {
   </d:prop>
 </d:principal-property-search>';
 
-        $serverVars = [
-            'REQUEST_METHOD' => 'REPORT',
-            'HTTP_DEPTH'     => '0',
-            'REQUEST_URI'    => '/',
-        ];
-
-        $request = HTTP\Sapi::createFromServerArray($serverVars);
-        $request->setBody($xml);
+        $request = new ServerRequest('REPORT', '/', ['Depth' => '0'], $xml);
 
         $server = $this->getServer();
-        $server->httpRequest = $request;
+        
 
-        $server->start();
-        $response = $server->httpResponse->getResponse();
+        
+        $response = $server->handle($request);
         $responseBody = $response->getBody()->getContents();
 
 

--- a/tests/Sabre/DAVACL/PrincipalPropertySearchTest.php
+++ b/tests/Sabre/DAVACL/PrincipalPropertySearchTest.php
@@ -19,7 +19,6 @@ class PrincipalPropertySearchTest extends \PHPUnit_Framework_TestCase {
 
         $fakeServer = new DAV\Server($dir);
         $fakeServer->sapi = new HTTP\SapiMock();
-        $fakeServer->httpResponse = new HTTP\ResponseMock();
         $fakeServer->debugExceptions = true;
         $plugin = new MockPlugin();
         $plugin->allowAccessToNodesWithoutACL = true;
@@ -61,13 +60,14 @@ class PrincipalPropertySearchTest extends \PHPUnit_Framework_TestCase {
         $server = $this->getServer();
         $server->httpRequest = $request;
 
-        $server->exec();
+        $server->start();
 
-        $this->assertEquals(400, $server->httpResponse->getStatus(), $server->httpResponse->getBodyAsString());
+        $response = $server->httpResponse->getResponse();
+        $this->assertEquals(400, $response->getStatusCode(), $response->getBody()->getContents());
         $this->assertEquals([
             'X-Sabre-Version' => [DAV\Version::VERSION],
             'Content-Type'    => ['application/xml; charset=utf-8'],
-        ], $server->httpResponse->getHeaders());
+        ], $response->getHeaders());
 
     }
 
@@ -100,14 +100,16 @@ class PrincipalPropertySearchTest extends \PHPUnit_Framework_TestCase {
         $server = $this->getServer();
         $server->httpRequest = $request;
 
-        $server->exec();
+        $server->start();
+        $response = $server->httpResponse->getResponse();
+        $responseBody = $response->getBody()->getContents();
 
-        $this->assertEquals(207, $server->httpResponse->getStatus(), "Full body: " . $server->httpResponse->getBodyAsString());
+        $this->assertEquals(207, $response->getStatusCode(), "Full body: " . $responseBody);
         $this->assertEquals([
             'X-Sabre-Version' => [DAV\Version::VERSION],
             'Content-Type'    => ['application/xml; charset=utf-8'],
             'Vary'            => ['Brief,Prefer'],
-        ], $server->httpResponse->getHeaders());
+        ], $response->getHeaders());
 
     }
 
@@ -140,14 +142,16 @@ class PrincipalPropertySearchTest extends \PHPUnit_Framework_TestCase {
         $server = $this->getServer();
         $server->httpRequest = $request;
 
-        $server->exec();
+        $server->start();
 
-        $this->assertEquals(207, $server->httpResponse->status, $server->httpResponse->body);
+        $response = $server->httpResponse->getResponse();
+        $responseBody = $response->getBody()->getContents();
+        $this->assertEquals(207, $response->getStatusCode(), $responseBody);
         $this->assertEquals([
             'X-Sabre-Version' => [DAV\Version::VERSION],
             'Content-Type'    => ['application/xml; charset=utf-8'],
             'Vary'            => ['Brief,Prefer'],
-        ], $server->httpResponse->getHeaders());
+        ], $response->getHeaders());
 
 
         $check = [
@@ -161,7 +165,7 @@ class PrincipalPropertySearchTest extends \PHPUnit_Framework_TestCase {
             '/d:multistatus/d:response/d:propstat/d:status'                  => 4,
         ];
 
-        $xml = simplexml_load_string($server->httpResponse->body);
+        $xml = simplexml_load_string($responseBody);
         $xml->registerXPathNamespace('d', 'DAV:');
         foreach ($check as $v1 => $v2) {
 
@@ -172,7 +176,7 @@ class PrincipalPropertySearchTest extends \PHPUnit_Framework_TestCase {
             $count = 1;
             if (!is_int($v1)) $count = $v2;
 
-            $this->assertEquals($count, count($result), 'we expected ' . $count . ' appearances of ' . $xpath . ' . We found ' . count($result) . '. Full response body: ' . $server->httpResponse->body);
+            $this->assertEquals($count, count($result), 'we expected ' . $count . ' appearances of ' . $xpath . ' . We found ' . count($result) . '. Full response body: ' . $responseBody);
 
         }
 
@@ -213,14 +217,16 @@ class PrincipalPropertySearchTest extends \PHPUnit_Framework_TestCase {
         $server = $this->getServer();
         $server->httpRequest = $request;
 
-        $server->exec();
+        $server->start();
+        $response = $server->httpResponse->getResponse();
+        $responseBody = $response->getBody()->getContents();
 
-        $this->assertEquals(207, $server->httpResponse->status, $server->httpResponse->body);
+        $this->assertEquals(207, $response->getStatusCode(), $responseBody);
         $this->assertEquals([
             'X-Sabre-Version' => [DAV\Version::VERSION],
             'Content-Type'    => ['application/xml; charset=utf-8'],
             'Vary'            => ['Brief,Prefer'],
-        ], $server->httpResponse->getHeaders());
+        ], $response->getHeaders());
 
 
         $check = [
@@ -234,7 +240,7 @@ class PrincipalPropertySearchTest extends \PHPUnit_Framework_TestCase {
             '/d:multistatus/d:response/d:propstat/d:status'                  => 0,
         ];
 
-        $xml = simplexml_load_string($server->httpResponse->body);
+        $xml = simplexml_load_string($responseBody);
         $xml->registerXPathNamespace('d', 'DAV:');
         foreach ($check as $v1 => $v2) {
 
@@ -245,7 +251,7 @@ class PrincipalPropertySearchTest extends \PHPUnit_Framework_TestCase {
             $count = 1;
             if (!is_int($v1)) $count = $v2;
 
-            $this->assertEquals($count, count($result), 'we expected ' . $count . ' appearances of ' . $xpath . ' . We found ' . count($result) . '. Full response body: ' . $server->httpResponse->body);
+            $this->assertEquals($count, count($result), 'we expected ' . $count . ' appearances of ' . $xpath . ' . We found ' . count($result) . '. Full response body: ' . $responseBody);
 
         }
 
@@ -285,14 +291,16 @@ class PrincipalPropertySearchTest extends \PHPUnit_Framework_TestCase {
         $server = $this->getServer();
         $server->httpRequest = $request;
 
-        $server->exec();
+        $server->start();
+        $response = $server->httpResponse->getResponse();
+        $responseBody = $response->getBody()->getContents();
 
-        $this->assertEquals(207, $server->httpResponse->status, $server->httpResponse->body);
+        $this->assertEquals(207, $response->getStatusCode(), $responseBody);
         $this->assertEquals([
             'X-Sabre-Version' => [DAV\Version::VERSION],
             'Content-Type'    => ['application/xml; charset=utf-8'],
             'Vary'            => ['Brief,Prefer'],
-        ], $server->httpResponse->getHeaders());
+        ], $response->getHeaders());
 
 
         $check = [
@@ -306,7 +314,7 @@ class PrincipalPropertySearchTest extends \PHPUnit_Framework_TestCase {
             '/d:multistatus/d:response/d:propstat/d:status'                  => 4,
         ];
 
-        $xml = simplexml_load_string($server->httpResponse->body);
+        $xml = simplexml_load_string($responseBody);
         $xml->registerXPathNamespace('d', 'DAV:');
         foreach ($check as $v1 => $v2) {
 
@@ -317,7 +325,7 @@ class PrincipalPropertySearchTest extends \PHPUnit_Framework_TestCase {
             $count = 1;
             if (!is_int($v1)) $count = $v2;
 
-            $this->assertEquals($count, count($result), 'we expected ' . $count . ' appearances of ' . $xpath . ' . We found ' . count($result) . '. Full response body: ' . $server->httpResponse->body);
+            $this->assertEquals($count, count($result), 'we expected ' . $count . ' appearances of ' . $xpath . ' . We found ' . count($result) . '. Full response body: ' . $responseBody);
 
         }
 
@@ -350,14 +358,17 @@ class PrincipalPropertySearchTest extends \PHPUnit_Framework_TestCase {
         $server = $this->getServer();
         $server->httpRequest = $request;
 
-        $server->exec();
+        $server->start();
+        $response = $server->httpResponse->getResponse();
+        $responseBody = $response->getBody()->getContents();
 
-        $this->assertEquals(207, $server->httpResponse->status, $server->httpResponse->body);
+
+        $this->assertEquals(207, $response->getStatusCode(), $responseBody);
         $this->assertEquals([
             'X-Sabre-Version' => [DAV\Version::VERSION],
             'Content-Type'    => ['application/xml; charset=utf-8'],
             'Vary'            => ['Brief,Prefer'],
-        ], $server->httpResponse->getHeaders());
+        ], $response->getHeaders());
 
 
         $check = [
@@ -365,7 +376,7 @@ class PrincipalPropertySearchTest extends \PHPUnit_Framework_TestCase {
             '/d:multistatus/d:response' => 0,
         ];
 
-        $xml = simplexml_load_string($server->httpResponse->body);
+        $xml = simplexml_load_string($responseBody);
         $xml->registerXPathNamespace('d', 'DAV:');
         foreach ($check as $v1 => $v2) {
 
@@ -376,7 +387,7 @@ class PrincipalPropertySearchTest extends \PHPUnit_Framework_TestCase {
             $count = 1;
             if (!is_int($v1)) $count = $v2;
 
-            $this->assertEquals($count, count($result), 'we expected ' . $count . ' appearances of ' . $xpath . ' . We found ' . count($result) . '. Full response body: ' . $server->httpResponse->body);
+            $this->assertEquals($count, count($result), 'we expected ' . $count . ' appearances of ' . $xpath . ' . We found ' . count($result) . '. Full response body: ' . $responseBody);
 
         }
 

--- a/tests/Sabre/DAVACL/PrincipalSearchPropertySetTest.php
+++ b/tests/Sabre/DAVACL/PrincipalSearchPropertySetTest.php
@@ -18,7 +18,7 @@ class PrincipalSearchPropertySetTest extends \PHPUnit_Framework_TestCase {
         $principals = new PrincipalCollection($backend);
         $dir->addChild($principals);
 
-        $fakeServer = new DAV\Server($dir);
+        $fakeServer = new DAV\Server($dir, null, null, function() {});;
         $plugin = new Plugin();
         $plugin->allowUnauthenticatedAccess = false;
         $this->assertTrue($plugin instanceof Plugin);
@@ -42,7 +42,7 @@ class PrincipalSearchPropertySetTest extends \PHPUnit_Framework_TestCase {
 
         $this->assertEquals(400, $response->getStatusCode());
         $this->assertEquals([
-            'X-Sabre-Version' => [DAV\Version::VERSION],
+
             'Content-Type'    => ['application/xml; charset=utf-8'],
         ], $response->getHeaders());
 
@@ -60,7 +60,7 @@ class PrincipalSearchPropertySetTest extends \PHPUnit_Framework_TestCase {
 
         $this->assertEquals(400, $response->getStatusCode(), $response->getBody()->getContents());
         $this->assertEquals([
-            'X-Sabre-Version' => [DAV\Version::VERSION],
+
             'Content-Type'    => ['application/xml; charset=utf-8'],
         ], $response->getHeaders());
 
@@ -85,7 +85,7 @@ class PrincipalSearchPropertySetTest extends \PHPUnit_Framework_TestCase {
 
         $this->assertEquals(200, $response->getStatusCode(), $responseBody);
         $this->assertEquals([
-            'X-Sabre-Version' => [DAV\Version::VERSION],
+
             'Content-Type'    => ['application/xml; charset=utf-8'],
         ], $response->getHeaders());
 

--- a/tests/Sabre/DAVACL/PrincipalSearchPropertySetTest.php
+++ b/tests/Sabre/DAVACL/PrincipalSearchPropertySetTest.php
@@ -19,7 +19,6 @@ class PrincipalSearchPropertySetTest extends \PHPUnit_Framework_TestCase {
 
         $fakeServer = new DAV\Server($dir);
         $fakeServer->sapi = new HTTP\SapiMock();
-        $fakeServer->httpResponse = new HTTP\ResponseMock();
         $plugin = new Plugin();
         $plugin->allowUnauthenticatedAccess = false;
         $this->assertTrue($plugin instanceof Plugin);
@@ -47,13 +46,14 @@ class PrincipalSearchPropertySetTest extends \PHPUnit_Framework_TestCase {
         $server = $this->getServer();
         $server->httpRequest = $request;
 
-        $server->exec();
+        $server->start();
+        $response = $server->httpResponse->getResponse();
 
-        $this->assertEquals(400, $server->httpResponse->status);
+        $this->assertEquals(400, $response->getStatusCode());
         $this->assertEquals([
             'X-Sabre-Version' => [DAV\Version::VERSION],
             'Content-Type'    => ['application/xml; charset=utf-8'],
-        ], $server->httpResponse->getHeaders());
+        ], $response->getHeaders());
 
     }
 
@@ -74,13 +74,14 @@ class PrincipalSearchPropertySetTest extends \PHPUnit_Framework_TestCase {
         $server = $this->getServer();
         $server->httpRequest = $request;
 
-        $server->exec();
+        $server->start();
+        $response = $server->httpResponse->getResponse();
 
-        $this->assertEquals(400, $server->httpResponse->status, $server->httpResponse->body);
+        $this->assertEquals(400, $response->getStatusCode(), $response->getBody()->getContents());
         $this->assertEquals([
             'X-Sabre-Version' => [DAV\Version::VERSION],
             'Content-Type'    => ['application/xml; charset=utf-8'],
-        ], $server->httpResponse->getHeaders());
+        ], $response->getHeaders());
 
     }
 
@@ -101,13 +102,15 @@ class PrincipalSearchPropertySetTest extends \PHPUnit_Framework_TestCase {
         $server = $this->getServer();
         $server->httpRequest = $request;
 
-        $server->exec();
+        $server->start();
+        $response = $server->httpResponse->getResponse();
+        $responseBody = $response->getBody()->getContents();
 
-        $this->assertEquals(200, $server->httpResponse->status, $server->httpResponse->body);
+        $this->assertEquals(200, $response->getStatusCode(), $responseBody);
         $this->assertEquals([
             'X-Sabre-Version' => [DAV\Version::VERSION],
             'Content-Type'    => ['application/xml; charset=utf-8'],
-        ], $server->httpResponse->getHeaders());
+        ], $response->getHeaders());
 
 
         $check = [
@@ -119,7 +122,7 @@ class PrincipalSearchPropertySetTest extends \PHPUnit_Framework_TestCase {
             '/d:principal-search-property-set/d:principal-search-property/d:description'          => 2,
         ];
 
-        $xml = simplexml_load_string($server->httpResponse->body);
+        $xml = simplexml_load_string($responseBody);
         $xml->registerXPathNamespace('d', 'DAV:');
         $xml->registerXPathNamespace('s', 'http://sabredav.org/ns');
         foreach ($check as $v1 => $v2) {
@@ -131,7 +134,7 @@ class PrincipalSearchPropertySetTest extends \PHPUnit_Framework_TestCase {
             $count = 1;
             if (!is_int($v1)) $count = $v2;
 
-            $this->assertEquals($count, count($result), 'we expected ' . $count . ' appearances of ' . $xpath . ' . We found ' . count($result) . '. Full response body: ' . $server->httpResponse->body);
+            $this->assertEquals($count, count($result), 'we expected ' . $count . ' appearances of ' . $xpath . ' . We found ' . count($result) . '. Full response body: ' . $responseBody);
 
         }
 

--- a/tests/Sabre/DAVACL/PrincipalTest.php
+++ b/tests/Sabre/DAVACL/PrincipalTest.php
@@ -16,7 +16,7 @@ class PrincipalTest extends \PHPUnit_Framework_TestCase {
     }
 
     /**
-     * @expectedException Sabre\DAV\Exception
+     * @expectedException \Sabre\DAV\Exception
      */
     function testConstructNoUri() {
 

--- a/tests/Sabre/DAVACL/SimplePluginTest.php
+++ b/tests/Sabre/DAVACL/SimplePluginTest.php
@@ -118,7 +118,7 @@ class SimplePluginTest extends \PHPUnit_Framework_TestCase {
 
         $plugin = new Plugin();
         $plugin->allowUnauthenticatedAccess = false;
-        $server = new DAV\Server();
+        $server = new DAV\Server(null, null, null, function(){});
         $server->addPlugin($plugin);
         $this->assertEquals($expected, $plugin->getFlatPrivilegeSet(''));
 
@@ -128,7 +128,7 @@ class SimplePluginTest extends \PHPUnit_Framework_TestCase {
 
         $acl = new Plugin();
         $acl->allowUnauthenticatedAccess = false;
-        $server = new DAV\Server();
+        $server = new DAV\Server(null, null, null, function(){});
         $server->addPlugin($acl);
 
         $this->assertEquals([], $acl->getCurrentUserPrincipals());
@@ -147,7 +147,7 @@ class SimplePluginTest extends \PHPUnit_Framework_TestCase {
 
         $acl = new Plugin();
         $acl->allowUnauthenticatedAccess = false;
-        $server = new DAV\Server($tree);
+        $server = new DAV\Server($tree, null, null, function(){});
         $server->addPlugin($acl);
 
         $auth = new DAV\Auth\Plugin(new DAV\Auth\Backend\Mock());
@@ -175,7 +175,7 @@ class SimplePluginTest extends \PHPUnit_Framework_TestCase {
 
         $acl = new Plugin();
         $acl->allowUnauthenticatedAccess = false;
-        $server = new DAV\Server($tree);
+        $server = new DAV\Server($tree, null, null, function(){});
         $server->addPlugin($acl);
 
         $auth = new DAV\Auth\Plugin(new DAV\Auth\Backend\Mock());
@@ -216,7 +216,7 @@ class SimplePluginTest extends \PHPUnit_Framework_TestCase {
             new MockACLNode('foo', $acl),
         ];
 
-        $server = new DAV\Server($tree);
+        $server = new DAV\Server($tree, null, null, function(){});
         $aclPlugin = new Plugin();
         $aclPlugin->allowUnauthenticatedAccess = false;
         $server->addPlugin($aclPlugin);
@@ -252,7 +252,7 @@ class SimplePluginTest extends \PHPUnit_Framework_TestCase {
 
         ];
 
-        $server = new DAV\Server($tree);
+        $server = new DAV\Server($tree, null, null, function(){});
         $aclPlugin = new Plugin();
         $aclPlugin->allowUnauthenticatedAccess = false;
         $server->addPlugin($aclPlugin);
@@ -305,7 +305,7 @@ class SimplePluginTest extends \PHPUnit_Framework_TestCase {
 
         ];
 
-        $server = new DAV\Server($tree);
+        $server = new DAV\Server($tree, null, null, function(){});
         $aclPlugin = new Plugin();
         $aclPlugin->allowUnauthenticatedAccess = false;
         $server->addPlugin($aclPlugin);

--- a/tests/Sabre/DAVACL/SimplePluginTest.php
+++ b/tests/Sabre/DAVACL/SimplePluginTest.php
@@ -2,6 +2,7 @@
 
 namespace Sabre\DAVACL;
 
+use GuzzleHttp\Psr7\ServerRequest;
 use Sabre\DAV;
 use Sabre\HTTP;
 
@@ -153,7 +154,7 @@ class SimplePluginTest extends \PHPUnit_Framework_TestCase {
         $server->addPlugin($auth);
 
         //forcing login
-        $auth->beforeMethod(new HTTP\Request('GET', '/'), new HTTP\Response());
+        $auth->beforeMethod(new DAV\Psr7RequestWrapper(new ServerRequest('GET', '/')), new HTTP\Response());
 
         $this->assertEquals(['principals/admin'], $acl->getCurrentUserPrincipals());
 
@@ -181,7 +182,7 @@ class SimplePluginTest extends \PHPUnit_Framework_TestCase {
         $server->addPlugin($auth);
 
         //forcing login
-        $auth->beforeMethod(new HTTP\Request('GET', '/'), new HTTP\Response());
+        $auth->beforeMethod(new DAV\Psr7RequestWrapper(new ServerRequest('GET', '/')), new HTTP\Response());
 
         $expected = [
             'principals/admin',
@@ -260,7 +261,7 @@ class SimplePluginTest extends \PHPUnit_Framework_TestCase {
         $server->addPlugin($auth);
 
         //forcing login
-        $auth->beforeMethod(new HTTP\Request('GET', '/'), new HTTP\Response());
+        $auth->beforeMethod(new DAV\Psr7RequestWrapper(new ServerRequest('GET', '/')), new HTTP\Response());
 
         $expected = [
             '{DAV:}write',

--- a/tests/Sabre/DAVACL/Xml/Property/ACLTest.php
+++ b/tests/Sabre/DAVACL/Xml/Property/ACLTest.php
@@ -18,7 +18,7 @@ class ACLTest extends \PHPUnit_Framework_TestCase {
     function testSerializeEmpty() {
 
         $acl = new Acl([]);
-        $xml = (new DAV\Server())->xml->write('{DAV:}root', $acl);
+        $xml = (new DAV\Server(null, null, null, function(){}))->xml->write('{DAV:}root', $acl);
 
         $expected = '<?xml version="1.0"?>
 <d:root xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns" />';
@@ -42,7 +42,7 @@ class ACLTest extends \PHPUnit_Framework_TestCase {
         ];
 
         $acl = new Acl($privileges);
-        $xml = (new DAV\Server())->xml->write('{DAV:}root', $acl, '/');
+        $xml = (new DAV\Server(null, null, null, function(){}))->xml->write('{DAV:}root', $acl, '/');
 
         $expected = '<?xml version="1.0"?>
 <d:root xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns">
@@ -92,7 +92,7 @@ class ACLTest extends \PHPUnit_Framework_TestCase {
         ];
 
         $acl = new Acl($privileges);
-        $xml = (new DAV\Server())->xml->write('{DAV:}root', $acl, '/');
+        $xml = (new DAV\Server(null, null, null, function(){}))->xml->write('{DAV:}root', $acl, '/');
 
         $expected = '<?xml version="1.0"?>
 <d:root xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns">

--- a/tests/Sabre/DAVACL/Xml/Property/ACLTest.php
+++ b/tests/Sabre/DAVACL/Xml/Property/ACLTest.php
@@ -188,7 +188,7 @@ class ACLTest extends \PHPUnit_Framework_TestCase {
     }
 
     /**
-     * @expectedException Sabre\DAV\Exception\BadRequest
+     * @expectedException \Sabre\DAV\Exception\BadRequest
      */
     function testUnserializeNoPrincipal() {
 
@@ -277,7 +277,7 @@ class ACLTest extends \PHPUnit_Framework_TestCase {
     }
 
     /**
-     * @expectedException Sabre\DAV\Exception\NotImplemented
+     * @expectedException \Sabre\DAV\Exception\NotImplemented
      */
     function testUnserializeDeny() {
 

--- a/tests/Sabre/DAVACL/Xml/Property/AclRestrictionsTest.php
+++ b/tests/Sabre/DAVACL/Xml/Property/AclRestrictionsTest.php
@@ -17,7 +17,7 @@ class AclRestrictionsTest extends \PHPUnit_Framework_TestCase {
     function testSerialize() {
 
         $prop = new AclRestrictions();
-        $xml = (new DAV\Server())->xml->write('{DAV:}root', $prop);
+        $xml = (new DAV\Server(null, null, null, function(){}))->xml->write('{DAV:}root', $prop);
 
         $expected = '<?xml version="1.0"?>
 <d:root xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns"><d:grant-only/><d:no-invert/></d:root>';

--- a/tests/Sabre/DAVACL/Xml/Property/CurrentUserPrivilegeSetTest.php
+++ b/tests/Sabre/DAVACL/Xml/Property/CurrentUserPrivilegeSetTest.php
@@ -16,7 +16,7 @@ class CurrentUserPrivilegeSetTest extends \PHPUnit_Framework_TestCase {
             '{DAV:}write',
         ];
         $prop = new CurrentUserPrivilegeSet($privileges);
-        $xml = (new DAV\Server())->xml->write('{DAV:}root', $prop);
+        $xml = (new DAV\Server(null, null, null, function(){}))->xml->write('{DAV:}root', $prop);
 
         $expected = <<<XML
 <d:root xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns">

--- a/tests/Sabre/DAVACL/Xml/Property/PrincipalTest.php
+++ b/tests/Sabre/DAVACL/Xml/Property/PrincipalTest.php
@@ -42,7 +42,7 @@ class PrincipalTest extends \PHPUnit_Framework_TestCase {
 
         $prin = new Principal(Principal::UNAUTHENTICATED);
 
-        $xml = (new DAV\Server())->xml->write('{DAV:}principal', $prin);
+        $xml = (new DAV\Server(null, null, null, function(){}))->xml->write('{DAV:}principal', $prin);
 
         $this->assertXmlStringEqualsXmlString('
 <d:principal xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns">
@@ -58,7 +58,7 @@ class PrincipalTest extends \PHPUnit_Framework_TestCase {
     function testSerializeAuthenticated() {
 
         $prin = new Principal(Principal::AUTHENTICATED);
-        $xml = (new DAV\Server())->xml->write('{DAV:}principal', $prin);
+        $xml = (new DAV\Server(null, null, null, function(){}))->xml->write('{DAV:}principal', $prin);
 
         $this->assertXmlStringEqualsXmlString('
 <d:principal xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns">
@@ -74,7 +74,7 @@ class PrincipalTest extends \PHPUnit_Framework_TestCase {
     function testSerializeHref() {
 
         $prin = new Principal(Principal::HREF, 'principals/admin');
-        $xml = (new DAV\Server())->xml->write('{DAV:}principal', $prin, '/');
+        $xml = (new DAV\Server(null, null, null, function(){}))->xml->write('{DAV:}principal', $prin, '/');
 
         $this->assertXmlStringEqualsXmlString('
 <d:principal xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns">

--- a/tests/Sabre/DAVACL/Xml/Property/PrincipalTest.php
+++ b/tests/Sabre/DAVACL/Xml/Property/PrincipalTest.php
@@ -27,7 +27,7 @@ class PrincipalTest extends \PHPUnit_Framework_TestCase {
 
     /**
      * @depends testSimple
-     * @expectedException Sabre\DAV\Exception
+     * @expectedException \Sabre\DAV\Exception
      */
     function testNoHref() {
 
@@ -121,7 +121,7 @@ class PrincipalTest extends \PHPUnit_Framework_TestCase {
     }
 
     /**
-     * @expectedException Sabre\DAV\Exception\BadRequest
+     * @expectedException \Sabre\DAV\Exception\BadRequest
      */
     function testUnserializeUnknown() {
 

--- a/tests/Sabre/DAVACL/Xml/Property/SupportedPrivilegeSetTest.php
+++ b/tests/Sabre/DAVACL/Xml/Property/SupportedPrivilegeSetTest.php
@@ -25,7 +25,7 @@ class SupportedPrivilegeSetTest extends \PHPUnit_Framework_TestCase {
 
         $prop = new SupportedPrivilegeSet([]);
 
-        $xml = (new DAV\Server())->xml->write('{DAV:}supported-privilege-set', $prop);
+        $xml = (new DAV\Server(null, null, null, function(){}))->xml->write('{DAV:}supported-privilege-set', $prop);
 
         $this->assertXmlStringEqualsXmlString('
 <d:supported-privilege-set xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns">
@@ -50,7 +50,7 @@ class SupportedPrivilegeSetTest extends \PHPUnit_Framework_TestCase {
             ]
         ]);
 
-        $xml = (new DAV\Server())->xml->write('{DAV:}supported-privilege-set', $prop);
+        $xml = (new DAV\Server(null, null, null, function(){}))->xml->write('{DAV:}supported-privilege-set', $prop);
 
         $this->assertXmlStringEqualsXmlString('
 <d:supported-privilege-set xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns">

--- a/tests/Sabre/DAVServerTest.php
+++ b/tests/Sabre/DAVServerTest.php
@@ -120,7 +120,12 @@ abstract class DAVServerTest extends \PHPUnit_Framework_TestCase {
         $this->setUpBackends();
         $this->setUpTree();
 
-        $this->server = new DAV\Server($this->tree);
+        $this->server = new DAV\Server(
+            $this->tree,
+            function() { return new \GuzzleHttp\Psr7\Response(); },
+            new ServerRequest('GET', ''),
+            function(ResponseInterface $response) { }
+        );
 
         $this->server->debugExceptions = true;
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -53,3 +53,6 @@ foreach ($config as $key => $value) {
 
 if (!file_exists(SABRE_TEMPDIR)) mkdir(SABRE_TEMPDIR);
 if (file_exists('.sabredav')) unlink('.sabredav');
+
+
+\Sabre\DAV\Server::$exposeVersion = false;

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -4,6 +4,9 @@ set_include_path(__DIR__ . '/../lib/' . PATH_SEPARATOR . __DIR__ . PATH_SEPARATO
 
 $autoLoader = include __DIR__ . '/../vendor/autoload.php';
 
+class PHPUnit_Framework_TestCase extends PHPUnit\Framework\TestCase {
+
+}
 // SabreDAV tests auto loading
 $autoLoader->add('Sabre\\', __DIR__);
 // VObject tests auto loading

--- a/tests/phpunit.xml.dist
+++ b/tests/phpunit.xml.dist
@@ -43,4 +43,5 @@
        <directory suffix=".php">../lib/</directory>
     </whitelist>
   </filter>
+    <php><ini name="memory_limit" value="768M"/></php>
 </phpunit>


### PR DESCRIPTION
This is a work in progress.

- [x] Convert tests to only use PSR-7 for the response object.
- [] Convert tests to only use PSR-7 for the request object.
- [ ] Identify next tasks.

For now I've created a PSR7 wrapper that takes a response factory and implements the `Response` interface. This way we can run tests against a native PSR7 implementation with minimal changes.
(The only change required is the way to get the PSR7 response object from the server).