### PR TITLE
Add INodeByPath interface to allow optimizing getNodeForPath

### DIFF
--- a/lib/DAV/INodeByPath.php
+++ b/lib/DAV/INodeByPath.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sabre\DAV;
+
+/**
+ * INodeByPath.
+ *
+ * This interface adds a tiny bit of functionality to collections.
+ *
+ * Getting a node that is deep in the tree normally requires going trough each parent node
+ * which can cause a significant performance overhead.
+ *
+ * Implementing this interface allows solving this overhead by directly jumping to the target node.
+ *
+ * @copyright Copyright (C) Robin Appelman (https://icewind.nl/)
+ * @author Robin Appelman (https://icewind.nl/)
+ * @license http://sabre.io/license/ Modified BSD License
+ */
+interface INodeByPath
+{
+    /**
+     * Returns the INode object for the requested path.
+     *
+     * In case where this collection can not retrieve the requested node
+     * but also can not determine that the node does not exists,
+     * null should be returned to signal that the caller should fallback
+     * to walking the directory tree.
+     *
+     * @param string $path
+     *
+     * @return INode|null
+     */
+    public function getNodeForPath($path);
+}

--- a/lib/DAV/Tree.php
+++ b/lib/DAV/Tree.php
@@ -16,7 +16,7 @@ use Sabre\Uri;
  * @author Evert Pot (http://evertpot.com/)
  * @license http://sabre.io/license/ Modified BSD License
  */
-class Tree
+class Tree implements INodeByPath
 {
     /**
      * The root node.

--- a/lib/DAV/Tree.php
+++ b/lib/DAV/Tree.php
@@ -62,20 +62,18 @@ class Tree
             return $this->rootNode;
         }
 
-        // Attempting to fetch its parent
-        list($parentName, $baseName) = Uri\split($path);
+        $parts = explode('/', $path);
+        $node = $this->rootNode;
 
-        // If there was no parent, we must simply ask it from the root node.
-        if ('' === $parentName) {
-            $node = $this->rootNode->getChild($baseName);
-        } else {
-            // Otherwise, we recursively grab the parent and ask him/her.
-            $parent = $this->getNodeForPath($parentName);
-
-            if (!($parent instanceof ICollection)) {
+        while (count($parts)) {
+            if (!($node instanceof ICollection)) {
                 throw new Exception\NotFound('Could not find node at path: '.$path);
             }
-            $node = $parent->getChild($baseName);
+
+            $part = array_shift($parts);
+            if ('' !== $part) {
+                $node = $node->getChild($part);
+            }
         }
 
         $this->cache[$path] = $node;

--- a/lib/DAV/Tree.php
+++ b/lib/DAV/Tree.php
@@ -70,6 +70,14 @@ class Tree implements INodeByPath
                 throw new Exception\NotFound('Could not find node at path: '.$path);
             }
 
+            if ($node instanceof INodeByPath) {
+                $targetNode = $node->getNodeForPath(implode('/', $parts));
+                if ($targetNode instanceof Node) {
+                    $node = $targetNode;
+                    break;
+                }
+            }
+
             $part = array_shift($parts);
             if ('' !== $part) {
                 $node = $node->getChild($part);

--- a/tests/Sabre/DAV/TreeTest.php
+++ b/tests/Sabre/DAV/TreeTest.php
@@ -100,6 +100,13 @@ class TreeTest extends \PHPUnit\Framework\TestCase
         self::assertArrayHasKey('multi/1', $result);
         self::assertArrayHasKey('multi/2', $result);
     }
+
+    public function testGetSubTreeNode()
+    {
+        $tree = new TreeMock();
+        $this->assertInstanceOf(INode::class, $tree->getNodeForPath('subtree/sub/1'));
+        $this->assertInstanceOf(INode::class, $tree->getNodeForPath('subtree/2/3'));
+    }
 }
 
 class TreeMock extends Tree
@@ -125,6 +132,12 @@ class TreeMock extends Tree
                 ]),
                 new TreeDirectoryTester('1', [
                     new TreeDirectoryTester('2'),
+                ]),
+                new NodeByPathTester('subtree', [
+                    new TreeFileTester('sub/1'),
+                    new TreeDirectoryTester('2', [
+                        new TreeFileTester('3'),
+                    ]),
                 ]),
             ])
         );
@@ -174,6 +187,18 @@ class TreeDirectoryTester extends SimpleCollection
     {
         $this->isRenamed = true;
         $this->name = $name;
+    }
+}
+
+class NodeByPathTester extends SimpleCollection implements INodeByPath
+{
+    public function getNodeForPath($path)
+    {
+        if (isset($this->children[$path])) {
+            return $this->children[$path];
+        } else {
+            return null;
+        }
     }
 }
 


### PR DESCRIPTION
As discussed in https://github.com/sabre-io/dav/pull/1059, doing this in a separate PR so the other can stay open for the "nested tree" discussion.

A few points of detail

- `INodeByPath` does not extend `ICollection` so `Tree` can implement the interface without further changes, having `Tree` implement this does not really provide any benefit atm though and was mostly done to support future tree nesting. It might be better to change it to extend `ICollection` and make `Tree` implement it if we ever make a collection.
- `INodeByPath::getNodeForPath` can return `null`, I fear that requiring any collection implementing the interface to be able to retrieve **all** nodes within it's path would prevent the ability to cleanly allow nesting collections that implement the interface