### PR TITLE
Bump dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,8 @@ bin/phpunit
 bin/vobject
 bin/generate_vcards
 bin/phpdocmd
+bin/phpstan
+bin/phpstan.phar
 bin/php-cs-fixer
 bin/sabre-cs-fixer
 

--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,6 @@ bin/phpunit
 bin/vobject
 bin/generate_vcards
 bin/phpdocmd
-bin/phpunit
 bin/php-cs-fixer
 bin/sabre-cs-fixer
 
@@ -43,3 +42,6 @@ docs/wikidocs
 .DS_Store
 
 .php_cs.cache
+
+# IDEs
+/.idea

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ services:
   - postgresql
 
 install:
-  - if [ $RUN_PHPSTAN == "TRUE"  ]; then wget https://github.com/phpstan/phpstan/releases/download/0.11.8/phpstan.phar; fi
+  - if [ $RUN_PHPSTAN == "TRUE"  ]; then composer require --dev phpstan/phpstan:^0.12; fi
 
 before_script:
 #  - mysql -u root -h 127.0.0.1 sabredav_test -e 'SELECT VERSION();'
@@ -45,7 +45,7 @@ addons:
 script:
   - if [ $RUN_PHPSTAN == "FALSE"  ]; then ./bin/phpunit --verbose --configuration tests/phpunit.xml.dist $WITH_COVERAGE $TEST_DEPS; fi
   - if [ $RUN_PHPSTAN == "FALSE"  ]; then rm -f ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini; fi
-  - if [ $RUN_PHPSTAN == "TRUE"  ]; then php phpstan.phar analyse -c phpstan.neon lib; fi
+  - if [ $RUN_PHPSTAN == "TRUE"  ]; then php ./bin/phpstan analyse -c phpstan.neon lib; fi
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
1) Add .idea (PHPstorm IDE settings) to .gitignore so nobody accidentally commits it
2) Bump phpstan to current version 0.12.5 (the one that was hardcoded in `.travis.yml`)
3) remove duplicate bin/phpunit from .gitignore
4) switch to using phpstan from composer.json