### PR TITLE
fix Browser plugin open root path

### DIFF
--- a/lib/CalDAV/Plugin.php
+++ b/lib/CalDAV/Plugin.php
@@ -77,7 +77,7 @@ class Plugin extends DAV\ServerPlugin
         // parents extend IExtendedCollection
         list($parent, $name) = Uri\split($uri);
 
-        $node = $this->server->tree->getNodeForPath($parent);
+        $node = $this->server->tree->getNodeForPath($parent ?: '');
 
         if ($node instanceof DAV\IExtendedCollection) {
             try {


### PR DESCRIPTION
In case a CalDAV uri exist, and you want to open the Browser plugin on root path, this error is thrown: 
```
Uncaught TypeError: trim() expects parameter 1 to be string, null given in sabre/dav/lib/DAV/Tree.php:57
```
This is caused by an empty value in `$uri`, and a `null` value in `$parent` variable.