### PR TITLE
Fixes #1135 replaced continue with break in switch statement.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 ChangeLog
 =========
 
+3.2.4 (2019-03-20)
+------------------
+
+* #1135: Fix use of continue in switch for PHP7.3 compabiltiy
+
 3.2.3 (2018-10-19)
 ------------------
 

--- a/lib/CalDAV/ICSExportPlugin.php
+++ b/lib/CalDAV/ICSExportPlugin.php
@@ -318,7 +318,7 @@ class ICSExportPlugin extends DAV\ServerPlugin {
                     // VTIMEZONE is special, because we need to filter out the duplicates
                     case 'VTIMEZONE' :
                         // Naively just checking tzid.
-                        if (in_array((string) $child->TZID, $collectedTimezones)) {
+                        if (in_array((string)$child->TZID, $collectedTimezones)) {
                             break;
                         }
 

--- a/lib/CalDAV/ICSExportPlugin.php
+++ b/lib/CalDAV/ICSExportPlugin.php
@@ -318,7 +318,9 @@ class ICSExportPlugin extends DAV\ServerPlugin {
                     // VTIMEZONE is special, because we need to filter out the duplicates
                     case 'VTIMEZONE' :
                         // Naively just checking tzid.
-                        if (in_array((string)$child->TZID, $collectedTimezones)) continue;
+                        if (in_array((string) $child->TZID, $collectedTimezones)) {
+                            break;
+                        }
 
                         $timezones[] = clone $child;
                         $collectedTimezones[] = $child->TZID;

--- a/lib/DAV/Version.php
+++ b/lib/DAV/Version.php
@@ -14,6 +14,6 @@ class Version {
     /**
      * Full version number
      */
-    const VERSION = '3.2.2';
+    const VERSION = '3.2.4';
 
 }


### PR DESCRIPTION
This is a bug fix for 3.2 branch, that fixes the issue with the use of continue statement inside a switch block in PHP 7.3.