### PR TITLE
Feature/streaming propfind restart

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,9 @@ matrix:
     - name: 'PHPStan'
       php: 7.2
       env: RUN_PHPSTAN="TRUE"
+    - name: 'Test with streaming propfind'
+      php: 7.2
+      env: RUN_TEST_WITH_STREAMING_PROPFIND="TRUE"
 
 services:
   - mysql

--- a/tests/Sabre/CalDAV/ExpandEventsDTSTARTandDTENDTest.php
+++ b/tests/Sabre/CalDAV/ExpandEventsDTSTARTandDTENDTest.php
@@ -82,11 +82,12 @@ END:VCALENDAR
 
         $response = $this->request($request);
 
+        $bodyAsString = $response->getBodyAsString();
         // Everts super awesome xml parser.
         $body = substr(
-            $response->body,
-            $start = strpos($response->body, 'BEGIN:VCALENDAR'),
-            strpos($response->body, 'END:VCALENDAR') - $start + 13
+            $bodyAsString,
+            $start = strpos($bodyAsString, 'BEGIN:VCALENDAR'),
+            strpos($bodyAsString, 'END:VCALENDAR') - $start + 13
         );
         $body = str_replace('&#13;', '', $body);
 

--- a/tests/Sabre/CalDAV/ExpandEventsDTSTARTandDTENDbyDayTest.php
+++ b/tests/Sabre/CalDAV/ExpandEventsDTSTARTandDTENDbyDayTest.php
@@ -73,11 +73,12 @@ END:VCALENDAR
 
         $response = $this->request($request);
 
+        $bodyAsString = $response->getBodyAsString();
         // Everts super awesome xml parser.
         $body = substr(
-            $response->body,
-            $start = strpos($response->body, 'BEGIN:VCALENDAR'),
-            strpos($response->body, 'END:VCALENDAR') - $start + 13
+            $bodyAsString,
+            $start = strpos($bodyAsString, 'BEGIN:VCALENDAR'),
+            strpos($bodyAsString, 'END:VCALENDAR') - $start + 13
         );
         $body = str_replace('&#13;', '', $body);
 

--- a/tests/Sabre/CalDAV/ExpandEventsDoubleEventsTest.php
+++ b/tests/Sabre/CalDAV/ExpandEventsDoubleEventsTest.php
@@ -84,11 +84,12 @@ END:VCALENDAR
 
         $response = $this->request($request);
 
+        $bodyAsString = $response->getBodyAsString();
         // Everts super awesome xml parser.
         $body = substr(
-            $response->body,
-            $start = strpos($response->body, 'BEGIN:VCALENDAR'),
-            strpos($response->body, 'END:VCALENDAR') - $start + 13
+            $bodyAsString,
+            $start = strpos($bodyAsString, 'BEGIN:VCALENDAR'),
+            strpos($bodyAsString, 'END:VCALENDAR') - $start + 13
         );
         $body = str_replace('&#13;', '', $body);
 

--- a/tests/Sabre/CalDAV/ExpandEventsFloatingTimeTest.php
+++ b/tests/Sabre/CalDAV/ExpandEventsFloatingTimeTest.php
@@ -95,11 +95,12 @@ END:VCALENDAR
 
         $response = $this->request($request);
 
+        $bodyAsString = $response->getBodyAsString();
         // Everts super awesome xml parser.
         $body = substr(
-            $response->body,
-            $start = strpos($response->body, 'BEGIN:VCALENDAR'),
-            strpos($response->body, 'END:VCALENDAR') - $start + 13
+            $bodyAsString,
+            $start = strpos($bodyAsString, 'BEGIN:VCALENDAR'),
+            strpos($bodyAsString, 'END:VCALENDAR') - $start + 13
         );
         $body = str_replace('&#13;', '', $body);
 
@@ -143,11 +144,12 @@ END:VCALENDAR
 
         $this->assertEquals(207, $response->getStatus());
 
+        $bodyAsString = $response->getBodyAsString();
         // Everts super awesome xml parser.
         $body = substr(
-            $response->body,
-            $start = strpos($response->body, 'BEGIN:VCALENDAR'),
-            strpos($response->body, 'END:VCALENDAR') - $start + 13
+            $bodyAsString,
+            $start = strpos($bodyAsString, 'BEGIN:VCALENDAR'),
+            strpos($bodyAsString, 'END:VCALENDAR') - $start + 13
         );
         $body = str_replace('&#13;', '', $body);
 
@@ -182,9 +184,9 @@ END:VCALENDAR
 
         // Everts super awesome xml parser.
         $body = substr(
-            $response->body,
-            $start = strpos($response->body, 'BEGIN:VCALENDAR'),
-            strpos($response->body, 'END:VCALENDAR') - $start + 13
+            $response->getBodyAsString(),
+            $start = strpos($response->getBodyAsString(), 'BEGIN:VCALENDAR'),
+            strpos($response->getBodyAsString(), 'END:VCALENDAR') - $start + 13
         );
         $body = str_replace('&#13;', '', $body);
 

--- a/tests/Sabre/CalDAV/GetEventsByTimerangeTest.php
+++ b/tests/Sabre/CalDAV/GetEventsByTimerangeTest.php
@@ -77,6 +77,6 @@ END:VCALENDAR
 
         $response = $this->request($request);
 
-        $this->assertTrue(false !== strpos($response->body, 'BEGIN:VCALENDAR'));
+        $this->assertTrue(false !== strpos($response->getBodyAsString(), 'BEGIN:VCALENDAR'));
     }
 }

--- a/tests/Sabre/CalDAV/ICSExportPluginTest.php
+++ b/tests/Sabre/CalDAV/ICSExportPluginTest.php
@@ -82,7 +82,7 @@ ICS
         $this->assertEquals(200, $response->getStatus());
         $this->assertEquals('text/calendar', $response->getHeader('Content-Type'));
 
-        $obj = VObject\Reader::read($response->body);
+        $obj = VObject\Reader::read($response->getBodyAsString());
 
         $this->assertEquals(8, count($obj->children()));
         $this->assertEquals(1, count($obj->VERSION));
@@ -108,7 +108,7 @@ ICS
         $this->assertEquals(200, $response->getStatus());
         $this->assertEquals('text/calendar', $response->getHeader('Content-Type'));
 
-        $obj = VObject\Reader::read($response->body);
+        $obj = VObject\Reader::read($response->getBodyAsString());
 
         $this->assertEquals(8, count($obj->children()));
         $this->assertEquals(1, count($obj->VERSION));
@@ -166,7 +166,7 @@ ICS
         $response = $this->request($request, 200);
         $this->assertEquals('text/calendar', $response->getHeader('Content-Type'));
 
-        $obj = VObject\Reader::read($response->body);
+        $obj = VObject\Reader::read($response->getBodyAsString());
 
         $this->assertEquals(8, count($obj->children()));
         $this->assertEquals(1, count($obj->VERSION));
@@ -276,7 +276,7 @@ ICS
 
         $response = $this->request($request, 200);
 
-        $obj = VObject\Reader::read($response->body);
+        $obj = VObject\Reader::read($response->getBodyAsString());
         $this->assertEquals(1, count($obj->VTIMEZONE));
         $this->assertEquals(1, count($obj->VEVENT));
         $this->assertNull($obj->VTODO);
@@ -291,7 +291,7 @@ ICS
 
         $response = $this->request($request, 200);
 
-        $obj = VObject\Reader::read($response->body);
+        $obj = VObject\Reader::read($response->getBodyAsString());
 
         $this->assertNull($obj->VTIMEZONE);
         $this->assertNull($obj->VEVENT);

--- a/tests/Sabre/CalDAV/Issue203Test.php
+++ b/tests/Sabre/CalDAV/Issue203Test.php
@@ -86,11 +86,12 @@ END:VCALENDAR
 
         $response = $this->request($request);
 
+        $bodyAsString = $response->getBodyAsString();
         // Everts super awesome xml parser.
         $body = substr(
-            $response->body,
-            $start = strpos($response->body, 'BEGIN:VCALENDAR'),
-            strpos($response->body, 'END:VCALENDAR') - $start + 13
+            $bodyAsString,
+            $start = strpos($bodyAsString, 'BEGIN:VCALENDAR'),
+            strpos($bodyAsString, 'END:VCALENDAR') - $start + 13
         );
         $body = str_replace('&#13;', '', $body);
 

--- a/tests/Sabre/CalDAV/Issue205Test.php
+++ b/tests/Sabre/CalDAV/Issue205Test.php
@@ -81,14 +81,14 @@ END:VCALENDAR
 
         $response = $this->request($request);
 
-        $this->assertFalse(strpos($response->body, '<s:exception>Exception</s:exception>'), 'Exception occurred: '.$response->body);
-        $this->assertFalse(strpos($response->body, 'Unknown or bad format'), 'DateTime unknown format Exception: '.$response->body);
+        $this->assertFalse(strpos($response->getBodyAsString(), '<s:exception>Exception</s:exception>'), 'Exception occurred: '.$response->getBodyAsString());
+        $this->assertFalse(strpos($response->getBodyAsString(), 'Unknown or bad format'), 'DateTime unknown format Exception: '.$response->getBodyAsString());
 
         // Everts super awesome xml parser.
         $body = substr(
-            $response->body,
-            $start = strpos($response->body, 'BEGIN:VCALENDAR'),
-            strpos($response->body, 'END:VCALENDAR') - $start + 13
+            $response->getBodyAsString(),
+            $start = strpos($response->getBodyAsString(), 'BEGIN:VCALENDAR'),
+            strpos($response->getBodyAsString(), 'END:VCALENDAR') - $start + 13
         );
         $body = str_replace('&#13;', '', $body);
 

--- a/tests/Sabre/CalDAV/Issue211Test.php
+++ b/tests/Sabre/CalDAV/Issue211Test.php
@@ -85,6 +85,6 @@ END:VCALENDAR
 
         // if this assert is reached, the endless loop is gone
         // There should be no matching events
-        $this->assertFalse(strpos('BEGIN:VEVENT', $response->body));
+        $this->assertFalse(strpos('BEGIN:VEVENT', $response->getBodyAsString()));
     }
 }

--- a/tests/Sabre/CalDAV/Issue220Test.php
+++ b/tests/Sabre/CalDAV/Issue220Test.php
@@ -93,8 +93,8 @@ END:VCALENDAR
 
         $response = $this->request($request);
 
-        $this->assertFalse(strpos($response->body, '<s:exception>PHPUnit_Framework_Error_Warning</s:exception>'), 'Error Warning occurred: '.$response->body);
-        $this->assertFalse(strpos($response->body, 'Invalid argument supplied for foreach()'), 'Invalid argument supplied for foreach(): '.$response->body);
+        $this->assertFalse(strpos($response->getBodyAsString(), '<s:exception>PHPUnit_Framework_Error_Warning</s:exception>'), 'Error Warning occurred: '.$response->getBodyAsString());
+        $this->assertFalse(strpos($response->getBodyAsString(), 'Invalid argument supplied for foreach()'), 'Invalid argument supplied for foreach(): '.$response->getBodyAsString());
 
         $this->assertEquals(207, $response->status);
     }

--- a/tests/Sabre/CalDAV/Issue228Test.php
+++ b/tests/Sabre/CalDAV/Issue228Test.php
@@ -75,6 +75,6 @@ END:VCALENDAR
         $response = $this->request($request);
 
         // We must check if absolutely nothing was returned from this query.
-        $this->assertFalse(strpos($response->body, 'BEGIN:VCALENDAR'));
+        $this->assertFalse(strpos($response->getBodyAsString(), 'BEGIN:VCALENDAR'));
     }
 }

