### PR TITLE
Fixed null path error

### DIFF
--- a/lib/CalDAV/Plugin.php
+++ b/lib/CalDAV/Plugin.php
@@ -77,6 +77,10 @@ class Plugin extends DAV\ServerPlugin
         // parents extend IExtendedCollection
         list($parent, $name) = Uri\split($uri);
 
+        if ('' === $uri) {
+            $parent = '';
+        }
+
         $node = $this->server->tree->getNodeForPath($parent);
 
         if ($node instanceof DAV\IExtendedCollection) {


### PR DESCRIPTION
When opening the http/get user interface on the `/` path, an error is displayed. All other pages work. Might be related to #1165. Where do all those `NULL` paths come from? Do you have an idea, @DeepDiver1975 @staabm? Instead of fixing in each plugin, we should probably fix this somewhere further up the call stack.

```
#0 baikal/vendor/sabre/dav/lib/DAV/Tree.php(58): trim(NULL, '/')
#1 baikal/vendor/sabre/dav/lib/CalDAV/Plugin.php(80): Sabre\DAV\Tree->getNodeForPath(NULL)
#2 baikal/vendor/sabre/dav/lib/DAV/Server.php(520): Sabre\CalDAV\Plugin->getHTTPMethods('')
#3 baikal/vendor/sabre/dav/lib/DAV/CorePlugin.php(825): Sabre\DAV\Server->getAllowedMethods('')
#4 baikal/vendor/sabre/dav/lib/DAV/Browser/PropFindAll.php(53): Sabre\DAV\CorePlugin->Sabre\DAV\{closure}()
#5 baikal/vendor/sabre/dav/lib/DAV/CorePlugin.php(827): Sabre\DAV\Browser\PropFindAll->handle('{DAV:}supported...', Object(Closure))
#6 baikal/vendor/sabre/event/lib/WildcardEmitterTrait.php(96): Sabre\DAV\CorePlugin->propFind(Object(Sabre\DAV\Browser\PropFindAll), Object(Sabre\DAV\SimpleCollection))
#7 baikal/vendor/sabre/dav/lib/DAV/Server.php(1053): Sabre\DAV\Server->emit('propFind', Array)
#8 baikal/vendor/sabre/dav/lib/DAV/Browser/Plugin.php(344): Sabre\DAV\Server->getPropertiesByNode(Object(Sabre\DAV\Browser\PropFindAll), Object(Sabre\DAV\SimpleCollection))
#9 baikal/vendor/sabre/dav/lib/DAV/Browser/Plugin.php(143): Sabre\DAV\Browser\Plugin->generateDirectoryIndex('')
#10 baikal/vendor/sabre/event/lib/WildcardEmitterTrait.php(96): Sabre\DAV\Browser\Plugin->httpGet(Object(Sabre\HTTP\Request), Object(Sabre\HTTP\Response))
#11 baikal/vendor/sabre/dav/lib/DAV/Server.php(464): Sabre\DAV\Server->emit('method:GET', Array)
#12 baikal/vendor/sabre/dav/lib/DAV/Server.php(241): Sabre\DAV\Server->invokeMethod(Object(Sabre\HTTP\Request), Object(Sabre\HTTP\Response))
#13 baikal/vendor/sabre/dav/lib/DAV/Server.php(309): Sabre\DAV\Server->start()
#14 baikal/Core/Frameworks/Baikal/Core/Server.php(123): Sabre\DAV\Server->exec()
#15 baikal/html/dav.php(61): Baikal\Core\Server->start()
#16 {main}
```