### PR TITLE
fix Trying to access array offset on value of type null in 7.4

### DIFF
--- a/lib/DAV/Xml/Property/Href.php
+++ b/lib/DAV/Xml/Property/Href.php
@@ -59,7 +59,7 @@ class Href implements Element, HtmlOutput
      */
     public function getHref()
     {
-        return $this->hrefs[0];
+        return $this->hrefs[0] ?? null;
     }
 
     /**

--- a/lib/DAV/Xml/Property/Href.php
+++ b/lib/DAV/Xml/Property/Href.php
@@ -55,7 +55,7 @@ class Href implements Element, HtmlOutput
     /**
      * Returns the first Href.
      *
-     * @return string
+     * @return string|null
      */
     public function getHref()
     {


### PR DESCRIPTION
Fix for
```
4) Sabre\DAVACL\Xml\Property\PrincipalTest::testSimple
Trying to access array offset on value of type null

/work/GIT/sabre-dav/lib/DAV/Xml/Property/Href.php:62
/work/GIT/sabre-dav/tests/Sabre/DAVACL/Xml/Property/PrincipalTest.php:17

```
After this fix, still some other error in used library
```

There were 3 errors:

1) Sabre\HTTP\Auth\DigestTest::testInvalidDigest2
Trying to access array offset on value of type bool

/work/GIT/sabre-dav/vendor/sabre/http/lib/Auth/Digest.php:130
/work/GIT/sabre-dav/vendor/sabre/http/lib/Auth/Digest.php:98
/work/GIT/sabre-dav/vendor/sabre/http/tests/HTTP/Auth/DigestTest.php:101

2) Sabre\VObject\Parser\MimeDirTest::testParseError
fgets(): read of 8192 bytes failed with errno=9 Bad file descriptor

/work/GIT/sabre-dav/vendor/sabre/vobject/lib/Parser/MimeDir.php:278
/work/GIT/sabre-dav/vendor/sabre/vobject/lib/Parser/MimeDir.php:144
/work/GIT/sabre-dav/vendor/sabre/vobject/lib/Parser/MimeDir.php:90
/work/GIT/sabre-dav/vendor/sabre/vobject/tests/VObject/Parser/MimeDirTest.php:19

3) Sabre\DAV\Auth\Backend\AbstractDigestTest::testCheckNoHeaders
Trying to access array offset on value of type bool

/work/GIT/sabre-dav/vendor/sabre/http/lib/Auth/Digest.php:121
/work/GIT/sabre-dav/lib/DAV/Auth/Backend/AbstractDigest.php:106
/work/GIT/sabre-dav/tests/Sabre/DAV/Auth/Backend/AbstractDigestTest.php:18

```