### PR TITLE
Avoid malformed address

### DIFF
--- a/lib/CalDAV/Schedule/IMipPlugin.php
+++ b/lib/CalDAV/Schedule/IMipPlugin.php
@@ -112,7 +112,7 @@ class IMipPlugin extends DAV\ServerPlugin
         if ($iTipMessage->senderName) {
             $sender = $iTipMessage->senderName.' <'.$sender.'>';
         }
-        if ($iTipMessage->recipientName) {
+        if ($iTipMessage->recipientName && $iTipMessage->recipientName !== $recipient) {
             $recipient = $iTipMessage->recipientName.' <'.$recipient.'>';
         }
 


### PR DESCRIPTION
Hi,

I faced following error sending invite to `name@mail.com` :
```
name@mail.com <name@mail.com>: malformed address: <name@mail.com> may not follow name@mail.com
```

This PR should then solve the issue.

Thank you 👍 