--- a/tests/Sabre/CalDAV/JCalTransformTest.php
+++ b/tests/Sabre/CalDAV/JCalTransformTest.php
@@ -79,11 +79,10 @@ XML;
 
         $response = $this->request($request);
 
-        $this->assertEquals(207, $response->getStatus(), 'Full rsponse: '.$response->getBodyAsString());
+        $bodyAsString = $response->getBodyAsString();
+        $this->assertEquals(207, $response->getStatus(), 'Full rsponse: '.$bodyAsString);
 
-        $multiStatus = $this->server->xml->parse(
-            $response->getBodyAsString()
-        );
+        $multiStatus = $this->server->xml->parse($bodyAsString);
 
         $responses = $multiStatus->getResponses();
         $this->assertEquals(1, count($responses));
@@ -131,11 +130,10 @@ XML;
 
         $response = $this->request($request);
 
-        $this->assertEquals(207, $response->getStatus(), 'Invalid response code. Full body: '.$response->getBodyAsString());
+        $bodyAsString = $response->getBodyAsString();
+        $this->assertEquals(207, $response->getStatus(), 'Invalid response code. Full body: '.$bodyAsString);
 
-        $multiStatus = $this->server->xml->parse(
-            $response->getBodyAsString()
-        );
+        $multiStatus = $this->server->xml->parse($bodyAsString);
 
         $responses = $multiStatus->getResponses();
 
@@ -183,11 +181,10 @@ XML;
 
         $response = $this->request($request);
 
-        $this->assertEquals(207, $response->getStatus(), 'Invalid response code. Full body: '.$response->getBodyAsString());
+        $bodyAsString = $response->getBodyAsString();
+        $this->assertEquals(207, $response->getStatus(), 'Invalid response code. Full body: '.$bodyAsString);
 
-        $multiStatus = $this->server->xml->parse(
-            $response->getBodyAsString()
-        );
+        $multiStatus = $this->server->xml->parse($bodyAsString);
 
         $responses = $multiStatus->getResponses();
 

--- a/tests/Sabre/CalDAV/PluginTest.php
+++ b/tests/Sabre/CalDAV/PluginTest.php
@@ -118,7 +118,7 @@ class PluginTest extends \PHPUnit\Framework\TestCase
         $this->server->httpRequest = $request;
         $this->server->exec();
 
-        $this->assertEquals(501, $this->response->status, 'Incorrect status returned. Full response body:'.$this->response->body);
+        $this->assertEquals(501, $this->response->status, 'Incorrect status returned. Full response body:'.$this->response->getBodyAsString());
     }
 
     public function testGetWithoutContentType()
@@ -336,7 +336,7 @@ END:VCALENDAR';
         $this->server->httpRequest = $request;
         $this->server->exec();
 
-        $this->assertEquals(201, $this->response->status, 'Invalid response code received. Full response body: '.$this->response->body);
+        $this->assertEquals(201, $this->response->status, 'Invalid response code received. Full response body: '.$this->response->getBodyAsString());
 
         $calendars = $this->caldavBackend->getCalendarsForUser('principals/user1');
         $this->assertEquals(3, count($calendars));
@@ -381,7 +381,7 @@ END:VCALENDAR';
         $this->server->httpRequest = $request;
         $this->server->exec();
 
-        $this->assertEquals(201, $this->response->status, 'Invalid response code received. Full response body: '.$this->response->body);
+        $this->assertEquals(201, $this->response->status, 'Invalid response code received. Full response body: '.$this->response->getBodyAsString());
 
         $calendars = $this->caldavBackend->getCalendarsForUser('principals/user1');
         $this->assertEquals(3, count($calendars));
@@ -606,7 +606,8 @@ XML;
         $this->server->httpRequest = $request;
         $this->server->exec();
 
-        $this->assertEquals(207, $this->response->status, 'Invalid HTTP status received. Full response body: '.$this->response->body);
+        $bodyAsString = $this->response->getBodyAsString();
+        $this->assertEquals(207, $this->response->status, 'Invalid HTTP status received. Full response body: '.$bodyAsString);
 
         $expectedIcal = TestUtil::getTestCalendarData();
         $expectedIcal = \Sabre\VObject\Reader::read($expectedIcal);
@@ -632,7 +633,7 @@ XML;
 </d:multistatus>
 XML;
 
