### PR TITLE
Fix propfind without contenttype

### DIFF
--- a/lib/CardDAV/Plugin.php
+++ b/lib/CardDAV/Plugin.php
@@ -686,7 +686,7 @@ class Plugin extends DAV\ServerPlugin
             return;
         }
         $contentType = $propFind->get('{DAV:}getcontenttype');
-        list($part) = explode(';', $contentType);
+        list($part) = explode(';', $contentType ?: '');
         if ('text/x-vcard' === $part || 'text/vcard' === $part) {
             $propFind->set('{DAV:}getcontenttype', 'text/x-vcard');
         }


### PR DESCRIPTION
Tried with Thunderbird 60 + CardBook 37
Adding an addressbook result in an error because `$contentType` is null in `explode(';', $contentType ?: '');`
This fix it. In fact it does not set the contenttype, which is fine I guess.