### PR TITLE
Fix sending mail

### DIFF
--- a/lib/CalDAV/Schedule/IMipPlugin.php
+++ b/lib/CalDAV/Schedule/IMipPlugin.php
@@ -112,7 +112,7 @@ class IMipPlugin extends DAV\ServerPlugin
         if ($iTipMessage->senderName) {
             $sender = $iTipMessage->senderName.' <'.$sender.'>';
         }
-        if ($iTipMessage->recipientName) {
+        if ($iTipMessage->recipientName && $iTipMessage->recipientName != $recipient) {
             $recipient = $iTipMessage->recipientName.' <'.$recipient.'>';
         }
 

--- a/lib/CalDAV/Schedule/IMipPlugin.php
+++ b/lib/CalDAV/Schedule/IMipPlugin.php
@@ -122,7 +122,7 @@ class IMipPlugin extends DAV\ServerPlugin
                 $subject = 'Re: '.$summary;
                 break;
             case 'REQUEST':
-                $subject = $summary;
+                $subject = 'Invitation: '.$summary;
                 break;
             case 'CANCEL':
                 $subject = 'Cancelled: '.$summary;

--- a/tests/Sabre/CalDAV/Schedule/IMipPluginTest.php
+++ b/tests/Sabre/CalDAV/Schedule/IMipPluginTest.php
@@ -113,7 +113,7 @@ ICS;
         $expected = [
             [
                 'to' => 'Recipient <recipient@example.org>',
-                'subject' => 'Birthday party',
+                'subject' => 'Invitation: Birthday party',
                 'body' => $ics,
                 'headers' => [
                     'Reply-To: Sender <sender@example.org>',
@@ -206,5 +206,31 @@ ICS;
         $expected = [];
         $this->assertEquals($expected, $result);
         $this->assertEquals('1.0', $message->getScheduleStatus()[0]);
+    }
+
+    public function testRecipientNameIsEmail()
+    {
+        $message = new Message();
+        $message->sender = 'mailto:sender@example.org';
+        $message->senderName = 'Sender';
+        $message->recipient = 'mailto:recipient@example.org';
+        $message->recipientName = 'recipient@example.org';
+        $message->method = 'REQUEST';
+
+        $ics = <<<ICS
+BEGIN:VCALENDAR\r
+METHOD:REQUEST\r
+BEGIN:VEVENT\r
+SUMMARY:Birthday party\r
+END:VEVENT\r
+END:VCALENDAR\r
+
+ICS;
+
+        $message->message = Reader::read($ics);
+
+        $result = $this->schedule($message);
+
+        $this->assertEquals('recipient@example.org', $result[0]['to']);
     }
 }


### PR DESCRIPTION
These changes are needed to get mail working on my server. Publishing in case someone else has the same problem. I think this does no harm when merging for everyone.

    if ($iTipMessage->recipientName && $iTipMessage->recipientName != $recipient) {

My server silently fails when using `mail()` with a receiver that looks like  `a@b.c <a@b.c>`. It works fine when using `d <a@b.c>`. Looks like it does not accept using an email address as name.

    $subject = 'Invitation: '.$summary;

My server displays an error when not prepending a string: `mail() expects parameter 2 to be string, object given`