### PR TITLE
Drop PHP 7.0 and adjust tests for phpunit7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 sudo: required
 php:
-  - 7.0
   - 7.1
   - 7.2
   - 7.3

--- a/composer.json
+++ b/composer.json
@@ -15,10 +15,10 @@
     ],
     "require": {
         "php": "^7.1.0",
-        "sabre/vobject": "^4.2.0-alpha1",
+        "sabre/vobject": "^4.2.1",
         "sabre/event" : "^5.0",
         "sabre/xml"  : "^2.0.1",
-        "sabre/http" : "^5.0",
+        "sabre/http" : "^5.0.5",
         "sabre/uri" : "^2.0",
         "ext-dom": "*",
         "ext-pcre": "*",

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": ">=7.0.0",
+        "php": "^7.1.0",
         "sabre/vobject": "^4.2.0-alpha1",
         "sabre/event" : "^5.0",
         "sabre/xml"  : "^2.0.1",
@@ -33,7 +33,7 @@
         "ext-json": "*"
     },
     "require-dev" : {
-        "phpunit/phpunit" : "^6",
+        "phpunit/phpunit" : "^7",
         "evert/phpdoc-md" : "~0.1.0",
         "monolog/monolog": "^1.18"
     },

--- a/tests/Sabre/CalDAV/Backend/AbstractPDOTest.php
+++ b/tests/Sabre/CalDAV/Backend/AbstractPDOTest.php
@@ -1316,7 +1316,7 @@ abstract class AbstractPDOTest extends \PHPUnit\Framework\TestCase
                 ],
             ]),
         ];
-        $this->assertEquals($expected, $result, null, 0.0, 10, true); // Last argument is $canonicalize = true, which allows us to compare, ignoring the order, because it's different between MySQL and Sqlite.
+        $this->assertEquals($expected, $result, '', 0.0, 10, true); // Last argument is $canonicalize = true, which allows us to compare, ignoring the order, because it's different between MySQL and Sqlite.
     }
 
     /**

--- a/tests/Sabre/CalDAV/Schedule/IMipPluginTest.php
+++ b/tests/Sabre/CalDAV/Schedule/IMipPluginTest.php
@@ -205,7 +205,7 @@ ICS;
 
         $expected = [];
         $this->assertEquals($expected, $result);
-        $this->assertEquals('1.0', $message->getScheduleStatus()[0]);
+        $this->assertSame('1', $message->getScheduleStatus()[0]);
     }
 
     public function testRecipientNameIsEmail()

--- a/tests/Sabre/CardDAV/ValidateFilterTest.php
+++ b/tests/Sabre/CardDAV/ValidateFilterTest.php
@@ -16,7 +16,7 @@ class ValidateFilterTest extends AbstractPluginTest
      * @param string|null $message
      * @dataProvider data
      */
-    public function testFilter($input, $filters, $test, $result, $message = null)
+    public function testFilter($input, $filters, $test, $result, $message = '')
     {
         if ($result) {
             $this->assertTrue($this->plugin->validateFilters($input, $filters, $test), $message);

--- a/tests/Sabre/DAV/ServerRangeTest.php
+++ b/tests/Sabre/DAV/ServerRangeTest.php
@@ -133,7 +133,7 @@ class ServerRangeTest extends \Sabre\DAVServerTest
         $request = new HTTP\Request('GET', '/files/no-seeking.txt', ['Range' => 'bytes=2-5']);
         $response = $this->request($request);
 
-        $this->assertEquals(206, $response->getStatus(), $response);
+        $this->assertEquals(206, $response->getStatus());
         $this->assertEquals([
             'X-Sabre-Version' => [Version::VERSION],
             'Content-Type' => ['application/octet-stream'],

--- a/tests/phpunit.xml.dist
+++ b/tests/phpunit.xml.dist
@@ -7,36 +7,38 @@
   convertWarningsToExceptions="true"
   beStrictAboutTestsThatDoNotTestAnything="true"
   beStrictAboutOutputDuringTests="true"
-  beStrictAboutTestSize="true">
+  enforceTimeLimit="true">
 
-  <testsuite name="sabre-event">
-      <directory>../vendor/sabre/event/tests/</directory>
-  </testsuite>
-  <testsuite name="sabre-uri">
-      <directory>../vendor/sabre/uri/tests/</directory>
-  </testsuite>
-  <testsuite name="sabre-xml">
-    <directory>../vendor/sabre/xml/tests/Sabre/Xml/</directory>
-  </testsuite>
-  <testsuite name="sabre-http">
-      <directory>../vendor/sabre/http/tests/HTTP</directory>
-  </testsuite>
-  <testsuite name="sabre-vobject">
-      <directory>../vendor/sabre/vobject/tests/VObject</directory>
-  </testsuite>
+  <testsuites>
+      <testsuite name="sabre-event">
+          <directory>../vendor/sabre/event/tests/</directory>
+      </testsuite>
+      <testsuite name="sabre-uri">
+          <directory>../vendor/sabre/uri/tests/</directory>
+      </testsuite>
+      <testsuite name="sabre-xml">
+        <directory>../vendor/sabre/xml/tests/Sabre/Xml/</directory>
+      </testsuite>
+      <testsuite name="sabre-http">
+          <directory>../vendor/sabre/http/tests/HTTP</directory>
+      </testsuite>
+      <testsuite name="sabre-vobject">
+          <directory>../vendor/sabre/vobject/tests/VObject</directory>
+      </testsuite>
 
-  <testsuite name="sabre-dav">
-      <directory>Sabre/DAV</directory>
-  </testsuite>
-  <testsuite name="sabre-davacl">
-      <directory>Sabre/DAVACL</directory>
-  </testsuite>
-  <testsuite name="sabre-caldav">
-      <directory>Sabre/CalDAV</directory>
-  </testsuite>
-  <testsuite name="sabre-carddav">
-      <directory>Sabre/CardDAV</directory>
-  </testsuite>
+      <testsuite name="sabre-dav">
+          <directory>Sabre/DAV</directory>
+      </testsuite>
+      <testsuite name="sabre-davacl">
+          <directory>Sabre/DAVACL</directory>
+      </testsuite>
+      <testsuite name="sabre-caldav">
+          <directory>Sabre/CalDAV</directory>
+      </testsuite>
+      <testsuite name="sabre-carddav">
+          <directory>Sabre/CardDAV</directory>
+      </testsuite>
+  </testsuites>
 
   <filter>
     <whitelist addUncoveredFilesFromWhitelist="true">


### PR DESCRIPTION
I tried locally running phpunit7 and PHP 7.4.
This fixes things so that it passes.

1) `beStrictAboutTestSize` seems to have been deprecated and is not called `enforceTimeLimit`
2) when there are multiple `testSuite` entries in phpunit.xml they should be enclosed in `testsuites` 
3) A few phpunit Asserts have the message parameter as something other than a string - fix those
4) 1 failure happened:
```
There was 1 failure:

1) Sabre\CalDAV\Schedule\IMipPluginTest::testDeliverInsignificantRequest
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'1.0'
+'1'

/home/phil/git/sabre-io/dav/tests/Sabre/CalDAV/Schedule/IMipPluginTest.php:208
```
The result of the call to `getScheduleStatus()` is actually the string `1` and not `1.0` - I changed the the assert to `assertSame` so that this behaviour is not hidden by the test.

Is it supposed to return the string `1.0` ?