### PR TITLE
Fix implementations of IProperties::getProperties()

### DIFF
--- a/lib/CalDAV/Calendar.php
+++ b/lib/CalDAV/Calendar.php
@@ -75,19 +75,33 @@ class Calendar implements ICalendar, DAV\IProperties, DAV\Sync\ISyncCollection, 
     }
 
     /**
-     * Returns the list of properties.
+     * Returns a list of properties for this nodes.
      *
-     * @param array $requestedProperties
+     * The properties list is a list of propertynames the client requested,
+     * encoded in clark-notation {xmlnamespace}tagname
+     *
+     * If the array is empty, it means 'all properties' were requested.
+     *
+     * Note that it's fine to liberally give properties back, instead of
+     * conforming to the list of requested properties.
+     * The Server class will filter out the extra.
+     *
+     * @param array $properties
      *
      * @return array
      */
-    public function getProperties($requestedProperties)
+    public function getProperties($properties)
     {
         $response = [];
 
         foreach ($this->calendarInfo as $propName => $propValue) {
+            if (!empty($properties) && !in_array($propName, $properties)) {
+                // Return property only if it is present in requested properties
+                // or requested properties is an empty array (all properties has been requested).
+                continue;
+            }
             if (!is_null($propValue) && '{' === $propName[0]) {
-                $response[$propName] = $this->calendarInfo[$propName];
+                $response[$propName] = $propValue;
             }
         }
 

--- a/lib/CalDAV/Subscriptions/Subscription.php
+++ b/lib/CalDAV/Subscriptions/Subscription.php
@@ -144,22 +144,26 @@ class Subscription extends Collection implements ISubscription, IACL
      */
     public function getProperties($properties)
     {
-        $r = [];
+        $response = [];
 
-        foreach ($properties as $prop) {
-            switch ($prop) {
-                case '{http://calendarserver.org/ns/}source':
-                    $r[$prop] = new Href($this->subscriptionInfo['source']);
-                    break;
-                default:
-                    if (array_key_exists($prop, $this->subscriptionInfo)) {
-                        $r[$prop] = $this->subscriptionInfo[$prop];
-                    }
-                    break;
+        foreach ($this->subscriptionInfo as $propName => $propValue) {
+            if ('source' === $propName) {
+                $propName = '{http://calendarserver.org/ns/}source';
+                $propValue = new Href($propValue);
+            }
+
+            if (!empty($properties) && !in_array($propName, $properties)) {
+                // Return property only if it is present in requested properties
+                // or requested properties is an empty array (all properties has been requested).
+                continue;
+            }
+
+            if (!is_null($propName) && '{' === $propName[0]) {
+                $response[$propName] = $propValue;
             }
         }
 
-        return $r;
+        return $response;
     }
 
     /**

--- a/lib/CardDAV/AddressBook.php
+++ b/lib/CardDAV/AddressBook.php
@@ -197,6 +197,10 @@ class AddressBook extends DAV\Collection implements IAddressBook, DAV\IPropertie
      *
      * If the array is empty, it means 'all properties' were requested.
      *
+     * Note that it's fine to liberally give properties back, instead of
+     * conforming to the list of requested properties.
+     * The Server class will filter out the extra.
+     *
      * @param array $properties
      *
      * @return array
@@ -204,9 +208,15 @@ class AddressBook extends DAV\Collection implements IAddressBook, DAV\IPropertie
     public function getProperties($properties)
     {
         $response = [];
-        foreach ($properties as $propertyName) {
-            if (isset($this->addressBookInfo[$propertyName])) {
-                $response[$propertyName] = $this->addressBookInfo[$propertyName];
+
+        foreach ($this->addressBookInfo as $propName => $propValue) {
+            if (!empty($properties) && !in_array($propName, $properties)) {
+                // Return property only if it is present in requested properties
+                // or requested properties is an empty array (all properties has been requested).
+                continue;
+            }
+            if (!is_null($propValue) && '{' === $propName[0]) {
+                $response[$propName] = $propValue;
             }
         }
 

--- a/lib/DAVACL/Principal.php
+++ b/lib/DAVACL/Principal.php
@@ -155,22 +155,37 @@ class Principal extends DAV\Node implements IPrincipal, DAV\IProperties, IACL
     }
 
     /**
-     * Returns a list of properties.
+     * Returns a list of properties for this nodes.
      *
-     * @param array $requestedProperties
+     * The properties list is a list of propertynames the client requested,
+     * encoded in clark-notation {xmlnamespace}tagname
+     *
+     * If the array is empty, it means 'all properties' were requested.
+     *
+     * Note that it's fine to liberally give properties back, instead of
+     * conforming to the list of requested properties.
+     * The Server class will filter out the extra.
+     *
+     * @param array $properties
      *
      * @return array
      */
-    public function getProperties($requestedProperties)
+    public function getProperties($properties)
     {
-        $newProperties = [];
-        foreach ($requestedProperties as $propName) {
-            if (isset($this->principalProperties[$propName])) {
-                $newProperties[$propName] = $this->principalProperties[$propName];
+        $response = [];
+
+        foreach ($this->principalProperties as $propName => $propValue) {
+            if (!empty($properties) && !in_array($propName, $properties)) {
+                // Return property only if it is present in requested properties
+                // or requested properties is an empty array (all properties has been requested).
+                continue;
+            }
+            if (!is_null($propValue) && '{' === $propName[0]) {
+                $response[$propName] = $propValue;
             }
         }
 
-        return $newProperties;
+        return $response;
     }
 
     /**

--- a/tests/Sabre/CalDAV/Subscriptions/SubscriptionTest.php
+++ b/tests/Sabre/CalDAV/Subscriptions/SubscriptionTest.php
@@ -73,6 +73,24 @@ class SubscriptionTest extends \PHPUnit\Framework\TestCase
         $this->assertNull($sub->getSupportedPrivilegeSet());
     }
 
+    public function testGetProperties()
+    {
+        $expectedValues = [
+            '{DAV:}displayname' => 'displayname',
+            '{http://calendarserver.org/ns/}source' => new Href('http://example.org/src', false),
+        ];
+
+        $sub = $this->getSub();
+
+        // Call with empty prop list should return all values
+        $this->assertEquals($expectedValues, $sub->getProperties([]));
+
+        foreach ($expectedValues as $propName => $propValue) {
+            // Call with not empty prop list should return only requested properties values
+            $this->assertEquals([$propName => $propValue], $sub->getProperties([$propName]));
+        }
+    }
+
     public function testValues2()
     {
         $sub = $this->getSub([

--- a/tests/Sabre/DAV/Mock/PropertiesCollection.php
+++ b/tests/Sabre/DAV/Mock/PropertiesCollection.php
@@ -76,20 +76,25 @@ class PropertiesCollection extends Collection implements IProperties
      * conforming to the list of requested properties.
      * The Server class will filter out the extra.
      *
-     * @param array $requestedProperties
+     * @param array $properties
      *
      * @return array
      */
-    public function getProperties($requestedProperties)
+    public function getProperties($properties)
     {
-        $returnedProperties = [];
-        foreach ($requestedProperties as $requestedProperty) {
-            if (isset($this->properties[$requestedProperty])) {
-                $returnedProperties[$requestedProperty] =
-                    $this->properties[$requestedProperty];
+        $response = [];
+
+        foreach ($this->properties as $propName => $propValue) {
+            if (!empty($properties) && !in_array($propName, $properties)) {
+                // Return property only if it is present in requested properties
+                // or requested properties is an empty array (all properties has been requested).
+                continue;
+            }
+            if (!is_null($propValue) && '{' === $propName[0]) {
+                $response[$propName] = $propValue;
             }
         }
 
-        return $returnedProperties;
+        return $response;
     }
 }


### PR DESCRIPTION
`IProperties::getProperties()` indicates that passing an empty array of properties names will result in getting back all properties of the node, but on some classes, this is not the implemented behavior.