### PR TITLE
Update Directory.php - Fix folder (file) move issue if rename fails (…

### DIFF
--- a/lib/DAV/FSExt/Directory.php
+++ b/lib/DAV/FSExt/Directory.php
@@ -207,8 +207,6 @@ class Directory extends Node implements DAV\ICollection, DAV\IQuota, DAV\IMoveTa
         // PHP allows us to access protected properties from other objects, as
         // long as they are defined in a class that has a shared inheritance
         // with the current class.
-        rename($sourceNode->path, $this->path.'/'.$targetName);
-
-        return true;
+        return rename($sourceNode->path, $this->path.'/'.$targetName);
     }
 }


### PR DESCRIPTION
…if $sourceNode->path is NULL)

The moveInto function shall always return the result value of the rename function instead of always true. So it would return false if the rename function fails (as $sourceNode->path seems NULL by default) and not always true as currently...