### PR TITLE
Changed require_once -> Composer autoloader for test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ tests/cov
 # Custom settings for tests
 tests/config.user.php
 
+# PHPUnit test Cache
+.phpunit.result.cache
+
 # ViM
 *.swp
 

--- a/composer.json
+++ b/composer.json
@@ -50,6 +50,17 @@
             "Sabre\\CardDAV\\" : "lib/CardDAV/"
         }
     },
+    "autoload-dev" : {
+        "psr-4" : {
+            "Sabre\\" : "tests/sabre/",
+            "Sabre\\CalDAV\\" : "tests/sabre/CalDAV",
+            "Sabre\\CardDAV\\" : "tests/sabre/CardDAV",
+            "Sabre\\DAV\\" : "tests/sabre/DAV",
+            "Sabre\\DAV\\Property\\" : "tests/sabre/DAV/Xml/Property",
+            "Sabre\\DAVACL\\" : "tests/sabre/DAVACL",
+            "Sabre\\HTTP\\" : "tests/sabre/HTTP"
+        }
+    },
     "support" : {
         "forum" : "https://groups.google.com/group/sabredav-discuss",
         "source" : "https://github.com/fruux/sabre-dav"

--- a/tests/Sabre/CalDAV/CalendarObjectTest.php
+++ b/tests/Sabre/CalDAV/CalendarObjectTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Sabre\CalDAV;
 
-require_once 'Sabre/CalDAV/TestUtil.php';
+
 
 class CalendarObjectTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/Sabre/CalDAV/CalendarTest.php
+++ b/tests/Sabre/CalDAV/CalendarTest.php
@@ -6,7 +6,7 @@ namespace Sabre\CalDAV;
 
 use Sabre\DAV\PropPatch;
 
-require_once 'Sabre/CalDAV/TestUtil.php';
+
 
 class CalendarTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/Sabre/CalDAV/ValidateICalTest.php
+++ b/tests/Sabre/CalDAV/ValidateICalTest.php
@@ -8,7 +8,7 @@ use Sabre\DAV;
 use Sabre\DAVACL;
 use Sabre\HTTP;
 
-require_once 'Sabre/HTTP/ResponseMock.php';
+
 
 class ValidateICalTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/Sabre/CalDAV/ValidateICalTest.php
+++ b/tests/Sabre/CalDAV/ValidateICalTest.php
@@ -13,7 +13,7 @@ require_once 'Sabre/HTTP/ResponseMock.php';
 class ValidateICalTest extends \PHPUnit\Framework\TestCase
 {
     /**
-     * @var Sabre\DAV\Server
+     * @var DAV\Server
      */
     protected $server;
     /**
@@ -56,6 +56,9 @@ class ValidateICalTest extends \PHPUnit\Framework\TestCase
         $this->server->httpResponse = $response;
     }
 
+    /**
+     * @return Sabre\HTTP\ResponseMock
+     */
     public function request(HTTP\Request $request)
     {
         $this->server->httpRequest = $request;

--- a/tests/Sabre/CardDAV/AddressBookQueryTest.php
+++ b/tests/Sabre/CardDAV/AddressBookQueryTest.php
@@ -7,8 +7,8 @@ namespace Sabre\CardDAV;
 use Sabre\DAV;
 use Sabre\HTTP;
 
-require_once 'Sabre/CardDAV/AbstractPluginTest.php';
-require_once 'Sabre/HTTP/ResponseMock.php';
+
+
 
 class AddressBookQueryTest extends AbstractPluginTest
 {

--- a/tests/Sabre/CardDAV/MultiGetTest.php
+++ b/tests/Sabre/CardDAV/MultiGetTest.php
@@ -7,7 +7,7 @@ namespace Sabre\CardDAV;
 use Sabre\DAV;
 use Sabre\HTTP;
 
-require_once 'Sabre/HTTP/ResponseMock.php';
+
 
 class MultiGetTest extends AbstractPluginTest
 {

--- a/tests/Sabre/CardDAV/ValidateFilterTest.php
+++ b/tests/Sabre/CardDAV/ValidateFilterTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Sabre\CardDAV;
 
-require_once 'Sabre/CardDAV/AbstractPluginTest.php';
+
 
 class ValidateFilterTest extends AbstractPluginTest
 {

--- a/tests/Sabre/CardDAV/ValidateVCardTest.php
+++ b/tests/Sabre/CardDAV/ValidateVCardTest.php
@@ -8,7 +8,7 @@ use Sabre\DAV;
 use Sabre\DAVACL;
 use Sabre\HTTP;
 
-require_once 'Sabre/HTTP/ResponseMock.php';
+
 
 class ValidateVCardTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/Sabre/DAV/Browser/GuessContentTypeTest.php
+++ b/tests/Sabre/DAV/Browser/GuessContentTypeTest.php
@@ -6,7 +6,7 @@ namespace Sabre\DAV\Browser;
 
 use Sabre\DAV;
 
-require_once 'Sabre/DAV/AbstractServer.php';
+
 class GuessContentTypeTest extends DAV\AbstractServer
 {
     public function setUp()

--- a/tests/Sabre/DAV/Browser/MapGetToPropFindTest.php
+++ b/tests/Sabre/DAV/Browser/MapGetToPropFindTest.php
@@ -7,7 +7,7 @@ namespace Sabre\DAV\Browser;
 use Sabre\DAV;
 use Sabre\HTTP;
 
-require_once 'Sabre/DAV/AbstractServer.php';
+
 
 class MapGetToPropFindTest extends DAV\AbstractServer
 {

--- a/tests/Sabre/DAV/Browser/PluginTest.php
+++ b/tests/Sabre/DAV/Browser/PluginTest.php
@@ -7,7 +7,7 @@ namespace Sabre\DAV\Browser;
 use Sabre\DAV;
 use Sabre\HTTP;
 
-require_once 'Sabre/DAV/AbstractServer.php';
+
 
 class PluginTest extends DAV\AbstractServer
 {

--- a/tests/Sabre/DAV/ClientTest.php
+++ b/tests/Sabre/DAV/ClientTest.php
@@ -6,7 +6,7 @@ namespace Sabre\DAV;
 
 use Sabre\HTTP\Response;
 
-require_once 'Sabre/DAV/ClientMock.php';
+
 
 class ClientTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/Sabre/DAV/FSExt/FileTest.php
+++ b/tests/Sabre/DAV/FSExt/FileTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Sabre\DAV\FSExt;
 
-require_once 'Sabre/TestUtil.php';
+
 
 class FileTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/Sabre/DAV/FSExt/ServerTest.php
+++ b/tests/Sabre/DAV/FSExt/ServerTest.php
@@ -7,7 +7,7 @@ namespace Sabre\DAV\FSExt;
 use Sabre\DAV;
 use Sabre\HTTP;
 
-require_once 'Sabre/DAV/AbstractServer.php';
+
 
 class ServerTest extends DAV\AbstractServer
 {

--- a/tests/Sabre/DAV/GetIfConditionsTest.php
+++ b/tests/Sabre/DAV/GetIfConditionsTest.php
@@ -6,8 +6,8 @@ namespace Sabre\DAV;
 
 use Sabre\HTTP;
 
-require_once 'Sabre/HTTP/ResponseMock.php';
-require_once 'Sabre/DAV/AbstractServer.php';
+
+
 
 class GetIfConditionsTest extends AbstractServer
 {

--- a/tests/Sabre/DAV/Issue33Test.php
+++ b/tests/Sabre/DAV/Issue33Test.php
@@ -6,7 +6,7 @@ namespace Sabre\DAV;
 
 use Sabre\HTTP;
 
-require_once 'Sabre/TestUtil.php';
+
 
 class Issue33Test extends \PHPUnit\Framework\TestCase
 {

--- a/tests/Sabre/DAV/Locks/Backend/FileTest.php
+++ b/tests/Sabre/DAV/Locks/Backend/FileTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Sabre\DAV\Locks\Backend;
 
-require_once 'Sabre/TestUtil.php';
+
 
 class FileTest extends AbstractTest
 {

--- a/tests/Sabre/DAV/Locks/MSWordTest.php
+++ b/tests/Sabre/DAV/Locks/MSWordTest.php
@@ -7,8 +7,8 @@ namespace Sabre\DAV\Locks;
 use Sabre\DAV;
 use Sabre\HTTP;
 
-require_once 'Sabre/HTTP/ResponseMock.php';
-require_once 'Sabre/TestUtil.php';
+
+
 
 class MSWordTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/Sabre/DAV/Locks/PluginTest.php
+++ b/tests/Sabre/DAV/Locks/PluginTest.php
@@ -7,7 +7,7 @@ namespace Sabre\DAV\Locks;
 use Sabre\DAV;
 use Sabre\HTTP;
 
-require_once 'Sabre/DAV/AbstractServer.php';
+
 
 class PluginTest extends DAV\AbstractServer
 {

--- a/tests/Sabre/DAV/Mount/PluginTest.php
+++ b/tests/Sabre/DAV/Mount/PluginTest.php
@@ -7,7 +7,7 @@ namespace Sabre\DAV\Mount;
 use Sabre\DAV;
 use Sabre\HTTP;
 
-require_once 'Sabre/DAV/AbstractServer.php';
+
 
 class PluginTest extends DAV\AbstractServer
 {

--- a/tests/Sabre/DAV/ObjectTreeTest.php
+++ b/tests/Sabre/DAV/ObjectTreeTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Sabre\DAV;
 
-require_once 'Sabre/TestUtil.php';
+
 
 class ObjectTreeTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/Sabre/DAV/PartialUpdate/PluginTest.php
+++ b/tests/Sabre/DAV/PartialUpdate/PluginTest.php
@@ -6,7 +6,7 @@ namespace Sabre\DAV\PartialUpdate;
 
 use Sabre\HTTP;
 
-require_once 'Sabre/DAV/PartialUpdate/FileMock.php';
+
 
 class PluginTest extends \Sabre\DAVServerTest
 {

--- a/tests/Sabre/DAV/ServerEventsTest.php
+++ b/tests/Sabre/DAV/ServerEventsTest.php
@@ -6,7 +6,7 @@ namespace Sabre\DAV;
 
 use Sabre\HTTP;
 
-require_once 'Sabre/DAV/AbstractServer.php';
+
 
 class ServerEventsTest extends AbstractServer
 {

--- a/tests/Sabre/DAV/ServerPluginTest.php
+++ b/tests/Sabre/DAV/ServerPluginTest.php
@@ -6,8 +6,8 @@ namespace Sabre\DAV;
 
 use Sabre\HTTP;
 
-require_once 'Sabre/DAV/AbstractServer.php';
-require_once 'Sabre/DAV/TestPlugin.php';
+
+
 
 class ServerPluginTest extends AbstractServer
 {

--- a/tests/Sabre/DAV/ServerPreconditionsTest.php
+++ b/tests/Sabre/DAV/ServerPreconditionsTest.php
@@ -6,7 +6,6 @@ namespace Sabre\DAV;
 
 use Sabre\HTTP;
 
-require_once 'Sabre/HTTP/ResponseMock.php';
 
 class ServerPreconditionsTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/Sabre/DAV/ServerPropsInfiniteDepthTest.php
+++ b/tests/Sabre/DAV/ServerPropsInfiniteDepthTest.php
@@ -6,7 +6,7 @@ namespace Sabre\DAV;
 
 use Sabre\HTTP;
 
-require_once 'Sabre/DAV/AbstractServer.php';
+
 
 class ServerPropsInfiniteDepthTest extends AbstractServer
 {

--- a/tests/Sabre/DAV/ServerPropsTest.php
+++ b/tests/Sabre/DAV/ServerPropsTest.php
@@ -6,8 +6,8 @@ namespace Sabre\DAV;
 
 use Sabre\HTTP;
 
-require_once 'Sabre/HTTP/ResponseMock.php';
-require_once 'Sabre/DAV/AbstractServer.php';
+
+
 
 class ServerPropsTest extends AbstractServer
 {

--- a/tests/Sabre/DAV/Sync/PluginTest.php
+++ b/tests/Sabre/DAV/Sync/PluginTest.php
@@ -7,7 +7,7 @@ namespace Sabre\DAV\Sync;
 use Sabre\DAV;
 use Sabre\HTTP;
 
-require_once __DIR__.'/MockSyncCollection.php';
+
 
 class PluginTest extends \Sabre\DAVServerTest
 {

--- a/tests/Sabre/DAV/Xml/Property/SupportedReportSetTest.php
+++ b/tests/Sabre/DAV/Xml/Property/SupportedReportSetTest.php
@@ -7,9 +7,6 @@ namespace Sabre\DAV\Property;
 use Sabre\DAV;
 use Sabre\HTTP;
 
-require_once 'Sabre/HTTP/ResponseMock.php';
-require_once 'Sabre/DAV/AbstractServer.php';
-
 class SupportedReportSetTest extends DAV\AbstractServer
 {
     public function sendPROPFIND($body)

--- a/tests/Sabre/DAVACL/ExpandPropertiesTest.php
+++ b/tests/Sabre/DAVACL/ExpandPropertiesTest.php
@@ -7,7 +7,7 @@ namespace Sabre\DAVACL;
 use Sabre\DAV;
 use Sabre\HTTP;
 
-require_once 'Sabre/HTTP/ResponseMock.php';
+
 
 class ExpandPropertiesTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/Sabre/DAVACL/PluginAdminTest.php
+++ b/tests/Sabre/DAVACL/PluginAdminTest.php
@@ -7,8 +7,8 @@ namespace Sabre\DAVACL;
 use Sabre\DAV;
 use Sabre\HTTP;
 
-require_once 'Sabre/DAVACL/MockACLNode.php';
-require_once 'Sabre/HTTP/ResponseMock.php';
+
+
 
 class PluginAdminTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/Sabre/DAVACL/PrincipalPropertySearchTest.php
+++ b/tests/Sabre/DAVACL/PrincipalPropertySearchTest.php
@@ -7,7 +7,7 @@ namespace Sabre\DAVACL;
 use Sabre\DAV;
 use Sabre\HTTP;
 
-require_once 'Sabre/HTTP/ResponseMock.php';
+
 
 class PrincipalPropertySearchTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/Sabre/DAVACL/PrincipalSearchPropertySetTest.php
+++ b/tests/Sabre/DAVACL/PrincipalSearchPropertySetTest.php
@@ -7,7 +7,7 @@ namespace Sabre\DAVACL;
 use Sabre\DAV;
 use Sabre\HTTP;
 
-require_once 'Sabre/HTTP/ResponseMock.php';
+
 
 class PrincipalSearchPropertySetTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/Sabre/DAVACL/SimplePluginTest.php
+++ b/tests/Sabre/DAVACL/SimplePluginTest.php
@@ -7,8 +7,8 @@ namespace Sabre\DAVACL;
 use Sabre\DAV;
 use Sabre\HTTP;
 
-require_once 'Sabre/DAVACL/MockPrincipal.php';
-require_once 'Sabre/DAVACL/MockACLNode.php';
+
+
 
 class SimplePluginTest extends \PHPUnit\Framework\TestCase
 {


### PR DESCRIPTION
Composer autoload_dev is now used for all Unittests. require_once was no longer neccessary and therefore removed.

resolves #1231 