### PR TITLE
Fix #1199

### DIFF
--- a/lib/CalDAV/Backend/PDO.php
+++ b/lib/CalDAV/Backend/PDO.php
@@ -1286,13 +1286,18 @@ SQL;
     /**
      * Creates a new scheduling object. This should land in a users' inbox.
      *
-     * @param string $principalUri
-     * @param string $objectUri
-     * @param string $objectData
+     * @param string          $principalUri
+     * @param string          $objectUri
+     * @param string|resource $objectData
      */
     public function createSchedulingObject($principalUri, $objectUri, $objectData)
     {
         $stmt = $this->pdo->prepare('INSERT INTO '.$this->schedulingObjectTableName.' (principaluri, calendardata, uri, lastmodified, etag, size) VALUES (?, ?, ?, ?, ?, ?)');
+
+        if (is_resource($objectData)) {
+            $objectData = stream_get_contents($objectData);
+        }
+
         $stmt->execute([$principalUri, $objectData, $objectUri, time(), md5($objectData), strlen($objectData)]);
     }
 

--- a/lib/CalDAV/Backend/SchedulingSupport.php
+++ b/lib/CalDAV/Backend/SchedulingSupport.php
@@ -58,9 +58,9 @@ interface SchedulingSupport extends BackendInterface
     /**
      * Creates a new scheduling object. This should land in a users' inbox.
      *
-     * @param string $principalUri
-     * @param string $objectUri
-     * @param string $objectData
+     * @param string          $principalUri
+     * @param string          $objectUri
+     * @param string|resource $objectData
      */
     public function createSchedulingObject($principalUri, $objectUri, $objectData);
 }

--- a/tests/Sabre/CalDAV/Backend/AbstractPDOTest.php
+++ b/tests/Sabre/CalDAV/Backend/AbstractPDOTest.php
@@ -1026,11 +1026,27 @@ abstract class AbstractPDOTest extends \PHPUnit\Framework\TestCase
             $calData
         );
 
+        $calDataResource = "BEGIN:VCALENDAR\r\nEND:VCALENDAR\r\n";
+        $stream = fopen('data://text/plain,'.$calData, 'r');
+
+        $backend->createSchedulingObject(
+            'principals/user1',
+            'schedule1-resource.ics',
+            $stream
+        );
+
         $expected = [
             'calendardata' => $calData,
             'uri' => 'schedule1.ics',
             'etag' => '"'.md5($calData).'"',
             'size' => strlen($calData),
+        ];
+
+        $expectedResource = [
+            'calendardata' => $calDataResource,
+            'uri' => 'schedule1-resource.ics',
+            'etag' => '"'.md5($calDataResource).'"',
+            'size' => strlen($calDataResource),
         ];
 
         $result = $backend->getSchedulingObject('principals/user1', 'schedule1.ics');
@@ -1041,6 +1057,17 @@ abstract class AbstractPDOTest extends \PHPUnit\Framework\TestCase
             }
             $this->assertEquals($v, $result[$k]);
         }
+
+        $resultResource = $backend->getSchedulingObject('principals/user1', 'schedule1-resource.ics');
+        foreach ($expected as $k => $v) {
+            $this->assertArrayHasKey($k, $result);
+            if (is_resource($result[$k])) {
+                $result[$k] = stream_get_contents($result[$k]);
+            }
+            $this->assertEquals($v, $result[$k]);
+        }
+
+        $backend->deleteSchedulingObject('principals/user1', 'schedule1-resource.ics');
 
         $results = $backend->getSchedulingObjects('principals/user1');
 

--- a/tests/Sabre/CalDAV/Backend/MockScheduling.php
+++ b/tests/Sabre/CalDAV/Backend/MockScheduling.php
@@ -69,9 +69,9 @@ class MockScheduling extends Mock implements SchedulingSupport
     /**
      * Creates a new scheduling object. This should land in a users' inbox.
      *
-     * @param string $principalUri
-     * @param string $objectUri
-     * @param string $objectData;
+     * @param string          $principalUri
+     * @param string          $objectUri
+     * @param string|resource $objectData;
      */
     public function createSchedulingObject($principalUri, $objectUri, $objectData)
     {


### PR DESCRIPTION
Convert `$objectData` to string if it is a resource

Fixes md5() error as explained in #1199 