### PR TITLE
Repace multiple slash in URI

### DIFF
--- a/lib/DAV/Server.php
+++ b/lib/DAV/Server.php
@@ -554,7 +554,7 @@ class Server implements LoggerAwareInterface, EmitterInterface
             $uri = parse_url($uri, PHP_URL_PATH);
         }
 
-        $uri = Uri\normalize(str_replace('//', '/', $uri));
+        $uri = Uri\normalize(preg_replace('|/+|', '/', $uri));
         $baseUri = Uri\normalize($this->getBaseUri());
 
         if (0 === strpos($uri, $baseUri)) {

--- a/tests/Sabre/DAV/ServerSimpleTest.php
+++ b/tests/Sabre/DAV/ServerSimpleTest.php
@@ -135,6 +135,8 @@ class ServerSimpleTest extends AbstractServer
             'http://www.example.org/root/somepath',
             '/root/somepath',
             '/root/somepath/',
+            '//root/somepath/',
+            '///root///somepath///',
         ];
 
         $this->server->setBaseUri('/root/');


### PR DESCRIPTION
If the URI contains multiple slashes, then "be nice to the caller" and replace them with a single slash.
e.g. someone that asks for some URI like:
```
/////abc/def//ghi/jkl///mno//
```

any extra slashes with empty between them actually make no difference, and we can "compress" them.

Should help in cases where a client is "accidentally" sending bonus slashes or...

e.g. https://github.com/owncloud/core/issues/33119#issuecomment-433669371