### PR TITLE
Add `afterCopy` event

### DIFF
--- a/lib/DAV/CorePlugin.php
+++ b/lib/DAV/CorePlugin.php
@@ -682,6 +682,7 @@ class CorePlugin extends ServerPlugin {
         }
 
         $this->server->tree->copy($path, $copyInfo['destination']);
+		$this->server->emit('afterCopy', [$path, $copyInfo['destination']]);
         $this->server->emit('afterBind', [$copyInfo['destination']]);
 
         // If a resource was overwritten we should send a 204, otherwise a 201

--- a/lib/DAV/CorePlugin.php
+++ b/lib/DAV/CorePlugin.php
@@ -682,7 +682,7 @@ class CorePlugin extends ServerPlugin {
         }
 
         $this->server->tree->copy($path, $copyInfo['destination']);
-		$this->server->emit('afterCopy', [$path, $copyInfo['destination']]);
+        $this->server->emit('afterCopy', [$path, $copyInfo['destination']]);
         $this->server->emit('afterBind', [$copyInfo['destination']]);
 
         // If a resource was overwritten we should send a 204, otherwise a 201

--- a/lib/DAV/PropertyStorage/Backend/BackendInterface.php
+++ b/lib/DAV/PropertyStorage/Backend/BackendInterface.php
@@ -77,4 +77,17 @@ interface BackendInterface {
      */
     function move($source, $destination);
 
+	/**
+	 * This method is called after a successful COPY
+	 *
+	 * This should be used to migrate all properties from one path to another.
+	 * Note that entire collections may be moved, so ensure that all properties
+	 * for children are also moved along.
+	 *
+	 * @param string $source
+	 * @param string $destination
+	 * @return void
+	 */
+	function copy($source, $destination);
+
 }

--- a/lib/DAV/PropertyStorage/Backend/BackendInterface.php
+++ b/lib/DAV/PropertyStorage/Backend/BackendInterface.php
@@ -77,7 +77,7 @@ interface BackendInterface {
      */
     function move($source, $destination);
 
-	/**
+    /**
 	 * This method is called after a successful COPY
 	 *
 	 * This should be used to migrate all properties from one path to another.
@@ -88,6 +88,5 @@ interface BackendInterface {
 	 * @param string $destination
 	 * @return void
 	 */
-	function copy($source, $destination);
-
+    function copy($source, $destination);
 }

--- a/lib/DAV/PropertyStorage/Backend/PDO.php
+++ b/lib/DAV/PropertyStorage/Backend/PDO.php
@@ -243,7 +243,7 @@ SQL;
 
     }
 
-	/**
+    /**
 	 * This method is called after a successful COPY
 	 *
 	 * This should be used to migrate all properties from one path to another.
@@ -254,7 +254,7 @@ SQL;
 	 * @param string $destination
 	 * @return void
 	 */
-	function copy($source, $destination) {
-		// TODO: Implement copy() method.
-	}
+    function copy($source, $destination) {
+    	// TODO: Implement copy() method.
+    }
 }

--- a/lib/DAV/PropertyStorage/Backend/PDO.php
+++ b/lib/DAV/PropertyStorage/Backend/PDO.php
@@ -243,4 +243,18 @@ SQL;
 
     }
 
+	/**
+	 * This method is called after a successful COPY
+	 *
+	 * This should be used to migrate all properties from one path to another.
+	 * Note that entire collections may be moved, so ensure that all properties
+	 * for children are also moved along.
+	 *
+	 * @param string $source
+	 * @param string $destination
+	 * @return void
+	 */
+	function copy($source, $destination) {
+		// TODO: Implement copy() method.
+	}
 }

--- a/lib/DAV/PropertyStorage/Plugin.php
+++ b/lib/DAV/PropertyStorage/Plugin.php
@@ -69,7 +69,7 @@ class Plugin extends ServerPlugin {
         $server->on('propFind',    [$this, 'propFind'], 130);
         $server->on('propPatch',   [$this, 'propPatch'], 300);
         $server->on('afterMove',   [$this, 'afterMove']);
-		$server->on('afterCopy',   [$this, 'afterCopy']);
+        $server->on('afterCopy',   [$this, 'afterCopy']);
         $server->on('afterUnbind', [$this, 'afterUnbind']);
 
     }
@@ -149,26 +149,25 @@ class Plugin extends ServerPlugin {
 
     }
 
-	/**
-	 * Called after a node is copied.
-	 *
-	 * This allows the backend to copy all the associated properties.
+    /**
+     * Called after a node is copied.
+     *
+     * This allows the backend to copy all the associated properties.
 	 *
 	 * @param string $source
 	 * @param string $destination
 	 * @return void
-	 */
-	function afterCopy($source, $destination) {
+     */
+    function afterCopy($source, $destination) {
 
-		$pathFilter = $this->pathFilter;
-		if ($pathFilter && !$pathFilter($source)) return;
-		// If the destination is filtered, afterUnbind will handle cleaning up
-		// the properties.
-		if ($pathFilter && !$pathFilter($destination)) return;
+	    $pathFilter = $this->pathFilter;
+	    if ($pathFilter && !$pathFilter($source)) return;
+	    // If the destination is filtered, afterUnbind will handle cleaning up
+	    // the properties.
+	    if ($pathFilter && !$pathFilter($destination)) return;
 
-		$this->backend->copy($source, $destination);
-
-	}
+	    $this->backend->copy($source, $destination);
+    }
 
     /**
      * Returns a plugin name.

--- a/lib/DAV/PropertyStorage/Plugin.php
+++ b/lib/DAV/PropertyStorage/Plugin.php
@@ -69,6 +69,7 @@ class Plugin extends ServerPlugin {
         $server->on('propFind',    [$this, 'propFind'], 130);
         $server->on('propPatch',   [$this, 'propPatch'], 300);
         $server->on('afterMove',   [$this, 'afterMove']);
+		$server->on('afterCopy',   [$this, 'afterCopy']);
         $server->on('afterUnbind', [$this, 'afterUnbind']);
 
     }
@@ -147,6 +148,27 @@ class Plugin extends ServerPlugin {
         $this->backend->move($source, $destination);
 
     }
+
+	/**
+	 * Called after a node is copied.
+	 *
+	 * This allows the backend to copy all the associated properties.
+	 *
+	 * @param string $source
+	 * @param string $destination
+	 * @return void
+	 */
+	function afterCopy($source, $destination) {
+
+		$pathFilter = $this->pathFilter;
+		if ($pathFilter && !$pathFilter($source)) return;
+		// If the destination is filtered, afterUnbind will handle cleaning up
+		// the properties.
+		if ($pathFilter && !$pathFilter($destination)) return;
+
+		$this->backend->copy($source, $destination);
+
+	}
 
     /**
      * Returns a plugin name.

--- a/tests/Sabre/DAV/PropertyStorage/Backend/Mock.php
+++ b/tests/Sabre/DAV/PropertyStorage/Backend/Mock.php
@@ -114,4 +114,18 @@ class Mock implements BackendInterface {
 
     }
 
+	/**
+	 * This method is called after a successful COPY
+	 *
+	 * This should be used to migrate all properties from one path to another.
+	 * Note that entire collections may be moved, so ensure that all properties
+	 * for children are also moved along.
+	 *
+	 * @param string $source
+	 * @param string $destination
+	 * @return void
+	 */
+	function copy($source, $destination) {
+		// TODO: Implement copy() method.
+	}
 }


### PR DESCRIPTION
An afterCopy event is needed in order to perform custom actions such as clean up, or copying over custom properties similarly to afterMove. Fixes #1076