### PR TITLE
Fix for #1026 and #1179: return only calendar objects owned by principal itself

### DIFF
--- a/lib/CalDAV/Backend/PDO.php
+++ b/lib/CalDAV/Backend/PDO.php
@@ -874,6 +874,8 @@ WHERE
     calendar_instances.principaluri = ?
     AND
     calendarobjects.uid = ?
+    AND
+    calendar_instances.access = 1
 SQL;
 
         $stmt = $this->pdo->prepare($query);


### PR DESCRIPTION
This pull request updates PR #1032 for the actual code base.