-        $this->assertXmlStringEqualsXmlString($expected, $this->response->getBodyAsString());
+        $this->assertXmlStringEqualsXmlString($expected, $bodyAsString);
     }
 
     /**
@@ -663,7 +664,8 @@ XML;
         $this->server->httpRequest = $request;
         $this->server->exec();
 
-        $this->assertEquals(207, $this->response->status, 'Received an unexpected status. Full response body: '.$this->response->body);
+        $bodyAsString = $this->response->getBodyAsString();
+        $this->assertEquals(207, $this->response->status, 'Received an unexpected status. Full response body: '.$bodyAsString);
 
         $expectedIcal = TestUtil::getTestCalendarData();
         $expectedIcal = \Sabre\VObject\Reader::read($expectedIcal);
@@ -689,7 +691,7 @@ XML;
 </d:multistatus>
 XML;
 
-        $this->assertXmlStringEqualsXmlString($expected, $this->response->getBodyAsString());
+        $this->assertXmlStringEqualsXmlString($expected, $bodyAsString);
     }
 
     /**
@@ -724,7 +726,8 @@ XML;
         $this->server->httpRequest = $request;
         $this->server->exec();
 
-        $this->assertEquals(207, $this->response->status, 'Received an unexpected status. Full response body: '.$this->response->body);
+        $bodyAsString = $this->response->getBodyAsString();
+        $this->assertEquals(207, $this->response->status, 'Received an unexpected status. Full response body: '.$bodyAsString);
 
         $expectedIcal = TestUtil::getTestCalendarData();
         $expectedIcal = \Sabre\VObject\Reader::read($expectedIcal);
@@ -750,7 +753,7 @@ XML;
 </d:multistatus>
 XML;
 
-        $this->assertXmlStringEqualsXmlString($expected, $this->response->getBodyAsString());
+        $this->assertXmlStringEqualsXmlString($expected, $bodyAsString);
     }
 
     /**
@@ -783,7 +786,7 @@ XML;
         $this->server->httpRequest = $request;
         $this->server->exec();
 
-        $this->assertEquals(400, $this->response->status, 'Received an unexpected status. Full response body: '.$this->response->body);
+        $this->assertEquals(400, $this->response->status, 'Received an unexpected status. Full response body: '.$this->response->getBodyAsString());
     }
 
     /**
@@ -812,7 +815,8 @@ XML;
         $this->server->httpRequest = $request;
         $this->server->exec();
 
-        $this->assertEquals(207, $this->response->status, 'Received an unexpected status. Full response body: '.$this->response->body);
+        $bodyAsString = $this->server->httpResponse->getBodyAsString();
+        $this->assertEquals(207, $this->response->status, 'Received an unexpected status. Full response body: '.$bodyAsString);
 
         $expected = <<<XML
 <?xml version="1.0"?>
@@ -829,7 +833,7 @@ XML;
 </d:multistatus>
 XML;
 
-        $this->assertXmlStringEqualsXmlString($expected, $this->response->getBodyAsString());
+        $this->assertXmlStringEqualsXmlString($expected, $bodyAsString);
     }
 
     /**
@@ -852,7 +856,7 @@ XML;
         $this->server->httpRequest = $request;
         $this->server->exec();
 
-        $this->assertEquals(400, $this->response->status, 'Received an unexpected status. Full response body: '.$this->response->body);
+        $this->assertEquals(400, $this->response->status, 'Received an unexpected status. Full response body: '.$this->response->getBodyAsString());
     }
 
     /**
@@ -883,7 +887,8 @@ XML;
         $this->server->httpRequest = $request;
         $this->server->exec();
 
-        $this->assertEquals(207, $this->response->status, 'Received an unexpected status. Full response body: '.$this->response->body);
+        $bodyAsString = $this->server->httpResponse->getBodyAsString();
+        $this->assertEquals(207, $this->response->status, 'Received an unexpected status. Full response body: '.$bodyAsString);
 
         $expectedIcal = TestUtil::getTestCalendarData();
         $expectedIcal = \Sabre\VObject\Reader::read($expectedIcal);
@@ -909,7 +914,7 @@ XML;
 </d:multistatus>
 XML;
 
-        $this->assertXmlStringEqualsXmlString($expected, $this->response->getBodyAsString());
+        $this->assertXmlStringEqualsXmlString($expected, $bodyAsString);
     }
 
     /**
@@ -937,7 +942,8 @@ XML;
         $this->server->httpRequest = $request;
         $this->server->exec();
 
-        $this->assertEquals(207, $this->response->status, 'Received an unexpected status. Full response body: '.$this->response->body);
+        $bodyAsString = $this->server->httpResponse->getBodyAsString();
+        $this->assertEquals(207, $this->response->status, 'Received an unexpected status. Full response body: '.$bodyAsString);
 
         $expected = <<<XML
 <?xml version="1.0"?>
@@ -954,7 +960,7 @@ XML;
 </d:multistatus>
 XML;
 
-        $this->assertXmlStringEqualsXmlString($expected, $this->response->getBodyAsString());
+        $this->assertXmlStringEqualsXmlString($expected, $bodyAsString);
     }
 
     public function testHTMLActionsPanel()
@@ -989,7 +995,7 @@ XML;
         $this->server->httpRequest = $request;
         $this->server->exec();
 
-        $this->assertEquals(400, $this->response->status, 'Invalid HTTP status received. Full response body: '.$this->response->body);
+        $this->assertEquals(400, $this->response->status, 'Invalid HTTP status received. Full response body: '.$this->response->getBodyAsString());
     }
 
     /**
@@ -1015,7 +1021,7 @@ XML;
         $this->server->httpRequest = $request;
         $this->server->exec();
 
-        $this->assertEquals(400, $this->response->status, 'Invalid HTTP status received. Full response body: '.$this->response->body);
+        $this->assertEquals(400, $this->response->status, 'Invalid HTTP status received. Full response body: '.$this->response->getBodyAsString());
     }
 
     /**
@@ -1041,7 +1047,7 @@ XML;
         $this->server->httpRequest = $request;
         $this->server->exec();
 
-        $this->assertEquals(400, $this->response->status, 'Invalid HTTP status received. Full response body: '.$this->response->body);
+        $this->assertEquals(400, $this->response->status, 'Invalid HTTP status received. Full response body: '.$this->response->getBodyAsString());
     }
 
     /**

--- a/tests/Sabre/CalDAV/Schedule/FreeBusyRequestTest.php
+++ b/tests/Sabre/CalDAV/Schedule/FreeBusyRequestTest.php
@@ -298,13 +298,13 @@ ICS;
 
         foreach ($strings as $string) {
             $this->assertTrue(
-                false !== strpos($this->response->body, $string),
-                'The response body did not contain: '.$string.'Full response: '.$this->response->body
+                false !== strpos($this->response->getBodyAsString(), $string),
+                'The response body did not contain: '.$string.'Full response: '.$this->response->getBodyAsString()
             );
         }
 
         $this->assertTrue(
-            false == strpos($this->response->body, 'FREEBUSY;FBTYPE=BUSY:20110101T080000Z/20110101T090000Z'),
+            false == strpos($this->response->getBodyAsString(), 'FREEBUSY;FBTYPE=BUSY:20110101T080000Z/20110101T090000Z'),
             'The response body did contain free busy info from a transparent calendar.'
         );
     }
@@ -358,8 +358,8 @@ ICS;
 
         foreach ($strings as $string) {
             $this->assertTrue(
-                false !== strpos($this->response->body, $string),
-                'The response body did not contain: '.$string.'Full response: '.$this->response->body
+                false !== strpos($this->response->getBodyAsString(), $string),
+                'The response body did not contain: '.$string.'Full response: '.$this->response->getBodyAsString()
             );
         }
     }
@@ -410,8 +410,8 @@ ICS;
 
         foreach ($strings as $string) {
             $this->assertTrue(
-                false !== strpos($this->response->body, $string),
-                'The response body did not contain: '.$string.'Full response: '.$this->response->body
+                false !== strpos($this->response->getBodyAsString(), $string),
+                'The response body did not contain: '.$string.'Full response: '.$this->response->getBodyAsString()
             );
         }
     }
@@ -462,8 +462,8 @@ ICS;
 
         foreach ($strings as $string) {
             $this->assertTrue(
-                false !== strpos($this->response->body, $string),
-                'The response body did not contain: '.$string.'Full response: '.$this->response->body
+                false !== strpos($this->response->getBodyAsString(), $string),
+                'The response body did not contain: '.$string.'Full response: '.$this->response->getBodyAsString()
             );
         }
     }
@@ -532,8 +532,8 @@ ICS;
 
         foreach ($strings as $string) {
             $this->assertTrue(
-                false !== strpos($this->response->body, $string),
-                'The response body did not contain: '.$string.'Full response: '.$this->response->body
+                false !== strpos($this->response->getBodyAsString(), $string),
+                'The response body did not contain: '.$string.'Full response: '.$this->response->getBodyAsString()
             );
         }
     }

--- a/tests/Sabre/CalDAV/SharingPluginTest.php
+++ b/tests/Sabre/CalDAV/SharingPluginTest.php
@@ -131,7 +131,7 @@ class SharingPluginTest extends \Sabre\DAVServerTest
 
         $response = $this->request($request);
 
-        $this->assertEquals(501, $response->status, $response->body);
+        $this->assertEquals(501, $response->status, $response->getBodyAsString());
     }
 
     public function testUnknownMethodNoXML()
@@ -144,7 +144,7 @@ class SharingPluginTest extends \Sabre\DAVServerTest
 
         $response = $this->request($request);
 
-        $this->assertEquals(501, $response->status, $response->body);
+        $this->assertEquals(501, $response->status, $response->getBodyAsString());
     }
 
     public function testUnknownMethodNoNode()
@@ -157,7 +157,7 @@ class SharingPluginTest extends \Sabre\DAVServerTest
 
         $response = $this->request($request);
 
-        $this->assertEquals(501, $response->status, $response->body);
+        $this->assertEquals(501, $response->status, $response->getBodyAsString());
     }
 
     public function testShareRequest()
@@ -250,7 +250,7 @@ RRR;
 
         $request->setBody($xml);
         $response = $this->request($request);
-        $this->assertEquals(200, $response->status, $response->body);
+        $this->assertEquals(200, $response->status, $response->getBodyAsString());
     }
 
     public function testInviteBadXML()
@@ -267,7 +267,7 @@ RRR;
 ';
         $request->setBody($xml);
         $response = $this->request($request);
-        $this->assertEquals(400, $response->status, $response->body);
+        $this->assertEquals(400, $response->status, $response->getBodyAsString());
     }
 
     public function testInviteWrongUrl()
@@ -285,7 +285,7 @@ RRR;
 ';
         $request->setBody($xml);
         $response = $this->request($request);
-        $this->assertEquals(501, $response->status, $response->body);
+        $this->assertEquals(501, $response->status, $response->getBodyAsString());
 
         // If the plugin did not handle this request, it must ensure that the
         // body is still accessible by other plugins.
@@ -312,7 +312,7 @@ RRR;
         $request->setBody($xml);
 
         $response = $this->request($request);
-        $this->assertEquals(202, $response->status, $response->body);
+        $this->assertEquals(202, $response->status, $response->getBodyAsString());
     }
 
     public function testUnpublish()
@@ -330,7 +330,7 @@ RRR;
         $request->setBody($xml);
 
         $response = $this->request($request);
-        $this->assertEquals(200, $response->status, $response->body);
+        $this->assertEquals(200, $response->status, $response->getBodyAsString());
     }
 
     public function testPublishWrongUrl()
@@ -379,6 +379,6 @@ RRR;
         $request->setBody($xml);
 
         $response = $this->request($request);
-        $this->assertEquals(501, $response->status, $response->body);
+        $this->assertEquals(501, $response->status, $response->getBodyAsString());
     }
 }

--- a/tests/Sabre/CalDAV/ValidateICalTest.php
+++ b/tests/Sabre/CalDAV/ValidateICalTest.php
@@ -100,7 +100,7 @@ ICS;
 
         $response = $this->request($request);
 
-        $this->assertEquals(201, $response->status, 'Incorrect status returned! Full response body: '.$response->body);
+        $this->assertEquals(201, $response->status, 'Incorrect status returned! Full response body: '.$response->getBodyAsString());
         $this->assertEquals([
             'X-Sabre-Version' => [DAV\Version::VERSION],
             'Content-Length' => ['0'],
@@ -140,7 +140,7 @@ ICS;
 
         $response = $this->request($request);
 
-        $this->assertEquals(415, $response->status, 'Incorrect status returned! Full response body: '.$response->body);
+        $this->assertEquals(415, $response->status, 'Incorrect status returned! Full response body: '.$response->getBodyAsString());
     }
 
     public function testCreateFileNoVersionFixed()
@@ -166,7 +166,7 @@ ICS;
 
         $response = $this->request($request);
 
-        $this->assertEquals(201, $response->status, 'Incorrect status returned! Full response body: '.$response->body);
+        $this->assertEquals(201, $response->status, 'Incorrect status returned! Full response body: '.$response->getBodyAsString());
         $this->assertEquals([
             'X-Sabre-Version' => [DAV\Version::VERSION],
             'Content-Length' => ['0'],
@@ -213,7 +213,7 @@ ICS;
         $request->setBody($ics);
 
         $response = $this->request($request);
-        $this->assertEquals(403, $response->status, 'Incorrect status returned! Full response body: '.$response->body);
+        $this->assertEquals(403, $response->status, 'Incorrect status returned! Full response body: '.$response->getBodyAsString());
     }
 
     public function testCreateFileNoUID()
@@ -226,7 +226,7 @@ ICS;
 
         $response = $this->request($request);
 
-        $this->assertEquals(415, $response->status, 'Incorrect status returned! Full response body: '.$response->body);
+        $this->assertEquals(415, $response->status, 'Incorrect status returned! Full response body: '.$response->getBodyAsString());
     }
 
     public function testCreateFileVCard()
@@ -239,7 +239,7 @@ ICS;
 
         $response = $this->request($request);
 
-        $this->assertEquals(415, $response->status, 'Incorrect status returned! Full response body: '.$response->body);
+        $this->assertEquals(415, $response->status, 'Incorrect status returned! Full response body: '.$response->getBodyAsString());
     }
 
     public function testCreateFile2Components()
@@ -252,7 +252,7 @@ ICS;
 
         $response = $this->request($request);
 
-        $this->assertEquals(415, $response->status, 'Incorrect status returned! Full response body: '.$response->body);
+        $this->assertEquals(415, $response->status, 'Incorrect status returned! Full response body: '.$response->getBodyAsString());
     }
 
     public function testCreateFile2UIDS()
@@ -265,7 +265,7 @@ ICS;
 
         $response = $this->request($request);
 
-        $this->assertEquals(415, $response->status, 'Incorrect status returned! Full response body: '.$response->body);
+        $this->assertEquals(415, $response->status, 'Incorrect status returned! Full response body: '.$response->getBodyAsString());
     }
 
     public function testCreateFileWrongComponent()
@@ -278,7 +278,7 @@ ICS;
 
         $response = $this->request($request);
 
-        $this->assertEquals(403, $response->status, 'Incorrect status returned! Full response body: '.$response->body);
+        $this->assertEquals(403, $response->status, 'Incorrect status returned! Full response body: '.$response->getBodyAsString());
     }
 
     public function testUpdateFile()
@@ -338,7 +338,7 @@ ICS;
 
         $response = $this->request($request);
 
-        $this->assertEquals(403, $response->status, 'Incorrect status returned! Full response body: '.$response->body);
+        $this->assertEquals(403, $response->status, 'Incorrect status returned! Full response body: '.$response->getBodyAsString());
     }
 
     public function testUpdateFileInvalidComponent()
@@ -352,7 +352,7 @@ ICS;
 
         $response = $this->request($request);
 
-        $this->assertEquals(403, $response->status, 'Incorrect status returned! Full response body: '.$response->body);
+        $this->assertEquals(403, $response->status, 'Incorrect status returned! Full response body: '.$response->getBodyAsString());
     }
 
     /**
@@ -385,7 +385,7 @@ ICS;
 
         $response = $this->request($request);
 
-        $this->assertEquals(201, $response->status, 'Incorrect status returned! Full response body: '.$response->body);
+        $this->assertEquals(201, $response->status, 'Incorrect status returned! Full response body: '.$response->getBodyAsString());
         $this->assertNull($response->getHeader('ETag'));
     }
 }

--- a/tests/Sabre/CardDAV/AddressBookQueryTest.php
+++ b/tests/Sabre/CardDAV/AddressBookQueryTest.php
@@ -39,12 +39,13 @@ class AddressBookQueryTest extends AbstractPluginTest
 
         $this->server->exec();
 
-        $this->assertEquals(207, $response->status, 'Incorrect status code. Full response body:'.$response->body);
+        $bodyAsString = $response->getBodyAsString();
+        $this->assertEquals(207, $response->status, 'Incorrect status code. Full response body:'.$bodyAsString);
 
         // using the client for parsing
         $client = new DAV\Client(['baseUri' => '/']);
 
-        $result = $client->parseMultiStatus($response->body);
+        $result = $client->parseMultiStatus($bodyAsString);
 
         $this->assertEquals([
             '/addressbooks/user1/book1/card1' => [
@@ -87,12 +88,13 @@ class AddressBookQueryTest extends AbstractPluginTest
 
         $this->server->exec();
 
-        $this->assertEquals(207, $response->status, 'Incorrect status code. Full response body:'.$response->body);
+        $bodyAsString = $response->getBodyAsString();
+        $this->assertEquals(207, $response->status, 'Incorrect status code. Full response body:'.$bodyAsString);
 
         // using the client for parsing
         $client = new DAV\Client(['baseUri' => '/']);
 
-        $result = $client->parseMultiStatus($response->body);
+        $result = $client->parseMultiStatus($bodyAsString);
 
         $this->assertEquals([
             '/addressbooks/user1/book1/card1' => [
@@ -130,12 +132,13 @@ class AddressBookQueryTest extends AbstractPluginTest
 
         $this->server->exec();
 
-        $this->assertEquals(207, $response->status, 'Incorrect status code. Full response body:'.$response->body);
+        $bodyAsString = $response->getBodyAsString();
+        $this->assertEquals(207, $response->status, 'Incorrect status code. Full response body:'.$bodyAsString);
 
         // using the client for parsing
         $client = new DAV\Client(['baseUri' => '/']);
 
-        $result = $client->parseMultiStatus($response->body);
+        $result = $client->parseMultiStatus($bodyAsString);
 
         $this->assertEquals([], $result);
     }
@@ -168,12 +171,13 @@ class AddressBookQueryTest extends AbstractPluginTest
 
         $this->server->exec();
 
-        $this->assertEquals(207, $response->status, 'Incorrect status code. Full response body:'.$response->body);
+        $bodyAsString = $response->getBodyAsString();
+        $this->assertEquals(207, $response->status, 'Incorrect status code. Full response body:'.$bodyAsString);
 
         // using the client for parsing
         $client = new DAV\Client(['baseUri' => '/']);
 
-        $result = $client->parseMultiStatus($response->body);
+        $result = $client->parseMultiStatus($bodyAsString);
 
         $this->assertEquals([
             '/addressbooks/user1/book1/card1' => [
@@ -209,12 +213,13 @@ class AddressBookQueryTest extends AbstractPluginTest
 
         $this->server->exec();
 
-        $this->assertEquals(207, $response->status, 'Incorrect status code. Full response body:'.$response->body);
+        $bodyAsString = $response->getBodyAsString();
+        $this->assertEquals(207, $response->status, 'Incorrect status code. Full response body:'.$bodyAsString);
 
         // using the client for parsing
         $client = new DAV\Client(['baseUri' => '/']);
 
-        $result = $client->parseMultiStatus($response->body);
+        $result = $client->parseMultiStatus($bodyAsString);
 
         $vobjVersion = \Sabre\VObject\Version::VERSION;
 
@@ -253,12 +258,13 @@ class AddressBookQueryTest extends AbstractPluginTest
 
         $this->server->exec();
 
-        $this->assertEquals(207, $response->status, 'Incorrect status code. Full response body:'.$response->body);
+        $bodyAsString = $response->getBodyAsString();
+        $this->assertEquals(207, $response->status, 'Incorrect status code. Full response body:'.$bodyAsString);
 
         // using the client for parsing
         $client = new DAV\Client(['baseUri' => '/']);
 
-        $result = $client->parseMultiStatus($response->body);
+        $result = $client->parseMultiStatus($bodyAsString);
 
         $vobjVersion = \Sabre\VObject\Version::VERSION;
 
@@ -297,7 +303,7 @@ class AddressBookQueryTest extends AbstractPluginTest
 
         $this->server->exec();
 
-        $this->assertEquals(415, $response->status, 'Incorrect status code. Full response body:'.$response->body);
+        $this->assertEquals(415, $response->status, 'Incorrect status code. Full response body:'.$response->getBodyAsString());
     }
 
     public function testAddressBookProperties()
@@ -328,12 +334,13 @@ class AddressBookQueryTest extends AbstractPluginTest
 
         $this->server->exec();
 
-        $this->assertEquals(207, $response->status, 'Incorrect status code. Full response body:'.$response->body);
+        $bodyAsString = $response->getBodyAsString();
+        $this->assertEquals(207, $response->status, 'Incorrect status code. Full response body:'.$bodyAsString);
 
         // using the client for parsing
         $client = new DAV\Client(['baseUri' => '/']);
 
-        $result = $client->parseMultiStatus($response->body);
+        $result = $client->parseMultiStatus($bodyAsString);
 
         $this->assertEquals([
             '/addressbooks/user1/book3/card3' => [

--- a/tests/Sabre/CardDAV/MultiGetTest.php
+++ b/tests/Sabre/CardDAV/MultiGetTest.php
@@ -36,12 +36,13 @@ class MultiGetTest extends AbstractPluginTest
 
         $this->server->exec();
 
-        $this->assertEquals(207, $response->status, 'Incorrect status code. Full response body:'.$response->body);
+        $bodyAsString = $response->getBodyAsString();
+        $this->assertEquals(207, $response->status, 'Incorrect status code. Full response body:'.$bodyAsString);
 
         // using the client for parsing
         $client = new DAV\Client(['baseUri' => '/']);
 
-        $result = $client->parseMultiStatus($response->body);
+        $result = $client->parseMultiStatus($bodyAsString);
 
         $this->assertEquals([
             '/addressbooks/user1/book1/card1' => [
@@ -78,12 +79,13 @@ class MultiGetTest extends AbstractPluginTest
 
         $this->server->exec();
 
-        $this->assertEquals(207, $response->status, 'Incorrect status code. Full response body:'.$response->body);
+        $bodyAsString = $response->getBodyAsString();
+        $this->assertEquals(207, $response->status, 'Incorrect status code. Full response body:'.$bodyAsString);
 
         // using the client for parsing
         $client = new DAV\Client(['baseUri' => '/']);
 
-        $result = $client->parseMultiStatus($response->body);
+        $result = $client->parseMultiStatus($bodyAsString);
 
         $prodId = 'PRODID:-//Sabre//Sabre VObject '.\Sabre\VObject\Version::VERSION.'//EN';
 

--- a/tests/Sabre/CardDAV/VCFExportTest.php
+++ b/tests/Sabre/CardDAV/VCFExportTest.php
@@ -57,7 +57,7 @@ class VCFExportTest extends \Sabre\DAVServerTest
         ]);
 
         $response = $this->request($request);
-        $this->assertEquals(200, $response->status, $response->body);
+        $this->assertEquals(200, $response->status, $response->getBodyAsString());
 
         $expected = 'BEGIN:VCARD
 FN:Person1
@@ -75,7 +75,7 @@ END:VCARD
         // We actually expected windows line endings
         $expected = str_replace("\n", "\r\n", $expected);
 
-        $this->assertEquals($expected, $response->body);
+        $this->assertEquals($expected, $response->getBodyAsString());
     }
 
     public function testBrowserIntegration()

--- a/tests/Sabre/CardDAV/ValidateVCardTest.php
+++ b/tests/Sabre/CardDAV/ValidateVCardTest.php
@@ -240,7 +240,7 @@ VCF;
 
         $response = $this->request($request);
 
-        $this->assertEquals(201, $response->status, 'Incorrect status returned! Full response body: '.$response->body);
+        $this->assertEquals(201, $response->status, 'Incorrect status returned! Full response body: '.$response->getBodyAsString());
 
         $foo = $this->cardBackend->getCard('addressbook1', 'blabla.vcf');
         $this->assertEquals("BEGIN:VCARD\r\nVERSION:4.0\r\nUID:foo\r\nFN:FirstName LastName\r\nEND:VCARD\r\n", $foo['carddata']);
@@ -256,7 +256,7 @@ VCF;
 
         $response = $this->request($request);
 
-        $this->assertEquals(415, $response->status, 'Incorrect status returned! Full response body: '.$response->body);
+        $this->assertEquals(415, $response->status, 'Incorrect status returned! Full response body: '.$response->getBodyAsString());
     }
 
     public function testUpdateFile()

--- a/tests/Sabre/DAV/AbstractServer.php
+++ b/tests/Sabre/DAV/AbstractServer.php
@@ -9,7 +9,7 @@ use Sabre\HTTP;
 abstract class AbstractServer extends \PHPUnit\Framework\TestCase
 {
     /**
-     * @var Sabre\HTTP\ResponseMock
+     * @var \Sabre\HTTP\ResponseMock
      */
     protected $response;
     protected $request;

