### PR TITLE
Allow nesting of trees

### DIFF
--- a/lib/DAV/Tree.php
+++ b/lib/DAV/Tree.php
@@ -14,7 +14,7 @@ use Sabre\Uri;
  * @author Evert Pot (http://evertpot.com/)
  * @license http://sabre.io/license/ Modified BSD License
  */
-class Tree {
+class Tree implements ICollection {
 
     /**
      * The root node
@@ -176,9 +176,13 @@ class Tree {
      * @param string $path
      * @return void
      */
-    function delete($path) {
+    function delete($path = null) {
 
-        $node = $this->getNodeForPath($path);
+        if ($path === null || $path === '') {
+            $node = $this->rootNode;
+        } else {
+            $node = $this->getNodeForPath($path);
+        }
         $node->delete();
 
         list($parent) = Uri\split($path);
@@ -189,12 +193,17 @@ class Tree {
     /**
      * Returns a list of childnodes for a given path.
      *
-     * @param string $path
+     * @param string|null $path
      * @return \Traversable
      */
-    function getChildren($path) {
+    function getChildren($path = null) {
 
-        $node = $this->getNodeForPath($path);
+        if ($path === null || $path === '') {
+            $node = $this->rootNode;
+        } else {
+            $node = $this->getNodeForPath($path);
+        }
+
         $basePath = trim($path, '/');
         if ($basePath !== '') $basePath .= '/';
 
@@ -341,4 +350,32 @@ class Tree {
 
     }
 
+    function createFile($name, $data = null) {
+        return $this->rootNode->createFile($name, $data);
+    }
+
+    function createDirectory($name) {
+        $this->rootNode->createDirectory($name);
+    }
+
+    function getChild($name) {
+        return $this->rootNode->getChild($name);
+    }
+
+    function childExists($name) {
+        return $this->rootNode->childExists($name);
+    }
+
+    function getName() {
+        return $this->rootNode->getName();
+    }
+
+    function setName($name) {
+        $this->rootNode->setName($name);
+    }
+
+    function getLastModified()
+    {
+        return $this->rootNode->getLastModified();
+    }
 }

--- a/lib/DAV/Tree.php
+++ b/lib/DAV/Tree.php
@@ -60,21 +60,15 @@ class Tree implements ICollection {
             return $this->rootNode;
         }
 
-        // Attempting to fetch its parent
-        list($parentName, $baseName) = Uri\split($path);
+        $parts = explode('/', $path);
+        $node = $this->rootNode;
 
-        // If there was no parent, we must simply ask it from the root node.
-        if ($parentName === "") {
-            $node = $this->rootNode->getChild($baseName);
-        } else {
-            // Otherwise, we recursively grab the parent and ask him/her.
-            $parent = $this->getNodeForPath($parentName);
-
-            if (!($parent instanceof ICollection))
+        while (count($parts)) {
+            if (!($node instanceof ICollection))
                 throw new Exception\NotFound('Could not find node at path: ' . $path);
 
-            $node = $parent->getChild($baseName);
-
+            $part = array_shift($parts);
+            if ($part !== '') $node = $node->getChild($part);
         }
 
         $this->cache[$path] = $node;

--- a/lib/DAV/Tree.php
+++ b/lib/DAV/Tree.php
@@ -67,8 +67,13 @@ class Tree implements ICollection {
             if (!($node instanceof ICollection))
                 throw new Exception\NotFound('Could not find node at path: ' . $path);
 
-            $part = array_shift($parts);
-            if ($part !== '') $node = $node->getChild($part);
+            if ($node instanceof self) {
+                $node = $node->getNodeForPath(implode('/', $parts));
+                break;
+            } else {
+                $part = array_shift($parts);
+                if ($part !== '') $node = $node->getChild($part);
+            }
         }
 
         $this->cache[$path] = $node;

--- a/tests/Sabre/DAV/TreeTest.php
+++ b/tests/Sabre/DAV/TreeTest.php
@@ -97,6 +97,13 @@ class TreeTest extends \PHPUnit\Framework\TestCase {
 
     }
 
+    function testGetSubTreeNode() {
+
+        $tree = new TreeMock();
+        $this->assertTrue($tree->nodeExists('subtree/sub/1'));
+
+    }
+
 }
 
 class TreeMock extends Tree {
@@ -119,7 +126,12 @@ class TreeMock extends Tree {
                     new TreeFileTester('1'),
                     new TreeFileTester('2'),
                     new TreeFileTester('3'),
-                ])
+                ]),
+                new Tree(new TreeDirectoryTester('subtree', [
+                    new TreeDirectoryTester('sub', [
+                        new TreeFileTester('1')
+                    ]),
+                ]))
             ])
         );
 


### PR DESCRIPTION
Makes `Tree` implement `ICollection` and modify `getNodeForPath` to pass the request to nested trees.

My main use case for this in Nextcloud is that for part of the tree we can optimize `getNodeForPath` by directly getting the target node instead of going trough all parent nodes, but there is currently no clean way to apply this optimization to only a part of the dav tree.
With nested trees we could put this optimization in a separate `Tree` subclass and nest it into the "main" tree.