--- a/tests/Sabre/DAV/Browser/MapGetToPropFindTest.php
+++ b/tests/Sabre/DAV/Browser/MapGetToPropFindTest.php
@@ -29,7 +29,7 @@ class MapGetToPropFindTest extends DAV\AbstractServer
         $this->server->httpRequest = ($request);
         $this->server->exec();
 
-        $this->assertEquals(207, $this->response->status, 'Incorrect status response received. Full response body: '.$this->response->body);
+        $this->assertEquals(207, $this->response->status, 'Incorrect status response received. Full response body: '.$this->response->getBodyAsString());
         $this->assertEquals([
             'X-Sabre-Version' => [DAV\Version::VERSION],
             'Content-Type' => ['application/xml; charset=utf-8'],

--- a/tests/Sabre/DAV/Browser/PluginTest.php
+++ b/tests/Sabre/DAV/Browser/PluginTest.php
@@ -148,7 +148,7 @@ class PluginTest extends DAV\AbstractServer
         $this->server->httpRequest = $request;
         $this->server->exec();
 
-        $this->assertEquals(200, $this->response->getStatus(), 'Error: '.$this->response->body);
+        $this->assertEquals(200, $this->response->getStatus(), 'Error: '.$this->response->getBodyAsString());
         $this->assertEquals([
             'X-Sabre-Version' => [DAV\Version::VERSION],
             'Content-Type' => ['image/vnd.microsoft.icon'],
@@ -164,7 +164,7 @@ class PluginTest extends DAV\AbstractServer
         $this->server->httpRequest = $request;
         $this->server->exec();
 
-        $this->assertEquals(404, $this->response->getStatus(), 'Error: '.$this->response->body);
+        $this->assertEquals(404, $this->response->getStatus(), 'Error: '.$this->response->getBodyAsString());
     }
 
     public function testGetAssetEscapeBasePath()
@@ -173,6 +173,6 @@ class PluginTest extends DAV\AbstractServer
         $this->server->httpRequest = $request;
         $this->server->exec();
 
-        $this->assertEquals(404, $this->response->getStatus(), 'Error: '.$this->response->body);
+        $this->assertEquals(404, $this->response->getStatus(), 'Error: '.$this->response->getBodyAsString());
     }
 }

--- a/tests/Sabre/DAV/FSExt/ServerTest.php
+++ b/tests/Sabre/DAV/FSExt/ServerTest.php
@@ -34,7 +34,7 @@ class ServerTest extends DAV\AbstractServer
             $this->response->getHeaders()
          );
 
-        $this->assertEquals('Test contents', stream_get_contents($this->response->body));
+        $this->assertEquals('Test contents', $this->response->getBodyAsString());
     }
 
     public function testHEAD()
@@ -55,7 +55,7 @@ class ServerTest extends DAV\AbstractServer
          );
 
         $this->assertEquals(200, $this->response->status);
-        $this->assertEquals('', $this->response->body);
+        $this->assertEquals('', $this->response->getBodyAsString());
     }
 
     public function testPut()
@@ -73,7 +73,7 @@ class ServerTest extends DAV\AbstractServer
         ], $this->response->getHeaders());
 
         $this->assertEquals(201, $this->response->status);
-        $this->assertEquals('', $this->response->body);
+        $this->assertEquals('', $this->response->getBodyAsString());
         $this->assertEquals('Testing new file', file_get_contents($filename));
     }
 
@@ -105,7 +105,7 @@ class ServerTest extends DAV\AbstractServer
         ], $this->response->getHeaders());
 
         $this->assertEquals(201, $this->response->status);
-        $this->assertEquals('', $this->response->body);
+        $this->assertEquals('', $this->response->getBodyAsString());
         $this->assertTrue(is_dir($this->tempDir.'/testcol'));
     }
 
@@ -119,7 +119,7 @@ class ServerTest extends DAV\AbstractServer
         $this->assertEquals('0', $this->response->getHeader('Content-Length'));
 
         $this->assertEquals(204, $this->response->status);
-        $this->assertEquals('', $this->response->body);
+        $this->assertEquals('', $this->response->getBodyAsString());
         $this->assertEquals('Testing updated file', file_get_contents($this->tempDir.'/test.txt'));
     }
 
@@ -135,7 +135,7 @@ class ServerTest extends DAV\AbstractServer
         ], $this->response->getHeaders());
 
         $this->assertEquals(204, $this->response->status);
-        $this->assertEquals('', $this->response->body);
+        $this->assertEquals('', $this->response->getBodyAsString());
         $this->assertFalse(file_exists($this->tempDir.'/test.txt'));
     }
 
@@ -153,7 +153,7 @@ class ServerTest extends DAV\AbstractServer
             'Content-Length' => ['0'],
         ], $this->response->getHeaders());
         $this->assertEquals(204, $this->response->status);
-        $this->assertEquals('', $this->response->body);
+        $this->assertEquals('', $this->response->getBodyAsString());
         $this->assertFalse(file_exists($this->tempDir.'/testcol'));
     }
 
@@ -173,7 +173,7 @@ class ServerTest extends DAV\AbstractServer
         ], $this->response->getHeaders());
 
         $this->assertEquals(200, $this->response->status);
-        $this->assertEquals('', $this->response->body);
+        $this->assertEquals('', $this->response->getBodyAsString());
     }
 
     public function testMove()
@@ -185,7 +185,7 @@ class ServerTest extends DAV\AbstractServer
         $this->server->exec();
 
         $this->assertEquals(201, $this->response->status);
-        $this->assertEquals('', $this->response->body);
+        $this->assertEquals('', $this->response->getBodyAsString());
 
         $this->assertEquals([
             'Content-Length' => ['0'],
@@ -220,7 +220,7 @@ class ServerTest extends DAV\AbstractServer
         $this->server->exec();
 
         $this->assertEquals(201, $this->response->status);
-        $this->assertEquals('', $this->response->body);
+        $this->assertEquals('', $this->response->getBodyAsString());
 
         $this->assertEquals([
             'Content-Length' => ['0'],
@@ -241,7 +241,7 @@ class ServerTest extends DAV\AbstractServer
         $this->server->exec();
 
         $this->assertEquals(201, $this->response->status);
-        $this->assertEquals('', $this->response->body);
+        $this->assertEquals('', $this->response->getBodyAsString());
 
         $this->assertEquals([
             'Content-Length' => ['0'],

--- a/tests/Sabre/DAV/HTTPPreferParsingTest.php
+++ b/tests/Sabre/DAV/HTTPPreferParsingTest.php
@@ -145,7 +145,7 @@ BLA
 
         $response = $this->request($request);
 
-        $this->assertEquals('', $response->getBodyAsString(), 'Expected empty body: '.$response->body);
+        $this->assertEquals('', $response->getBodyAsString(), 'Expected empty body: '.$response->getBodyAsString());
         $this->assertEquals(204, $response->status);
     }
 

--- a/tests/Sabre/DAV/Locks/PluginTest.php
+++ b/tests/Sabre/DAV/Locks/PluginTest.php
@@ -77,9 +77,9 @@ class PluginTest extends DAV\AbstractServer
         $this->assertEquals('application/xml; charset=utf-8', $this->response->getHeader('Content-Type'));
         $this->assertTrue(1 === preg_match('/^<opaquelocktoken:(.*)>$/', $this->response->getHeader('Lock-Token')), 'We did not get a valid Locktoken back ('.$this->response->getHeader('Lock-Token').')');
 
-        $this->assertEquals(200, $this->response->status, 'Got an incorrect status back. Response body: '.$this->response->body);
+        $this->assertEquals(200, $this->response->status, 'Got an incorrect status back. Response body: '.$this->response->getBodyAsString());
 
-        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", 'xmlns\\1="urn:DAV"', $this->response->body);
+        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", 'xmlns\\1="urn:DAV"', $this->response->getBodyAsString());
         $xml = simplexml_load_string($body);
         $xml->registerXPathNamespace('d', 'urn:DAV');
 
@@ -102,7 +102,7 @@ class PluginTest extends DAV\AbstractServer
 
         foreach ($elements as $elem) {
             $data = $xml->xpath($elem);
-            $this->assertEquals(1, count($data), 'We expected 1 match for the xpath expression "'.$elem.'". '.count($data).' were found. Full response body: '.$this->response->body);
+            $this->assertEquals(1, count($data), 'We expected 1 match for the xpath expression "'.$elem.'". '.count($data).' were found. Full response body: '.$this->response->getBodyAsString());
         }
 
         $depth = $xml->xpath('/d:prop/d:lockdiscovery/d:activelock/d:depth');
@@ -137,7 +137,7 @@ class PluginTest extends DAV\AbstractServer
 
         $this->assertEquals('application/xml; charset=utf-8', $this->response->getHeader('Content-Type'));
 
-        $this->assertEquals(423, $this->response->status, 'Full response: '.$this->response->body);
+        $this->assertEquals(423, $this->response->status, 'Full response: '.$this->response->getBodyAsString());
     }
 
     /**
@@ -267,7 +267,7 @@ class PluginTest extends DAV\AbstractServer
             $this->response->getHeaders()
          );
 
-        $this->assertEquals(409, $this->response->status, 'Got an incorrect status code. Full response body: '.$this->response->body);
+        $this->assertEquals(409, $this->response->status, 'Got an incorrect status code. Full response body: '.$this->response->getBodyAsString());
     }
 
     /**
@@ -329,7 +329,7 @@ class PluginTest extends DAV\AbstractServer
         $this->server->httpResponse = new HTTP\ResponseMock();
         $this->server->invokeMethod($request, $this->server->httpResponse);
 
-        $this->assertEquals(204, $this->server->httpResponse->status, 'Got an incorrect status code. Full response body: '.$this->response->body);
+        $this->assertEquals(204, $this->server->httpResponse->status, 'Got an incorrect status code. Full response body: '.$this->response->getBodyAsString());
         $this->assertEquals([
             'X-Sabre-Version' => [DAV\Version::VERSION],
             'Content-Length' => ['0'],
@@ -366,7 +366,7 @@ class PluginTest extends DAV\AbstractServer
         $this->server->httpResponse = new HTTP\ResponseMock();
         $this->server->invokeMethod($request, $this->server->httpResponse);
 
-        $this->assertEquals(204, $this->server->httpResponse->status, 'Got an incorrect status code. Full response body: '.$this->response->body);
+        $this->assertEquals(204, $this->server->httpResponse->status, 'Got an incorrect status code. Full response body: '.$this->response->getBodyAsString());
         $this->assertEquals([
             'X-Sabre-Version' => [DAV\Version::VERSION],
             'Content-Length' => ['0'],
@@ -629,7 +629,7 @@ class PluginTest extends DAV\AbstractServer
         $this->server->httpRequest = $request;
         $this->server->exec();
 
-        $this->assertEquals(201, $this->response->status, 'A valid lock-token was provided for the source, so this MOVE operation must succeed. Full response body: '.$this->response->body);
+        $this->assertEquals(201, $this->response->status, 'A valid lock-token was provided for the source, so this MOVE operation must succeed. Full response body: '.$this->response->getBodyAsString());
     }
 
     /**
@@ -809,7 +809,7 @@ class PluginTest extends DAV\AbstractServer
 
         $this->server->httpRequest = $request;
         $this->server->exec();
-        $this->assertEquals(204, $this->response->status, 'Incorrect status received. Full response body:'.$this->response->body);
+        $this->assertEquals(204, $this->response->status, 'Incorrect status received. Full response body:'.$this->response->getBodyAsString());
     }
 
     public function testDeleteWithETagOnCollection()

--- a/tests/Sabre/DAV/Mount/PluginTest.php
+++ b/tests/Sabre/DAV/Mount/PluginTest.php
@@ -28,7 +28,7 @@ class PluginTest extends DAV\AbstractServer
         $this->server->httpRequest = ($request);
         $this->server->exec();
 
-        $this->assertEquals(501, $this->response->status, 'We expected GET to not be implemented for Directories. Response body: '.$this->response->body);
+        $this->assertEquals(501, $this->response->status, 'We expected GET to not be implemented for Directories. Response body: '.$this->response->getBodyAsString());
     }
 
     public function testMountResponse()
@@ -46,8 +46,8 @@ class PluginTest extends DAV\AbstractServer
 
         $this->assertEquals(200, $this->response->status);
 
-        $xml = simplexml_load_string($this->response->body);
-        $this->assertInstanceOf('SimpleXMLElement', $xml, 'Response was not a valid xml document. The list of errors:'.print_r(libxml_get_errors(), true).'. xml body: '.$this->response->body.'. What type we got: '.gettype($xml).' class, if object: '.get_class($xml));
+        $xml = simplexml_load_string($this->response->getBodyAsString());
+        $this->assertInstanceOf('SimpleXMLElement', $xml, 'Response was not a valid xml document. The list of errors:'.print_r(libxml_get_errors(), true).'. xml body: '.$this->response->getBodyAsString().'. What type we got: '.gettype($xml).' class, if object: '.get_class($xml));
 
         $xml->registerXPathNamespace('dm', 'http://purl.org/NET/webdav/mount');
         $url = $xml->xpath('//dm:url');

--- a/tests/Sabre/DAV/PartialUpdate/PluginTest.php
+++ b/tests/Sabre/DAV/PartialUpdate/PluginTest.php
@@ -44,7 +44,7 @@ class PluginTest extends \Sabre\DAVServerTest
         ]);
         $response = $this->request($request);
 
-        $this->assertEquals(400, $response->status, 'Full response body:'.$response->body);
+        $this->assertEquals(400, $response->status, 'Full response body:'.$response->getBodyAsString());
     }
 
     public function testPatchNotSupported()
@@ -56,7 +56,7 @@ class PluginTest extends \Sabre\DAVServerTest
         );
         $response = $this->request($request);
 
-        $this->assertEquals(405, $response->status, 'Full response body:'.$response->body);
+        $this->assertEquals(405, $response->status, 'Full response body:'.$response->getBodyAsString());
     }
 
     public function testPatchNoContentType()
@@ -68,7 +68,7 @@ class PluginTest extends \Sabre\DAVServerTest
         );
         $response = $this->request($request);
 
-        $this->assertEquals(415, $response->status, 'Full response body:'.$response->body);
+        $this->assertEquals(415, $response->status, 'Full response body:'.$response->getBodyAsString());
     }
 
     public function testPatchBadRange()
@@ -80,7 +80,7 @@ class PluginTest extends \Sabre\DAVServerTest
         );
         $response = $this->request($request);
 
-        $this->assertEquals(416, $response->status, 'Full response body:'.$response->body);
+        $this->assertEquals(416, $response->status, 'Full response body:'.$response->getBodyAsString());
     }
 
     public function testPatchNoLength()
@@ -92,7 +92,7 @@ class PluginTest extends \Sabre\DAVServerTest
         );
         $response = $this->request($request);
 
-        $this->assertEquals(411, $response->status, 'Full response body:'.$response->body);
+        $this->assertEquals(411, $response->status, 'Full response body:'.$response->getBodyAsString());
     }
 
     public function testPatchSuccess()
@@ -104,7 +104,7 @@ class PluginTest extends \Sabre\DAVServerTest
         );
         $response = $this->request($request);
 
-        $this->assertEquals(204, $response->status, 'Full response body:'.$response->body);
+        $this->assertEquals(204, $response->status, 'Full response body:'.$response->getBodyAsString());
         $this->assertEquals('aaabbbaa', $this->node->get());
     }
 

--- a/tests/Sabre/DAV/ServerMKCOLTest.php
+++ b/tests/Sabre/DAV/ServerMKCOLTest.php
@@ -26,7 +26,7 @@ class ServerMKCOLTest extends AbstractServer
         ], $this->response->getHeaders());
 
         $this->assertEquals(201, $this->response->status);
-        $this->assertEquals('', $this->response->body);
+        $this->assertEquals('', $this->response->getBodyAsString());
         $this->assertTrue(is_dir($this->tempDir.'/testcol'));
     }
 
@@ -129,7 +129,7 @@ class ServerMKCOLTest extends AbstractServer
             'Content-Type' => ['application/xml; charset=utf-8'],
         ], $this->response->getHeaders());
 
-        $this->assertEquals(400, $this->response->status, 'Wrong statuscode received. Full response body: '.$this->response->body);
+        $this->assertEquals(400, $this->response->status, 'Wrong statuscode received. Full response body: '.$this->response->getBodyAsString());
     }
 
     /**
@@ -160,7 +160,7 @@ class ServerMKCOLTest extends AbstractServer
             'Content-Type' => ['application/xml; charset=utf-8'],
         ], $this->response->getHeaders());
 
-        $this->assertEquals(403, $this->response->status, 'Wrong statuscode received. Full response body: '.$this->response->body);
+        $this->assertEquals(403, $this->response->status, 'Wrong statuscode received. Full response body: '.$this->response->getBodyAsString());
     }
 
     /**
@@ -191,7 +191,7 @@ class ServerMKCOLTest extends AbstractServer
             'Content-Length' => ['0'],
         ], $this->response->getHeaders());
 
-        $this->assertEquals(201, $this->response->status, 'Wrong statuscode received. Full response body: '.$this->response->body);
+        $this->assertEquals(201, $this->response->status, 'Wrong statuscode received. Full response body: '.$this->response->getBodyAsString());
     }
 
     /**
@@ -224,7 +224,7 @@ class ServerMKCOLTest extends AbstractServer
             'Content-Length' => ['0'],
         ], $this->response->getHeaders());
 
-        $this->assertEquals(201, $this->response->status, 'Wrong statuscode received. Full response body: '.$this->response->body);
+        $this->assertEquals(201, $this->response->status, 'Wrong statuscode received. Full response body: '.$this->response->getBodyAsString());
     }
 
     /**
@@ -248,7 +248,7 @@ class ServerMKCOLTest extends AbstractServer
             'Content-Type' => ['application/xml; charset=utf-8'],
         ], $this->response->getHeaders());
 
-        $this->assertEquals(409, $this->response->status, 'Wrong statuscode received. Full response body: '.$this->response->body);
+        $this->assertEquals(409, $this->response->status, 'Wrong statuscode received. Full response body: '.$this->response->getBodyAsString());
     }
 
     /**
@@ -272,7 +272,7 @@ class ServerMKCOLTest extends AbstractServer
             'Content-Type' => ['application/xml; charset=utf-8'],
         ], $this->response->getHeaders());
 
-        $this->assertEquals(409, $this->response->status, 'Wrong statuscode received. Full response body: '.$this->response->body);
+        $this->assertEquals(409, $this->response->status, 'Wrong statuscode received. Full response body: '.$this->response->getBodyAsString());
     }
 
     /**
@@ -297,7 +297,7 @@ class ServerMKCOLTest extends AbstractServer
             'Allow' => ['OPTIONS, GET, HEAD, DELETE, PROPFIND, PUT, PROPPATCH, COPY, MOVE, REPORT'],
         ], $this->response->getHeaders());
 
-        $this->assertEquals(405, $this->response->status, 'Wrong statuscode received. Full response body: '.$this->response->body);
+        $this->assertEquals(405, $this->response->status, 'Wrong statuscode received. Full response body: '.$this->response->getBodyAsString());
     }
 
     /**
@@ -323,14 +323,13 @@ class ServerMKCOLTest extends AbstractServer
         $this->server->httpRequest = ($request);
         $this->server->exec();
 
-        $this->assertEquals(207, $this->response->status, 'Wrong statuscode received. Full response body: '.$this->response->body);
+        $bodyAsString = $this->response->getBodyAsString();
+        $this->assertEquals(207, $this->response->status, 'Wrong statuscode received. Full response body: '.$bodyAsString);
 
         $this->assertEquals([
             'X-Sabre-Version' => [Version::VERSION],
             'Content-Type' => ['application/xml; charset=utf-8'],
         ], $this->response->getHeaders());
-
-        $responseBody = $this->response->getBodyAsString();
 
         $expected = <<<XML
 <?xml version="1.0"?>
@@ -349,7 +348,7 @@ XML;
 
         $this->assertXmlStringEqualsXmlString(
             $expected,
-            $responseBody
+            $bodyAsString
         );
     }
 }

--- a/tests/Sabre/DAV/ServerPluginTest.php
+++ b/tests/Sabre/DAV/ServerPluginTest.php
@@ -60,7 +60,7 @@ class ServerPluginTest extends AbstractServer
         ], $this->response->getHeaders());
 
         $this->assertEquals(200, $this->response->status);
-        $this->assertEquals('', $this->response->body);
+        $this->assertEquals('', $this->response->getBodyAsString());
         $this->assertEquals('OPTIONS', $this->testPlugin->beforeMethod);
     }
 

--- a/tests/Sabre/DAV/ServerPropsInfiniteDepthTest.php
+++ b/tests/Sabre/DAV/ServerPropsInfiniteDepthTest.php
@@ -50,7 +50,8 @@ class ServerPropsInfiniteDepthTest extends AbstractServer
     {
         $this->sendRequest('');
 
-        $this->assertEquals(207, $this->response->status, 'Incorrect status received. Full response body: '.$this->response->getBodyAsString());
+        $bodyAsString = $this->response->getBodyAsString();
+        $this->assertEquals(207, $this->response->status, 'Incorrect status received. Full response body: '.$bodyAsString);
 
         $this->assertEquals([
                 'X-Sabre-Version' => [Version::VERSION],
@@ -61,7 +62,7 @@ class ServerPropsInfiniteDepthTest extends AbstractServer
             $this->response->getHeaders()
          );
 
-        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", 'xmlns\\1="urn:DAV"', $this->response->body);
+        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", 'xmlns\\1="urn:DAV"', $bodyAsString);
         $xml = simplexml_load_string($body);
         $xml->registerXPathNamespace('d', 'urn:DAV');
 
@@ -121,7 +122,7 @@ class ServerPropsInfiniteDepthTest extends AbstractServer
 
         $this->sendRequest($xml);
 
-        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", 'xmlns\\1="urn:DAV"', $this->response->body);
+        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", 'xmlns\\1="urn:DAV"', $this->response->getBodyAsString());
         $xml = simplexml_load_string($body);
         $xml->registerXPathNamespace('d', 'urn:DAV');
 
@@ -139,7 +140,7 @@ class ServerPropsInfiniteDepthTest extends AbstractServer
 </d:propfind>';
 
         $this->sendRequest($xml);
-        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", 'xmlns\\1="urn:DAV"', $this->response->body);
+        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", 'xmlns\\1="urn:DAV"', $this->response->getBodyAsString());
         $xml = simplexml_load_string($body);
         $xml->registerXPathNamespace('d', 'urn:DAV');
         $pathTests = [
@@ -169,7 +170,7 @@ class ServerPropsInfiniteDepthTest extends AbstractServer
 </d:propfind>';
 
         $this->sendRequest($xml);
-        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", 'xmlns\\1="urn:DAV"', $this->response->body);
+        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", 'xmlns\\1="urn:DAV"', $this->response->getBodyAsString());
         $xml = simplexml_load_string($body);
         $xml->registerXPathNamespace('d', 'urn:DAV');
         $pathTests = [

--- a/tests/Sabre/DAV/ServerPropsTest.php
+++ b/tests/Sabre/DAV/ServerPropsTest.php
@@ -58,7 +58,7 @@ class ServerPropsTest extends AbstractServer
             $this->response->getHeaders()
          );
 
-        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", 'xmlns\\1="urn:DAV"', $this->response->body);
+        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", 'xmlns\\1="urn:DAV"', $this->response->getBodyAsString());
         $xml = simplexml_load_string($body);
         $xml->registerXPathNamespace('d', 'urn:DAV');
 
@@ -83,7 +83,7 @@ class ServerPropsTest extends AbstractServer
             $this->response->getHeaders()
          );
 
-        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", 'xmlns\\1="urn:DAV"', $this->response->body);
+        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", 'xmlns\\1="urn:DAV"', $this->response->getBodyAsString());
         $xml = simplexml_load_string($body);
         $xml->registerXPathNamespace('d', 'urn:DAV');
 
@@ -105,7 +105,7 @@ class ServerPropsTest extends AbstractServer
 
         $this->sendRequest($xml);
 
-        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", 'xmlns\\1="urn:DAV"', $this->response->body);
+        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", 'xmlns\\1="urn:DAV"', $this->response->getBodyAsString());
         $xml = simplexml_load_string($body);
         $xml->registerXPathNamespace('d', 'urn:DAV');
 
@@ -139,7 +139,7 @@ class ServerPropsTest extends AbstractServer
 
         $this->sendRequest($xml);
 
-        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", 'xmlns\\1="urn:DAV"', $this->response->body);
+        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", 'xmlns\\1="urn:DAV"', $this->response->getBodyAsString());
         $xml = simplexml_load_string($body);
         $xml->registerXPathNamespace('d', 'urn:DAV');
 
@@ -157,7 +157,7 @@ class ServerPropsTest extends AbstractServer
 </d:propfind>';
 
         $this->sendRequest($xml);
-        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", 'xmlns\\1="urn:DAV"', $this->response->body);
+        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", 'xmlns\\1="urn:DAV"', $this->response->getBodyAsString());
         $xml = simplexml_load_string($body);
         $xml->registerXPathNamespace('d', 'urn:DAV');
         $pathTests = [

--- a/tests/Sabre/DAV/ServerSimpleTest.php
+++ b/tests/Sabre/DAV/ServerSimpleTest.php
@@ -42,7 +42,7 @@ class ServerSimpleTest extends AbstractServer
         ], $this->response->getHeaders());
 
         $this->assertEquals(200, $this->response->status);
-        $this->assertEquals('', $this->response->body);
+        $this->assertEquals('', $this->response->getBodyAsString());
     }
 
     public function testOptionsUnmapped()
@@ -62,7 +62,7 @@ class ServerSimpleTest extends AbstractServer
         ], $this->response->getHeaders());
 
         $this->assertEquals(200, $this->response->status);
-        $this->assertEquals('', $this->response->body);
+        $this->assertEquals('', $this->response->getBodyAsString());
     }
 
     public function testNonExistantMethod()
@@ -371,7 +371,7 @@ class ServerSimpleTest extends AbstractServer
             $this->response->getHeaders()
          );
 
-        $this->assertEquals(415, $this->response->status, 'We got an incorrect status back. Full response body follows: '.$this->response->body);
+        $this->assertEquals(415, $this->response->status, 'We got an incorrect status back. Full response body follows: '.$this->response->getBodyAsString());
     }
 
     public function testReportIntercepted()
@@ -394,7 +394,7 @@ class ServerSimpleTest extends AbstractServer
             $this->response->getHeaders()
         );
 
-        $this->assertEquals(418, $this->response->status, 'We got an incorrect status back. Full response body follows: '.$this->response->body);
+        $this->assertEquals(418, $this->response->status, 'We got an incorrect status back. Full response body follows: '.$this->response->getBodyAsString());
     }
 
     public function reportHandler($reportName, $result, $path)

--- a/tests/Sabre/DAV/Sync/PluginTest.php
+++ b/tests/Sabre/DAV/Sync/PluginTest.php
@@ -92,7 +92,7 @@ BLA;
 
         $response = $this->request($request);
 
-        $this->assertEquals(207, $response->status, 'Full response body:'.$response->body);
+        $this->assertEquals(207, $response->status, 'Full response body:'.$response->getBodyAsString());
 
         $multiStatus = $this->server->xml->parse($response->getBodyAsString());
 
@@ -154,7 +154,7 @@ BLA;
 
         $response = $this->request($request);
 
-        $this->assertEquals(207, $response->status, 'Full response body:'.$response->body);
+        $this->assertEquals(207, $response->status, 'Full response body:'.$response->getBodyAsString());
 
         $multiStatus = $this->server->xml->parse($response->getBodyAsString());
 
@@ -213,7 +213,7 @@ BLA;
 
         $response = $this->request($request);
 
-        $this->assertEquals(207, $response->status, 'Full response body:'.$response->body);
+        $this->assertEquals(207, $response->status, 'Full response body:'.$response->getBodyAsString());
 
         $multiStatus = $this->server->xml->parse(
             $response->getBodyAsString()
@@ -263,7 +263,7 @@ BLA;
 
         $response = $this->request($request);
 
-        $this->assertEquals(207, $response->status, 'Full response body:'.$response->body);
+        $this->assertEquals(207, $response->status, 'Full response body:'.$response->getBodyAsString());
 
         $multiStatus = $this->server->xml->parse(
             $response->getBodyAsString()
@@ -320,7 +320,7 @@ BLA;
 
         // The default state has no sync-token, so this report should not yet
         // be supported.
-        $this->assertEquals(415, $response->status, 'Full response body:'.$response->body);
+        $this->assertEquals(415, $response->status, 'Full response body:'.$response->getBodyAsString());
     }
 
     public function testSyncNoSyncCollection()
@@ -348,7 +348,7 @@ BLA;
 
         // The default state has no sync-token, so this report should not yet
         // be supported.
-        $this->assertEquals(415, $response->status, 'Full response body:'.$response->body);
+        $this->assertEquals(415, $response->status, 'Full response body:'.$response->getBodyAsString());
     }
 
     public function testSyncInvalidToken()
@@ -377,7 +377,7 @@ BLA;
 
         // The default state has no sync-token, so this report should not yet
         // be supported.
-        $this->assertEquals(403, $response->status, 'Full response body:'.$response->body);
+        $this->assertEquals(403, $response->status, 'Full response body:'.$response->getBodyAsString());
     }
 
     public function testSyncInvalidTokenNoPrefix()
@@ -406,7 +406,7 @@ BLA;
 
         // The default state has no sync-token, so this report should not yet
         // be supported.
-        $this->assertEquals(403, $response->status, 'Full response body:'.$response->body);
+        $this->assertEquals(403, $response->status, 'Full response body:'.$response->getBodyAsString());
     }
 
     public function testSyncNoSyncToken()
@@ -433,7 +433,7 @@ BLA;
 
         // The default state has no sync-token, so this report should not yet
         // be supported.
-        $this->assertEquals(400, $response->status, 'Full response body:'.$response->body);
+        $this->assertEquals(400, $response->status, 'Full response body:'.$response->getBodyAsString());
     }
 
     public function testSyncNoProp()
@@ -459,7 +459,7 @@ BLA;
 
         // The default state has no sync-token, so this report should not yet
         // be supported.
-        $this->assertEquals(400, $response->status, 'Full response body:'.$response->body);
+        $this->assertEquals(400, $response->status, 'Full response body:'.$response->getBodyAsString());
     }
 
     public function testIfConditions()

--- a/tests/Sabre/DAV/TemporaryFileFilterTest.php
+++ b/tests/Sabre/DAV/TemporaryFileFilterTest.php
@@ -22,7 +22,7 @@ class TemporaryFileFilterTest extends AbstractServer
         $this->server->httpRequest = ($request);
         $this->server->exec();
 
-        $this->assertEquals('', $this->response->body);
+        $this->assertEquals('', $this->response->getBodyAsString());
         $this->assertEquals(201, $this->response->status);
         $this->assertEquals('0', $this->response->getHeader('Content-Length'));
 
@@ -37,7 +37,7 @@ class TemporaryFileFilterTest extends AbstractServer
         $this->server->httpRequest = ($request);
         $this->server->exec();
 
-        $this->assertEquals('', $this->response->body);
+        $this->assertEquals('', $this->response->getBodyAsString());
         $this->assertEquals(201, $this->response->status);
         $this->assertEquals([
             'X-Sabre-Temp' => ['true'],
@@ -54,7 +54,7 @@ class TemporaryFileFilterTest extends AbstractServer
         $this->server->httpRequest = ($request);
         $this->server->exec();
 
-        $this->assertEquals('', $this->response->body);
+        $this->assertEquals('', $this->response->getBodyAsString());
         $this->assertEquals(201, $this->response->status);
         $this->assertEquals([
             'X-Sabre-Temp' => ['true'],
@@ -78,7 +78,7 @@ class TemporaryFileFilterTest extends AbstractServer
         $this->server->httpRequest = ($request);
         $this->server->exec();
 
-        $this->assertEquals('', $this->response->body);
+        $this->assertEquals('', $this->response->getBodyAsString());
         $this->assertEquals(201, $this->response->status);
         $this->assertEquals([
             'X-Sabre-Temp' => ['true'],
@@ -147,7 +147,7 @@ class TemporaryFileFilterTest extends AbstractServer
         $this->server->httpRequest = $request;
         $this->server->exec();
 
-        $this->assertEquals('', $this->response->body);
+        $this->assertEquals('', $this->response->getBodyAsString());
         $this->assertEquals(201, $this->response->status);
         $this->assertEquals([
             'X-Sabre-Temp' => ['true'],
@@ -157,12 +157,12 @@ class TemporaryFileFilterTest extends AbstractServer
         $this->server->httpRequest = $request;
         $this->server->exec();
 
-        $this->assertEquals(204, $this->response->status, "Incorrect status code received. Full body:\n".$this->response->body);
+        $this->assertEquals(204, $this->response->status, "Incorrect status code received. Full body:\n".$this->response->getBodyAsString());
         $this->assertEquals([
             'X-Sabre-Temp' => ['true'],
         ], $this->response->getHeaders());
 
-        $this->assertEquals('', $this->response->body);
+        $this->assertEquals('', $this->response->getBodyAsString());
     }
 
     public function testPutPropfind()
@@ -172,7 +172,8 @@ class TemporaryFileFilterTest extends AbstractServer
         $this->server->httpRequest = $request;
         $this->server->exec();
 
-        $this->assertEquals('', $this->response->body);
+        $bodyAsString = $this->response->getBodyAsString();
+        $this->assertEquals('', $bodyAsString);
         $this->assertEquals(201, $this->response->status);
         $this->assertEquals([
             'X-Sabre-Temp' => ['true'],
@@ -183,13 +184,14 @@ class TemporaryFileFilterTest extends AbstractServer
         $this->server->httpRequest = ($request);
         $this->server->exec();
 
-        $this->assertEquals(207, $this->response->status, 'Incorrect status code returned. Body: '.$this->response->body);
+        $bodyAsString = $this->response->getBodyAsString();
+        $this->assertEquals(207, $this->response->status, 'Incorrect status code returned. Body: '.$bodyAsString);
         $this->assertEquals([
             'X-Sabre-Temp' => ['true'],
             'Content-Type' => ['application/xml; charset=utf-8'],
         ], $this->response->getHeaders());
 
-        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", 'xmlns\\1="urn:DAV"', $this->response->body);
+        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", 'xmlns\\1="urn:DAV"', $bodyAsString);
         $xml = simplexml_load_string($body);
         $xml->registerXPathNamespace('d', 'urn:DAV');
 

--- a/tests/Sabre/DAV/Xml/Property/SupportedReportSetTest.php
+++ b/tests/Sabre/DAV/Xml/Property/SupportedReportSetTest.php
@@ -38,9 +38,10 @@ class SupportedReportSetTest extends DAV\AbstractServer
 
         $this->sendPROPFIND($xml);
 
-        $this->assertEquals(207, $this->response->status, 'We expected a multi-status response. Full response body: '.$this->response->body);
+        $bodyAsString = $this->response->getBodyAsString();
+        $this->assertEquals(207, $this->response->status, 'We expected a multi-status response. Full response body: '.$bodyAsString);
 
-        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", 'xmlns\\1="urn:DAV"', $this->response->body);
+        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", 'xmlns\\1="urn:DAV"', $bodyAsString);
         $xml = simplexml_load_string($body);
         $xml->registerXPathNamespace('d', 'urn:DAV');
 
@@ -78,9 +79,10 @@ class SupportedReportSetTest extends DAV\AbstractServer
 
         $this->sendPROPFIND($xml);
 
-        $this->assertEquals(207, $this->response->status, 'We expected a multi-status response. Full response body: '.$this->response->body);
+        $bodyAsString = $this->response->getBodyAsString();
+        $this->assertEquals(207, $this->response->status, 'We expected a multi-status response. Full response body: '.$bodyAsString);
 
-        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", 'xmlns\\1="urn:DAV"', $this->response->body);
+        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", 'xmlns\\1="urn:DAV"', $bodyAsString);
         $xml = simplexml_load_string($body);
         $xml->registerXPathNamespace('d', 'urn:DAV');
         $xml->registerXPathNamespace('x', 'http://www.rooftopsolutions.nl/testnamespace');
@@ -98,10 +100,10 @@ class SupportedReportSetTest extends DAV\AbstractServer
         $this->assertEquals(2, count($data), 'We expected 2 \'d:report\' elements');
 
         $data = $xml->xpath('/d:multistatus/d:response/d:propstat/d:prop/d:supported-report-set/d:supported-report/d:report/x:myreport');
-        $this->assertEquals(1, count($data), 'We expected 1 \'x:myreport\' element. Full body: '.$this->response->body);
+        $this->assertEquals(1, count($data), 'We expected 1 \'x:myreport\' element. Full body: '.$bodyAsString);
 
         $data = $xml->xpath('/d:multistatus/d:response/d:propstat/d:prop/d:supported-report-set/d:supported-report/d:report/d:anotherreport');
-        $this->assertEquals(1, count($data), 'We expected 1 \'d:anotherreport\' element. Full body: '.$this->response->body);
+        $this->assertEquals(1, count($data), 'We expected 1 \'d:anotherreport\' element. Full body: '.$bodyAsString);
 
         $data = $xml->xpath('/d:multistatus/d:response/d:propstat/d:status');
         $this->assertEquals(1, count($data), 'We expected 1 \'d:status\' element');

--- a/tests/Sabre/DAVACL/ExpandPropertiesTest.php
+++ b/tests/Sabre/DAVACL/ExpandPropertiesTest.php
@@ -75,7 +75,7 @@ class ExpandPropertiesTest extends \PHPUnit\Framework\TestCase
 
         $server->exec();
 
-        $this->assertEquals(207, $server->httpResponse->status, 'Incorrect status code received. Full body: '.$server->httpResponse->body);
+        $this->assertEquals(207, $server->httpResponse->status, 'Incorrect status code received. Full body: '.$server->httpResponse->getBodyAsString());
         $this->assertEquals([
             'X-Sabre-Version' => [DAV\Version::VERSION],
             'Content-Type' => ['application/xml; charset=utf-8'],
@@ -93,7 +93,7 @@ class ExpandPropertiesTest extends \PHPUnit\Framework\TestCase
             '/d:multistatus/d:response/d:propstat/d:prop/s:href/d:href' => 1,
         ];
 
-        $xml = simplexml_load_string($server->httpResponse->body);
+        $xml = simplexml_load_string($server->httpResponse->getBodyAsString());
         $xml->registerXPathNamespace('d', 'DAV:');
         $xml->registerXPathNamespace('s', 'http://sabredav.org/ns');
         foreach ($check as $v1 => $v2) {
@@ -106,7 +106,7 @@ class ExpandPropertiesTest extends \PHPUnit\Framework\TestCase
                 $count = $v2;
             }
 
-            $this->assertEquals($count, count($result), 'we expected '.$count.' appearances of '.$xpath.' . We found '.count($result).'. Full response: '.$server->httpResponse->body);
+            $this->assertEquals($count, count($result), 'we expected '.$count.' appearances of '.$xpath.' . We found '.count($result).'. Full response: '.$server->httpResponse->getBodyAsString());
         }
     }
 
@@ -136,7 +136,7 @@ class ExpandPropertiesTest extends \PHPUnit\Framework\TestCase
 
         $server->exec();
 
-        $this->assertEquals(207, $server->httpResponse->status, 'Incorrect response status received. Full response body: '.$server->httpResponse->body);
+        $this->assertEquals(207, $server->httpResponse->status, 'Incorrect response status received. Full response body: '.$server->httpResponse->getBodyAsString());
         $this->assertEquals([
             'X-Sabre-Version' => [DAV\Version::VERSION],
             'Content-Type' => ['application/xml; charset=utf-8'],
@@ -156,7 +156,7 @@ class ExpandPropertiesTest extends \PHPUnit\Framework\TestCase
             '/d:multistatus/d:response/d:propstat/d:prop/s:href/d:response/d:propstat/d:prop/d:displayname' => 1,
         ];
 
-        $xml = simplexml_load_string($server->httpResponse->body);
+        $xml = simplexml_load_string($server->httpResponse->getBodyAsString());
         $xml->registerXPathNamespace('d', 'DAV:');
         $xml->registerXPathNamespace('s', 'http://sabredav.org/ns');
         foreach ($check as $v1 => $v2) {
@@ -219,7 +219,7 @@ class ExpandPropertiesTest extends \PHPUnit\Framework\TestCase
             '/d:multistatus/d:response/d:propstat/d:prop/s:hreflist/d:response/d:propstat/d:prop/d:displayname' => 2,
         ];
 
-        $xml = simplexml_load_string($server->httpResponse->body);
+        $xml = simplexml_load_string($server->httpResponse->getBodyAsString());
         $xml->registerXPathNamespace('d', 'DAV:');
         $xml->registerXPathNamespace('s', 'http://sabredav.org/ns');
         foreach ($check as $v1 => $v2) {
@@ -291,7 +291,7 @@ class ExpandPropertiesTest extends \PHPUnit\Framework\TestCase
             '/d:multistatus/d:response/d:propstat/d:prop/s:hreflist/d:response/d:propstat/d:prop/s:href/d:response/d:propstat/d:prop/d:displayname' => 1,
         ];
 
-        $xml = simplexml_load_string($server->httpResponse->body);
+        $xml = simplexml_load_string($server->httpResponse->getBodyAsString());
         $xml->registerXPathNamespace('d', 'DAV:');
         $xml->registerXPathNamespace('s', 'http://sabredav.org/ns');
         foreach ($check as $v1 => $v2) {

--- a/tests/Sabre/DAVACL/PrincipalPropertySearchTest.php
+++ b/tests/Sabre/DAVACL/PrincipalPropertySearchTest.php
@@ -140,7 +140,8 @@ class PrincipalPropertySearchTest extends \PHPUnit\Framework\TestCase
 
         $server->exec();
 
-        $this->assertEquals(207, $server->httpResponse->status, $server->httpResponse->body);
+        $bodyAsString = $server->httpResponse->getBodyAsString();
+        $this->assertEquals(207, $server->httpResponse->status, $bodyAsString);
         $this->assertEquals([
             'X-Sabre-Version' => [DAV\Version::VERSION],
             'Content-Type' => ['application/xml; charset=utf-8'],
@@ -158,7 +159,7 @@ class PrincipalPropertySearchTest extends \PHPUnit\Framework\TestCase
             '/d:multistatus/d:response/d:propstat/d:status' => 4,
         ];
 
-        $xml = simplexml_load_string($server->httpResponse->body);
+        $xml = simplexml_load_string($bodyAsString);
         $xml->registerXPathNamespace('d', 'DAV:');
         foreach ($check as $v1 => $v2) {
             $xpath = is_int($v1) ? $v2 : $v1;
@@ -170,7 +171,7 @@ class PrincipalPropertySearchTest extends \PHPUnit\Framework\TestCase
                 $count = $v2;
             }
 
-            $this->assertEquals($count, count($result), 'we expected '.$count.' appearances of '.$xpath.' . We found '.count($result).'. Full response body: '.$server->httpResponse->body);
+            $this->assertEquals($count, count($result), 'we expected '.$count.' appearances of '.$xpath.' . We found '.count($result).'. Full response body: '.$server->httpResponse->getBodyAsString());
         }
     }
 
@@ -211,7 +212,8 @@ class PrincipalPropertySearchTest extends \PHPUnit\Framework\TestCase
 
         $server->exec();
 
-        $this->assertEquals(207, $server->httpResponse->status, $server->httpResponse->body);
+        $bodyAsString = $server->httpResponse->getBodyAsString();
+        $this->assertEquals(207, $server->httpResponse->status, $bodyAsString);
         $this->assertEquals([
             'X-Sabre-Version' => [DAV\Version::VERSION],
             'Content-Type' => ['application/xml; charset=utf-8'],
@@ -229,7 +231,7 @@ class PrincipalPropertySearchTest extends \PHPUnit\Framework\TestCase
             '/d:multistatus/d:response/d:propstat/d:status' => 0,
         ];
 
-        $xml = simplexml_load_string($server->httpResponse->body);
+        $xml = simplexml_load_string($bodyAsString);
         $xml->registerXPathNamespace('d', 'DAV:');
         foreach ($check as $v1 => $v2) {
             $xpath = is_int($v1) ? $v2 : $v1;
@@ -241,7 +243,7 @@ class PrincipalPropertySearchTest extends \PHPUnit\Framework\TestCase
                 $count = $v2;
             }
 
-            $this->assertEquals($count, count($result), 'we expected '.$count.' appearances of '.$xpath.' . We found '.count($result).'. Full response body: '.$server->httpResponse->body);
+            $this->assertEquals($count, count($result), 'we expected '.$count.' appearances of '.$xpath.' . We found '.count($result).'. Full response body: '.$server->httpResponse->getBodyAsString());
         }
     }
 
@@ -282,7 +284,8 @@ class PrincipalPropertySearchTest extends \PHPUnit\Framework\TestCase
 
         $server->exec();
 
-        $this->assertEquals(207, $server->httpResponse->status, $server->httpResponse->body);
+        $bodyAsString = $server->httpResponse->getBodyAsString();
+        $this->assertEquals(207, $server->httpResponse->status, $bodyAsString);
         $this->assertEquals([
             'X-Sabre-Version' => [DAV\Version::VERSION],
             'Content-Type' => ['application/xml; charset=utf-8'],
@@ -300,7 +303,7 @@ class PrincipalPropertySearchTest extends \PHPUnit\Framework\TestCase
             '/d:multistatus/d:response/d:propstat/d:status' => 4,
         ];
 
-        $xml = simplexml_load_string($server->httpResponse->body);
+        $xml = simplexml_load_string($bodyAsString);
         $xml->registerXPathNamespace('d', 'DAV:');
         foreach ($check as $v1 => $v2) {
             $xpath = is_int($v1) ? $v2 : $v1;
@@ -312,7 +315,7 @@ class PrincipalPropertySearchTest extends \PHPUnit\Framework\TestCase
                 $count = $v2;
             }
 
-            $this->assertEquals($count, count($result), 'we expected '.$count.' appearances of '.$xpath.' . We found '.count($result).'. Full response body: '.$server->httpResponse->body);
+            $this->assertEquals($count, count($result), 'we expected '.$count.' appearances of '.$xpath.' . We found '.count($result).'. Full response body: '.$server->httpResponse->getBodyAsString());
         }
     }
 
@@ -346,7 +349,8 @@ class PrincipalPropertySearchTest extends \PHPUnit\Framework\TestCase
 
         $server->exec();
 
-        $this->assertEquals(207, $server->httpResponse->status, $server->httpResponse->body);
+        $bodyAsString = $server->httpResponse->getBodyAsString();
+        $this->assertEquals(207, $server->httpResponse->status, $bodyAsString);
         $this->assertEquals([
             'X-Sabre-Version' => [DAV\Version::VERSION],
             'Content-Type' => ['application/xml; charset=utf-8'],
@@ -358,7 +362,7 @@ class PrincipalPropertySearchTest extends \PHPUnit\Framework\TestCase
             '/d:multistatus/d:response' => 0,
         ];
 
-        $xml = simplexml_load_string($server->httpResponse->body);
+        $xml = simplexml_load_string($bodyAsString);
         $xml->registerXPathNamespace('d', 'DAV:');
         foreach ($check as $v1 => $v2) {
             $xpath = is_int($v1) ? $v2 : $v1;
@@ -370,7 +374,7 @@ class PrincipalPropertySearchTest extends \PHPUnit\Framework\TestCase
                 $count = $v2;
             }
 
-            $this->assertEquals($count, count($result), 'we expected '.$count.' appearances of '.$xpath.' . We found '.count($result).'. Full response body: '.$server->httpResponse->body);
+            $this->assertEquals($count, count($result), 'we expected '.$count.' appearances of '.$xpath.' . We found '.count($result).'. Full response body: '.$server->httpResponse->getBodyAsString());
         }
     }
 }

--- a/tests/Sabre/DAVACL/PrincipalSearchPropertySetTest.php
+++ b/tests/Sabre/DAVACL/PrincipalSearchPropertySetTest.php
@@ -76,7 +76,7 @@ class PrincipalSearchPropertySetTest extends \PHPUnit\Framework\TestCase
 
         $server->exec();
 
-        $this->assertEquals(400, $server->httpResponse->status, $server->httpResponse->body);
+        $this->assertEquals(400, $server->httpResponse->status, $server->httpResponse->getBodyAsString());
         $this->assertEquals([
             'X-Sabre-Version' => [DAV\Version::VERSION],
             'Content-Type' => ['application/xml; charset=utf-8'],
@@ -102,7 +102,8 @@ class PrincipalSearchPropertySetTest extends \PHPUnit\Framework\TestCase
 
         $server->exec();
 
-        $this->assertEquals(200, $server->httpResponse->status, $server->httpResponse->body);
+        $bodyAsString = $server->httpResponse->getBodyAsString();
+        $this->assertEquals(200, $server->httpResponse->status, $bodyAsString);
         $this->assertEquals([
             'X-Sabre-Version' => [DAV\Version::VERSION],
             'Content-Type' => ['application/xml; charset=utf-8'],
@@ -117,7 +118,7 @@ class PrincipalSearchPropertySetTest extends \PHPUnit\Framework\TestCase
             '/d:principal-search-property-set/d:principal-search-property/d:description' => 2,
         ];
 
-        $xml = simplexml_load_string($server->httpResponse->body);
+        $xml = simplexml_load_string($bodyAsString);
         $xml->registerXPathNamespace('d', 'DAV:');
         $xml->registerXPathNamespace('s', 'http://sabredav.org/ns');
         foreach ($check as $v1 => $v2) {
@@ -130,7 +131,7 @@ class PrincipalSearchPropertySetTest extends \PHPUnit\Framework\TestCase
                 $count = $v2;
             }
 
-            $this->assertEquals($count, count($result), 'we expected '.$count.' appearances of '.$xpath.' . We found '.count($result).'. Full response body: '.$server->httpResponse->body);
+            $this->assertEquals($count, count($result), 'we expected '.$count.' appearances of '.$xpath.' . We found '.count($result).'. Full response body: '.$bodyAsString);
         }
     }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -14,6 +14,11 @@ $autoLoader->addPsr4('Sabre\\Xml\\', __DIR__.'/../vendor/sabre/xml/tests/Sabre/X
 
 date_default_timezone_set('UTC');
 
+if ('TRUE' === getenv('RUN_TEST_WITH_STREAMING_PROPFIND')) {
+    echo 'Running unit tests with \Sabre\DAV\Server::$streamMultiStatus = true';
+    \Sabre\DAV\Server::$streamMultiStatus = true;
+}
+
 // List of variables that can be set by the environment
 $environmentVars = [
     'SABRE_MYSQLUSER',


### PR DESCRIPTION
Basically #1201 with clean git history and proper travis setup

## Description
- Server:generateMutliStatus can either return a callback or a string
- per default a string is returned in order to not break any existing functionality out there
- with Server::$streamMultiStatus the return can be controlled
- on travis the full test suite is executed with and without stream enabled

## ToDo
- [ ] run litmus
