### PR TITLE
Implement php-cs-fixer in CI and apply changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,6 @@ bin/phpdocmd
 bin/phpstan
 bin/phpstan.phar
 bin/php-cs-fixer
-bin/sabre-cs-fixer
 
 # Assuming every .php file in the root is for testing
 /*.php

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,7 @@ addons:
   postgresql: "9.5"
 
 script:
+  - if [ $RUN_PHPSTAN == "FALSE"  ]; then ./bin/php-cs-fixer  fix --dry-run --diff; fi
   - if [ $RUN_PHPSTAN == "FALSE"  ]; then ./bin/phpunit --verbose --configuration tests/phpunit.xml.dist $WITH_COVERAGE $TEST_DEPS; fi
   - if [ $RUN_PHPSTAN == "FALSE"  ]; then rm -f ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini; fi
   - if [ $RUN_PHPSTAN == "TRUE"  ]; then php ./bin/phpstan analyse -c phpstan.neon lib; fi

--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
         "ext-json": "*"
     },
     "require-dev" : {
+        "friendsofphp/php-cs-fixer": "~2.16.1",
         "phpunit/phpunit" : "^7",
         "evert/phpdoc-md" : "~0.1.0",
         "monolog/monolog": "^1.18"

--- a/lib/CalDAV/Backend/AbstractBackend.php
+++ b/lib/CalDAV/Backend/AbstractBackend.php
@@ -30,8 +30,7 @@ abstract class AbstractBackend implements BackendInterface
      *
      * Read the PropPatch documentation for more info and examples.
      *
-     * @param mixed                $calendarId
-     * @param \Sabre\DAV\PropPatch $propPatch
+     * @param mixed $calendarId
      */
     public function updateCalendar($calendarId, \Sabre\DAV\PropPatch $propPatch)
     {
@@ -46,7 +45,6 @@ abstract class AbstractBackend implements BackendInterface
      * If the backend supports this, it may allow for some speed-ups.
      *
      * @param mixed $calendarId
-     * @param array $uris
      *
      * @return array
      */
@@ -103,7 +101,6 @@ abstract class AbstractBackend implements BackendInterface
      * to think of.
      *
      * @param mixed $calendarId
-     * @param array $filters
      *
      * @return array
      */
@@ -124,9 +121,6 @@ abstract class AbstractBackend implements BackendInterface
     /**
      * This method validates if a filter (as passed to calendarQuery) matches
      * the given object.
-     *
-     * @param array $object
-     * @param array $filters
      *
      * @return bool
      */

--- a/lib/CalDAV/Backend/BackendInterface.php
+++ b/lib/CalDAV/Backend/BackendInterface.php
@@ -51,7 +51,6 @@ interface BackendInterface
      *
      * @param string $principalUri
      * @param string $calendarUri
-     * @param array  $properties
      *
      * @return mixed
      */
@@ -69,8 +68,7 @@ interface BackendInterface
      *
      * Read the PropPatch documentation for more info and examples.
      *
-     * @param mixed                $calendarId
-     * @param \Sabre\DAV\PropPatch $propPatch
+     * @param mixed $calendarId
      */
     public function updateCalendar($calendarId, \Sabre\DAV\PropPatch $propPatch);
 
@@ -143,7 +141,6 @@ interface BackendInterface
      * If the backend supports this, it may allow for some speed-ups.
      *
      * @param mixed $calendarId
-     * @param array $uris
      *
      * @return array
      */
@@ -247,7 +244,6 @@ interface BackendInterface
      * to think of.
      *
      * @param mixed $calendarId
-     * @param array $filters
      *
      * @return array
      */

--- a/lib/CalDAV/Backend/NotificationSupport.php
+++ b/lib/CalDAV/Backend/NotificationSupport.php
@@ -40,8 +40,7 @@ interface NotificationSupport extends BackendInterface
      *
      * This may be called by a client once it deems a notification handled.
      *
-     * @param string                $principalUri
-     * @param NotificationInterface $notification
+     * @param string $principalUri
      */
     public function deleteNotification($principalUri, NotificationInterface $notification);
 

--- a/lib/CalDAV/Backend/PDO.php
+++ b/lib/CalDAV/Backend/PDO.php
@@ -117,8 +117,6 @@ class PDO extends AbstractBackend implements SyncSupport, SubscriptionSupport, S
 
     /**
      * Creates the backend.
-     *
-     * @param \PDO $pdo
      */
     public function __construct(\PDO $pdo)
     {
@@ -220,7 +218,6 @@ SQL
      *
      * @param string $principalUri
      * @param string $calendarUri
-     * @param array  $properties
      *
      * @return string
      */
@@ -290,8 +287,7 @@ SQL
      *
      * Read the PropPatch documentation for more info and examples.
      *
-     * @param mixed                $calendarId
-     * @param \Sabre\DAV\PropPatch $propPatch
+     * @param mixed $calendarId
      */
     public function updateCalendar($calendarId, \Sabre\DAV\PropPatch $propPatch)
     {
@@ -483,7 +479,6 @@ SQL
      * If the backend supports this, it may allow for some speed-ups.
      *
      * @param mixed $calendarId
-     * @param array $uris
      *
      * @return array
      */
@@ -760,7 +755,6 @@ SQL
      * specific components, and VEVENT time-ranges.
      *
      * @param mixed $calendarId
-     * @param array $filters
      *
      * @return array
      */
@@ -1109,7 +1103,6 @@ SQL;
      *
      * @param string $principalUri
      * @param string $uri
-     * @param array  $properties
      *
      * @return mixed
      */

--- a/lib/CalDAV/Backend/SimplePDO.php
+++ b/lib/CalDAV/Backend/SimplePDO.php
@@ -44,8 +44,6 @@ class SimplePDO extends AbstractBackend
 
     /**
      * Creates the backend.
-     *
-     * @param \PDO $pdo
      */
     public function __construct(\PDO $pdo)
     {
@@ -103,7 +101,6 @@ class SimplePDO extends AbstractBackend
      *
      * @param string $principalUri
      * @param string $calendarUri
-     * @param array  $properties
      *
      * @return string
      */

--- a/lib/CalDAV/Backend/SubscriptionSupport.php
+++ b/lib/CalDAV/Backend/SubscriptionSupport.php
@@ -58,7 +58,6 @@ interface SubscriptionSupport extends BackendInterface
      *
      * @param string $principalUri
      * @param string $uri
-     * @param array  $properties
      *
      * @return mixed
      */

--- a/lib/CalDAV/Calendar.php
+++ b/lib/CalDAV/Calendar.php
@@ -39,8 +39,7 @@ class Calendar implements ICalendar, DAV\IProperties, DAV\Sync\ISyncCollection, 
     /**
      * Constructor.
      *
-     * @param Backend\BackendInterface $caldavBackend
-     * @param array                    $calendarInfo
+     * @param array $calendarInfo
      */
     public function __construct(Backend\BackendInterface $caldavBackend, $calendarInfo)
     {
@@ -66,8 +65,6 @@ class Calendar implements ICalendar, DAV\IProperties, DAV\Sync\ISyncCollection, 
      *
      * To update specific properties, call the 'handle' method on this object.
      * Read the PropPatch documentation for more information.
-     *
-     * @param PropPatch $propPatch
      */
     public function propPatch(PropPatch $propPatch)
     {
@@ -349,8 +346,6 @@ class Calendar implements ICalendar, DAV\IProperties, DAV\Sync\ISyncCollection, 
      *
      * The list of filters are specified as an array. The exact array is
      * documented by Sabre\CalDAV\CalendarQueryParser.
-     *
-     * @param array $filters
      *
      * @return array
      */

--- a/lib/CalDAV/CalendarHome.php
+++ b/lib/CalDAV/CalendarHome.php
@@ -43,8 +43,7 @@ class CalendarHome implements DAV\IExtendedCollection, DAVACL\IACL
     /**
      * Constructor.
      *
-     * @param Backend\BackendInterface $caldavBackend
-     * @param array                    $principalInfo
+     * @param array $principalInfo
      */
     public function __construct(Backend\BackendInterface $caldavBackend, $principalInfo)
     {
@@ -216,7 +215,6 @@ class CalendarHome implements DAV\IExtendedCollection, DAVACL\IACL
      * Creates a new calendar or subscription.
      *
      * @param string $name
-     * @param MkCol  $mkCol
      *
      * @throws DAV\Exception\InvalidResourceType
      */

--- a/lib/CalDAV/CalendarObject.php
+++ b/lib/CalDAV/CalendarObject.php
@@ -49,10 +49,6 @@ class CalendarObject extends \Sabre\DAV\File implements ICalendarObject, \Sabre\
      *   * size - (optional) The size of the data in bytes.
      *   * lastmodified - (optional) format as a unix timestamp.
      *   * acl - (optional) Use this to override the default ACL for the node.
-     *
-     * @param Backend\BackendInterface $caldavBackend
-     * @param array                    $calendarInfo
-     * @param array                    $objectData
      */
     public function __construct(Backend\BackendInterface $caldavBackend, array $calendarInfo, array $objectData)
     {

--- a/lib/CalDAV/CalendarQueryValidator.php
+++ b/lib/CalDAV/CalendarQueryValidator.php
@@ -27,9 +27,6 @@ class CalendarQueryValidator
      *
      * The list of filters must be formatted as parsed by \Sabre\CalDAV\CalendarQueryParser
      *
-     * @param VObject\Component\VCalendar $vObject
-     * @param array                       $filters
-     *
      * @return bool
      */
     public function validate(VObject\Component\VCalendar $vObject, array $filters)
@@ -51,9 +48,6 @@ class CalendarQueryValidator
      * A list of comp-filters needs to be specified. Also the parent of the
      * component we're checking should be specified, not the component to check
      * itself.
-     *
-     * @param VObject\Component $parent
-     * @param array             $filters
      *
      * @return bool
      */
@@ -115,9 +109,6 @@ class CalendarQueryValidator
      * A list of prop-filters needs to be specified. Also the parent of the
      * property we're checking should be specified, not the property to check
      * itself.
-     *
-     * @param VObject\Component $parent
-     * @param array             $filters
      *
      * @return bool
      */
@@ -181,9 +172,6 @@ class CalendarQueryValidator
      * parameter we're checking should be specified, not the parameter to check
      * itself.
      *
-     * @param VObject\Property $parent
-     * @param array            $filters
-     *
      * @return bool
      */
     protected function validateParamFilters(VObject\Property $parent, array $filters)
@@ -231,8 +219,7 @@ class CalendarQueryValidator
      * A single text-match should be specified as well as the specific property
      * or parameter we need to validate.
      *
-     * @param VObject\Node|string $check     value to check against
-     * @param array               $textMatch
+     * @param VObject\Node|string $check value to check against
      *
      * @return bool
      */
@@ -253,9 +240,8 @@ class CalendarQueryValidator
      * This is all based on the rules specified in rfc4791, which are quite
      * complex.
      *
-     * @param VObject\Node $component
-     * @param DateTime     $start
-     * @param DateTime     $end
+     * @param DateTime $start
+     * @param DateTime $end
      *
      * @return bool
      */

--- a/lib/CalDAV/CalendarRoot.php
+++ b/lib/CalDAV/CalendarRoot.php
@@ -38,9 +38,7 @@ class CalendarRoot extends \Sabre\DAVACL\AbstractPrincipalCollection
      * actually located in a different path, use the $principalPrefix argument
      * to override this.
      *
-     * @param PrincipalBackend\BackendInterface $principalBackend
-     * @param Backend\BackendInterface          $caldavBackend
-     * @param string                            $principalPrefix
+     * @param string $principalPrefix
      */
     public function __construct(PrincipalBackend\BackendInterface $principalBackend, Backend\BackendInterface $caldavBackend, $principalPrefix = 'principals')
     {
@@ -67,8 +65,6 @@ class CalendarRoot extends \Sabre\DAVACL\AbstractPrincipalCollection
      * The passed array contains principal information, and is guaranteed to
      * at least contain a uri item. Other properties may or may not be
      * supplied by the authentication backend.
-     *
-     * @param array $principal
      *
      * @return \Sabre\DAV\INode
      */

--- a/lib/CalDAV/Exception/InvalidComponentType.php
+++ b/lib/CalDAV/Exception/InvalidComponentType.php
@@ -20,9 +20,6 @@ class InvalidComponentType extends DAV\Exception\Forbidden
      * Adds in extra information in the xml response.
      *
      * This method adds the {CALDAV:}supported-calendar-component as defined in rfc4791
-     *
-     * @param DAV\Server  $server
-     * @param \DOMElement $errorNode
      */
     public function serialize(DAV\Server $server, \DOMElement $errorNode)
     {

--- a/lib/CalDAV/ICSExportPlugin.php
+++ b/lib/CalDAV/ICSExportPlugin.php
@@ -74,9 +74,6 @@ class ICSExportPlugin extends DAV\ServerPlugin
     /**
      * Intercepts GET requests on calendar urls ending with ?export.
      *
-     * @param RequestInterface  $request
-     * @param ResponseInterface $response
-     *
      * @throws BadRequest
      * @throws DAV\Exception\NotFound
      * @throws VObject\InvalidDataException
@@ -164,14 +161,13 @@ class ICSExportPlugin extends DAV\ServerPlugin
     /**
      * This method is responsible for generating the actual, full response.
      *
-     * @param string            $path
-     * @param DateTime|null     $start
-     * @param DateTime|null     $end
-     * @param bool              $expand
-     * @param string            $componentType
-     * @param string            $format
-     * @param array             $properties
-     * @param ResponseInterface $response
+     * @param string        $path
+     * @param DateTime|null $start
+     * @param DateTime|null $end
+     * @param bool          $expand
+     * @param string        $componentType
+     * @param string        $format
+     * @param array         $properties
      *
      * @throws DAV\Exception\NotFound
      * @throws VObject\InvalidDataException
@@ -283,8 +279,7 @@ class ICSExportPlugin extends DAV\ServerPlugin
     /**
      * Merges all calendar objects, and builds one big iCalendar blob.
      *
-     * @param array $properties   Some CalDAV properties
-     * @param array $inputObjects
+     * @param array $properties Some CalDAV properties
      *
      * @return VObject\Component\VCalendar
      */

--- a/lib/CalDAV/ICalendarObjectContainer.php
+++ b/lib/CalDAV/ICalendarObjectContainer.php
@@ -33,8 +33,6 @@ interface ICalendarObjectContainer extends \Sabre\DAV\ICollection
      * The list of filters are specified as an array. The exact array is
      * documented by \Sabre\CalDAV\CalendarQueryParser.
      *
-     * @param array $filters
-     *
      * @return array
      */
     public function calendarQuery(array $filters);

--- a/lib/CalDAV/Notifications/Collection.php
+++ b/lib/CalDAV/Notifications/Collection.php
@@ -43,8 +43,7 @@ class Collection extends DAV\Collection implements ICollection, DAVACL\IACL
     /**
      * Constructor.
      *
-     * @param CalDAV\Backend\NotificationSupport $caldavBackend
-     * @param string                             $principalUri
+     * @param string $principalUri
      */
     public function __construct(CalDAV\Backend\NotificationSupport $caldavBackend, $principalUri)
     {

--- a/lib/CalDAV/Notifications/Node.php
+++ b/lib/CalDAV/Notifications/Node.php
@@ -48,9 +48,7 @@ class Node extends DAV\File implements INode, DAVACL\IACL
     /**
      * Constructor.
      *
-     * @param CalDAV\Backend\NotificationSupport $caldavBackend
-     * @param string                             $principalUri
-     * @param NotificationInterface              $notification
+     * @param string $principalUri
      */
     public function __construct(CalDAV\Backend\NotificationSupport $caldavBackend, $principalUri, NotificationInterface $notification)
     {

--- a/lib/CalDAV/Notifications/Plugin.php
+++ b/lib/CalDAV/Notifications/Plugin.php
@@ -60,8 +60,6 @@ class Plugin extends ServerPlugin
      * addPlugin is called.
      *
      * This method should set up the required event subscriptions.
-     *
-     * @param Server $server
      */
     public function initialize(Server $server)
     {
@@ -80,9 +78,6 @@ class Plugin extends ServerPlugin
 
     /**
      * PropFind.
-     *
-     * @param PropFind  $propFind
-     * @param BaseINode $node
      */
     public function propFind(PropFind $propFind, BaseINode $node)
     {
@@ -112,9 +107,6 @@ class Plugin extends ServerPlugin
      *
      * We use this to intercept GET calls to notification nodes, and return the
      * proper response.
-     *
-     * @param RequestInterface  $request
-     * @param ResponseInterface $response
      */
     public function httpGet(RequestInterface $request, ResponseInterface $response)
     {

--- a/lib/CalDAV/Plugin.php
+++ b/lib/CalDAV/Plugin.php
@@ -183,8 +183,6 @@ class Plugin extends DAV\ServerPlugin
 
     /**
      * Initializes the plugin.
-     *
-     * @param DAV\Server $server
      */
     public function initialize(DAV\Server $server)
     {
@@ -272,9 +270,6 @@ class Plugin extends DAV\ServerPlugin
      * This function handles the MKCALENDAR HTTP method, which creates
      * a new calendar.
      *
-     * @param RequestInterface  $request
-     * @param ResponseInterface $response
-     *
      * @return bool
      */
     public function httpMkCalendar(RequestInterface $request, ResponseInterface $response)
@@ -323,9 +318,6 @@ class Plugin extends DAV\ServerPlugin
      * This method handler is invoked before any after properties for a
      * resource are fetched. This allows us to add in any CalDAV specific
      * properties.
-     *
-     * @param DAV\PropFind $propFind
-     * @param DAV\INode    $node
      */
     public function propFind(DAV\PropFind $propFind, DAV\INode $node)
     {
@@ -641,8 +633,6 @@ class Plugin extends DAV\ServerPlugin
     /**
      * This method is responsible for parsing the request and generating the
      * response for the CALDAV:free-busy-query REPORT.
-     *
-     * @param Xml\Request\FreeBusyQueryReport $report
      */
     protected function freeBusyQueryReport(Xml\Request\FreeBusyQueryReport $report)
     {
@@ -719,11 +709,10 @@ class Plugin extends DAV\ServerPlugin
      * This plugin uses this method to ensure that CalDAV objects receive
      * valid calendar data.
      *
-     * @param string    $path
-     * @param DAV\IFile $node
-     * @param resource  $data
-     * @param bool      $modified should be set to true, if this event handler
-     *                            changed &$data
+     * @param string   $path
+     * @param resource $data
+     * @param bool     $modified should be set to true, if this event handler
+     *                           changed &$data
      */
     public function beforeWriteContent($path, DAV\IFile $node, &$data, &$modified)
     {
@@ -757,11 +746,10 @@ class Plugin extends DAV\ServerPlugin
      * This plugin uses this method to ensure that newly created calendar
      * objects contain valid calendar data.
      *
-     * @param string          $path
-     * @param resource        $data
-     * @param DAV\ICollection $parentNode
-     * @param bool            $modified   should be set to true, if this event handler
-     *                                    changed &$data
+     * @param string   $path
+     * @param resource $data
+     * @param bool     $modified should be set to true, if this event handler
+     *                           changed &$data
      */
     public function beforeCreateFile($path, &$data, DAV\ICollection $parentNode, &$modified)
     {
@@ -927,9 +915,6 @@ class Plugin extends DAV\ServerPlugin
     /**
      * This method is triggered whenever a subsystem reqeuests the privileges
      * that are supported on a particular node.
-     *
-     * @param INode $node
-     * @param array $supportedPrivilegeSet
      */
     public function getSupportedPrivilegeSet(INode $node, array &$supportedPrivilegeSet)
     {
@@ -946,8 +931,7 @@ class Plugin extends DAV\ServerPlugin
      * DAV\Browser\Plugin. This allows us to generate an interface users
      * can use to create new calendars.
      *
-     * @param DAV\INode $node
-     * @param string    $output
+     * @param string $output
      *
      * @return bool
      */
@@ -974,9 +958,6 @@ class Plugin extends DAV\ServerPlugin
      * This event is triggered after GET requests.
      *
      * This is used to transform data into jCal, if this was requested.
-     *
-     * @param RequestInterface  $request
-     * @param ResponseInterface $response
      */
     public function httpAfterGet(RequestInterface $request, ResponseInterface $response)
     {

--- a/lib/CalDAV/Principal/Collection.php
+++ b/lib/CalDAV/Principal/Collection.php
@@ -23,8 +23,6 @@ class Collection extends DAVACL\PrincipalCollection
     /**
      * Returns a child object based on principal information.
      *
-     * @param array $principalInfo
-     *
      * @return User
      */
     public function getChildForPrincipal(array $principalInfo)

--- a/lib/CalDAV/Principal/ProxyRead.php
+++ b/lib/CalDAV/Principal/ProxyRead.php
@@ -38,9 +38,6 @@ class ProxyRead implements IProxyRead
      * Creates the object.
      *
      * Note that you MUST supply the parent principal information.
-     *
-     * @param DAVACL\PrincipalBackend\BackendInterface $principalBackend
-     * @param array                                    $principalInfo
      */
     public function __construct(DAVACL\PrincipalBackend\BackendInterface $principalBackend, array $principalInfo)
     {
@@ -143,8 +140,6 @@ class ProxyRead implements IProxyRead
      * The list of members is always overwritten, never appended to.
      *
      * This method should throw an exception if the members could not be set.
-     *
-     * @param array $principals
      */
     public function setGroupMemberSet(array $principals)
     {

--- a/lib/CalDAV/Principal/ProxyWrite.php
+++ b/lib/CalDAV/Principal/ProxyWrite.php
@@ -38,9 +38,6 @@ class ProxyWrite implements IProxyWrite
      * Creates the object.
      *
      * Note that you MUST supply the parent principal information.
-     *
-     * @param DAVACL\PrincipalBackend\BackendInterface $principalBackend
-     * @param array                                    $principalInfo
      */
     public function __construct(DAVACL\PrincipalBackend\BackendInterface $principalBackend, array $principalInfo)
     {
@@ -143,8 +140,6 @@ class ProxyWrite implements IProxyWrite
      * The list of members is always overwritten, never appended to.
      *
      * This method should throw an exception if the members could not be set.
-     *
-     * @param array $principals
      */
     public function setGroupMemberSet(array $principals)
     {

--- a/lib/CalDAV/Schedule/IMipPlugin.php
+++ b/lib/CalDAV/Schedule/IMipPlugin.php
@@ -81,8 +81,6 @@ class IMipPlugin extends DAV\ServerPlugin
 
     /**
      * Event handler for the 'schedule' event.
-     *
-     * @param ITip\Message $iTipMessage
      */
     public function schedule(ITip\Message $iTipMessage)
     {

--- a/lib/CalDAV/Schedule/Inbox.php
+++ b/lib/CalDAV/Schedule/Inbox.php
@@ -38,8 +38,7 @@ class Inbox extends DAV\Collection implements IInbox
     /**
      * Constructor.
      *
-     * @param Backend\SchedulingSupport $caldavBackend
-     * @param string                    $principalUri
+     * @param string $principalUri
      */
     public function __construct(Backend\SchedulingSupport $caldavBackend, $principalUri)
     {
@@ -175,8 +174,6 @@ class Inbox extends DAV\Collection implements IInbox
      *
      * The list of filters are specified as an array. The exact array is
      * documented by \Sabre\CalDAV\CalendarQueryParser.
-     *
-     * @param array $filters
      *
      * @return array
      */

--- a/lib/CalDAV/Schedule/Plugin.php
+++ b/lib/CalDAV/Schedule/Plugin.php
@@ -94,8 +94,6 @@ class Plugin extends ServerPlugin
 
     /**
      * Initializes the plugin.
-     *
-     * @param Server $server
      */
     public function initialize(Server $server)
     {
@@ -158,9 +156,6 @@ class Plugin extends ServerPlugin
     /**
      * This method handles POST request for the outbox.
      *
-     * @param RequestInterface  $request
-     * @param ResponseInterface $response
-     *
      * @return bool
      */
     public function httpPost(RequestInterface $request, ResponseInterface $response)
@@ -195,9 +190,6 @@ class Plugin extends ServerPlugin
      * This method handler is invoked during fetching of properties.
      *
      * We use this event to add calendar-auto-schedule-specific properties.
-     *
-     * @param PropFind $propFind
-     * @param INode    $node
      */
     public function propFind(PropFind $propFind, INode $node)
     {
@@ -297,8 +289,7 @@ class Plugin extends ServerPlugin
     /**
      * This method is called during property updates.
      *
-     * @param string    $path
-     * @param PropPatch $propPatch
+     * @param string $path
      */
     public function propPatch($path, PropPatch $propPatch)
     {
@@ -353,8 +344,6 @@ class Plugin extends ServerPlugin
 
     /**
      * This method is responsible for delivering the ITip message.
-     *
-     * @param ITip\Message $iTipMessage
      */
     public function deliver(ITip\Message $iTipMessage)
     {
@@ -413,8 +402,6 @@ class Plugin extends ServerPlugin
      *
      * This handler attempts to look at local accounts to deliver the
      * scheduling object.
-     *
-     * @param ITip\Message $iTipMessage
      */
     public function scheduleLocalDelivery(ITip\Message $iTipMessage)
     {
@@ -557,9 +544,6 @@ class Plugin extends ServerPlugin
      * that are supported on a particular node.
      *
      * We need to add a number of privileges for scheduling purposes.
-     *
-     * @param INode $node
-     * @param array $supportedPrivilegeSet
      */
     public function getSupportedPrivilegeSet(INode $node, array &$supportedPrivilegeSet)
     {
@@ -621,8 +605,6 @@ class Plugin extends ServerPlugin
      * This method may update $newObject to add any status changes.
      *
      * @param VCalendar|string $oldObject
-     * @param VCalendar        $newObject
-     * @param array            $addresses
      * @param array            $ignore    any addresses to not send messages to
      * @param bool             $modified  a marker to indicate that the original object
      *                                    modified by this process
@@ -700,10 +682,6 @@ class Plugin extends ServerPlugin
      * The latter is from an expired early draft of the CalDAV scheduling
      * extensions, but iCal depends on a feature from that spec, so we
      * implement it.
-     *
-     * @param IOutbox           $outboxNode
-     * @param RequestInterface  $request
-     * @param ResponseInterface $response
      */
     public function outboxRequest(IOutbox $outboxNode, RequestInterface $request, ResponseInterface $response)
     {
@@ -757,11 +735,6 @@ class Plugin extends ServerPlugin
     /**
      * This method is responsible for parsing a free-busy query request and
      * returning it's result.
-     *
-     * @param IOutbox           $outbox
-     * @param VObject\Component $vObject
-     * @param RequestInterface  $request
-     * @param ResponseInterface $response
      *
      * @return string
      */
@@ -852,10 +825,7 @@ class Plugin extends ServerPlugin
      *   * 2.0;description
      *   * 3.7;description
      *
-     * @param string             $email   address
-     * @param \DateTimeInterface $start
-     * @param \DateTimeInterface $end
-     * @param VObject\Component  $request
+     * @param string $email address
      *
      * @return array
      */
@@ -997,8 +967,6 @@ class Plugin extends ServerPlugin
     /**
      * This method checks the 'Schedule-Reply' header
      * and returns false if it's 'F', otherwise true.
-     *
-     * @param RequestInterface $request
      *
      * @return bool
      */

--- a/lib/CalDAV/Schedule/SchedulingObject.php
+++ b/lib/CalDAV/Schedule/SchedulingObject.php
@@ -29,9 +29,6 @@ class SchedulingObject extends \Sabre\CalDAV\CalendarObject implements IScheduli
      *   * size - (optional) The size of the data in bytes.
      *   * lastmodified - (optional) format as a unix timestamp.
      *   * acl - (optional) Use this to override the default ACL for the node.
-     *
-     * @param Backend\SchedulingSupport $caldavBackend
-     * @param array                     $objectData
      */
     public function __construct(Backend\SchedulingSupport $caldavBackend, array $objectData)
     {

--- a/lib/CalDAV/SharingPlugin.php
+++ b/lib/CalDAV/SharingPlugin.php
@@ -67,8 +67,6 @@ class SharingPlugin extends DAV\ServerPlugin
      * addPlugin is called.
      *
      * This method should set up the required event subscriptions.
-     *
-     * @param DAV\Server $server
      */
     public function initialize(DAV\Server $server)
     {
@@ -99,9 +97,6 @@ class SharingPlugin extends DAV\ServerPlugin
      * node.
      *
      * This allows us to inject any properties early.
-     *
-     * @param DAV\PropFind $propFind
-     * @param DAV\INode    $node
      */
     public function propFindEarly(DAV\PropFind $propFind, DAV\INode $node)
     {
@@ -118,9 +113,6 @@ class SharingPlugin extends DAV\ServerPlugin
      * This method is triggered *after* all properties have been retrieved.
      * This allows us to inject the correct resourcetype for calendars that
      * have been shared.
-     *
-     * @param DAV\PropFind $propFind
-     * @param DAV\INode    $node
      */
     public function propFindLate(DAV\PropFind $propFind, DAV\INode $node)
     {
@@ -154,8 +146,7 @@ class SharingPlugin extends DAV\ServerPlugin
      * Even though this is no longer in the current spec, we keep this around
      * because OS X 10.7 may still make use of this feature.
      *
-     * @param string        $path
-     * @param DAV\PropPatch $propPatch
+     * @param string $path
      */
     public function propPatch($path, DAV\PropPatch $propPatch)
     {
@@ -182,9 +173,6 @@ class SharingPlugin extends DAV\ServerPlugin
 
     /**
      * We intercept this to handle POST requests on calendars.
-     *
-     * @param RequestInterface  $request
-     * @param ResponseInterface $response
      *
      * @return bool|null
      */

--- a/lib/CalDAV/Subscriptions/Plugin.php
+++ b/lib/CalDAV/Subscriptions/Plugin.php
@@ -28,8 +28,6 @@ class Plugin extends ServerPlugin
      * addPlugin is called.
      *
      * This method should set up the required event subscriptions.
-     *
-     * @param Server $server
      */
     public function initialize(Server $server)
     {
@@ -57,9 +55,6 @@ class Plugin extends ServerPlugin
 
     /**
      * Triggered after properties have been fetched.
-     *
-     * @param PropFind $propFind
-     * @param INode    $node
      */
     public function propFind(PropFind $propFind, INode $node)
     {

--- a/lib/CalDAV/Subscriptions/Subscription.php
+++ b/lib/CalDAV/Subscriptions/Subscription.php
@@ -40,9 +40,6 @@ class Subscription extends Collection implements ISubscription, IACL
 
     /**
      * Constructor.
-     *
-     * @param SubscriptionSupport $caldavBackend
-     * @param array               $subscriptionInfo
      */
     public function __construct(SubscriptionSupport $caldavBackend, array $subscriptionInfo)
     {
@@ -115,8 +112,6 @@ class Subscription extends Collection implements ISubscription, IACL
      *
      * To update specific properties, call the 'handle' method on this object.
      * Read the PropPatch documentation for more information.
-     *
-     * @param PropPatch $propPatch
      */
     public function propPatch(PropPatch $propPatch)
     {

--- a/lib/CalDAV/Xml/Filter/CalendarData.php
+++ b/lib/CalDAV/Xml/Filter/CalendarData.php
@@ -47,8 +47,6 @@ class CalendarData implements XmlDeserializable
      * $reader->parseInnerTree() will parse the entire sub-tree, and advance to
      * the next element.
      *
-     * @param Reader $reader
-     *
      * @return mixed
      */
     public static function xmlDeserialize(Reader $reader)

--- a/lib/CalDAV/Xml/Filter/CompFilter.php
+++ b/lib/CalDAV/Xml/Filter/CompFilter.php
@@ -44,8 +44,6 @@ class CompFilter implements XmlDeserializable
      * $reader->parseInnerTree() will parse the entire sub-tree, and advance to
      * the next element.
      *
-     * @param Reader $reader
-     *
      * @return mixed
      */
     public static function xmlDeserialize(Reader $reader)

--- a/lib/CalDAV/Xml/Filter/ParamFilter.php
+++ b/lib/CalDAV/Xml/Filter/ParamFilter.php
@@ -42,8 +42,6 @@ class ParamFilter implements XmlDeserializable
      * $reader->parseInnerTree() will parse the entire sub-tree, and advance to
      * the next element.
      *
-     * @param Reader $reader
-     *
      * @return mixed
      */
     public static function xmlDeserialize(Reader $reader)

--- a/lib/CalDAV/Xml/Filter/PropFilter.php
+++ b/lib/CalDAV/Xml/Filter/PropFilter.php
@@ -44,8 +44,6 @@ class PropFilter implements XmlDeserializable
      * $reader->parseInnerTree() will parse the entire sub-tree, and advance to
      * the next element.
      *
-     * @param Reader $reader
-     *
      * @return mixed
      */
     public static function xmlDeserialize(Reader $reader)

--- a/lib/CalDAV/Xml/Notification/Invite.php
+++ b/lib/CalDAV/Xml/Notification/Invite.php
@@ -181,8 +181,6 @@ class Invite implements NotificationInterface
      * This allows serializers to be re-used for different element names.
      *
      * If you are opening new elements, you must also close them again.
-     *
-     * @param Writer $writer
      */
     public function xmlSerialize(Writer $writer)
     {
@@ -192,8 +190,6 @@ class Invite implements NotificationInterface
     /**
      * This method serializes the entire notification, as it is used in the
      * response body.
-     *
-     * @param Writer $writer
      */
     public function xmlSerializeFull(Writer $writer)
     {

--- a/lib/CalDAV/Xml/Notification/InviteReply.php
+++ b/lib/CalDAV/Xml/Notification/InviteReply.php
@@ -89,8 +89,6 @@ class InviteReply implements NotificationInterface
      *   * hostUrl      - A url to the shared calendar.
      *   * summary      - Description of the share, can be the same as the
      *                    calendar, but may also be modified (optional).
-     *
-     * @param array $values
      */
     public function __construct(array $values)
     {
@@ -132,8 +130,6 @@ class InviteReply implements NotificationInterface
      * This allows serializers to be re-used for different element names.
      *
      * If you are opening new elements, you must also close them again.
-     *
-     * @param Writer $writer
      */
     public function xmlSerialize(Writer $writer)
     {
@@ -143,8 +139,6 @@ class InviteReply implements NotificationInterface
     /**
      * This method serializes the entire notification, as it is used in the
      * response body.
-     *
-     * @param Writer $writer
      */
     public function xmlSerializeFull(Writer $writer)
     {

--- a/lib/CalDAV/Xml/Notification/NotificationInterface.php
+++ b/lib/CalDAV/Xml/Notification/NotificationInterface.php
@@ -19,8 +19,6 @@ interface NotificationInterface extends XmlSerializable
     /**
      * This method serializes the entire notification, as it is used in the
      * response body.
-     *
-     * @param Writer $writer
      */
     public function xmlSerializeFull(Writer $writer);
 

--- a/lib/CalDAV/Xml/Notification/SystemStatus.php
+++ b/lib/CalDAV/Xml/Notification/SystemStatus.php
@@ -90,8 +90,6 @@ class SystemStatus implements NotificationInterface
      *
      * Important note 2: If you are writing any new elements, you are also
      * responsible for closing them.
-     *
-     * @param Writer $writer
      */
     public function xmlSerialize(Writer $writer)
     {
@@ -116,8 +114,6 @@ class SystemStatus implements NotificationInterface
     /**
      * This method serializes the entire notification, as it is used in the
      * response body.
-     *
-     * @param Writer $writer
      */
     public function xmlSerializeFull(Writer $writer)
     {

--- a/lib/CalDAV/Xml/Property/AllowedSharingModes.php
+++ b/lib/CalDAV/Xml/Property/AllowedSharingModes.php
@@ -68,8 +68,6 @@ class AllowedSharingModes implements XmlSerializable
      * This allows serializers to be re-used for different element names.
      *
      * If you are opening new elements, you must also close them again.
-     *
-     * @param Writer $writer
      */
     public function xmlSerialize(Writer $writer)
     {

--- a/lib/CalDAV/Xml/Property/EmailAddressSet.php
+++ b/lib/CalDAV/Xml/Property/EmailAddressSet.php
@@ -30,8 +30,6 @@ class EmailAddressSet implements XmlSerializable
 
     /**
      * __construct.
-     *
-     * @param array $emails
      */
     public function __construct(array $emails)
     {
@@ -63,8 +61,6 @@ class EmailAddressSet implements XmlSerializable
      * This allows serializers to be re-used for different element names.
      *
      * If you are opening new elements, you must also close them again.
-     *
-     * @param Writer $writer
      */
     public function xmlSerialize(Writer $writer)
     {

--- a/lib/CalDAV/Xml/Property/Invite.php
+++ b/lib/CalDAV/Xml/Property/Invite.php
@@ -67,8 +67,6 @@ class Invite implements XmlSerializable
      * This allows serializers to be re-used for different element names.
      *
      * If you are opening new elements, you must also close them again.
-     *
-     * @param Writer $writer
      */
     public function xmlSerialize(Writer $writer)
     {

--- a/lib/CalDAV/Xml/Property/ScheduleCalendarTransp.php
+++ b/lib/CalDAV/Xml/Property/ScheduleCalendarTransp.php
@@ -76,8 +76,6 @@ class ScheduleCalendarTransp implements Element
      * This allows serializers to be re-used for different element names.
      *
      * If you are opening new elements, you must also close them again.
-     *
-     * @param Writer $writer
      */
     public function xmlSerialize(Writer $writer)
     {
@@ -108,8 +106,6 @@ class ScheduleCalendarTransp implements Element
      *
      * $reader->parseInnerTree() will parse the entire sub-tree, and advance to
      * the next element.
-     *
-     * @param Reader $reader
      *
      * @return mixed
      */

--- a/lib/CalDAV/Xml/Property/SupportedCalendarComponentSet.php
+++ b/lib/CalDAV/Xml/Property/SupportedCalendarComponentSet.php
@@ -36,8 +36,6 @@ class SupportedCalendarComponentSet implements Element
 
     /**
      * Creates the property.
-     *
-     * @param array $components
      */
     public function __construct(array $components)
     {
@@ -69,8 +67,6 @@ class SupportedCalendarComponentSet implements Element
      * This allows serializers to be re-used for different element names.
      *
      * If you are opening new elements, you must also close them again.
-     *
-     * @param Writer $writer
      */
     public function xmlSerialize(Writer $writer)
     {
@@ -98,8 +94,6 @@ class SupportedCalendarComponentSet implements Element
      *
      * $reader->parseInnerTree() will parse the entire sub-tree, and advance to
      * the next element.
-     *
-     * @param Reader $reader
      *
      * @return mixed
      */

--- a/lib/CalDAV/Xml/Property/SupportedCalendarData.php
+++ b/lib/CalDAV/Xml/Property/SupportedCalendarData.php
@@ -39,8 +39,6 @@ class SupportedCalendarData implements XmlSerializable
      * This allows serializers to be re-used for different element names.
      *
      * If you are opening new elements, you must also close them again.
-     *
-     * @param Writer $writer
      */
     public function xmlSerialize(Writer $writer)
     {

--- a/lib/CalDAV/Xml/Property/SupportedCollationSet.php
+++ b/lib/CalDAV/Xml/Property/SupportedCollationSet.php
@@ -38,8 +38,6 @@ class SupportedCollationSet implements XmlSerializable
      * This allows serializers to be re-used for different element names.
      *
      * If you are opening new elements, you must also close them again.
-     *
-     * @param Writer $writer
      */
     public function xmlSerialize(Writer $writer)
     {

--- a/lib/CalDAV/Xml/Request/CalendarMultiGetReport.php
+++ b/lib/CalDAV/Xml/Request/CalendarMultiGetReport.php
@@ -81,8 +81,6 @@ class CalendarMultiGetReport implements XmlDeserializable
      * $reader->parseInnerTree() will parse the entire sub-tree, and advance to
      * the next element.
      *
-     * @param Reader $reader
-     *
      * @return mixed
      */
     public static function xmlDeserialize(Reader $reader)

--- a/lib/CalDAV/Xml/Request/CalendarQueryReport.php
+++ b/lib/CalDAV/Xml/Request/CalendarQueryReport.php
@@ -81,8 +81,6 @@ class CalendarQueryReport implements XmlDeserializable
      * $reader->parseInnerTree() will parse the entire sub-tree, and advance to
      * the next element.
      *
-     * @param Reader $reader
-     *
      * @return mixed
      */
     public static function xmlDeserialize(Reader $reader)

--- a/lib/CalDAV/Xml/Request/FreeBusyQueryReport.php
+++ b/lib/CalDAV/Xml/Request/FreeBusyQueryReport.php
@@ -55,8 +55,6 @@ class FreeBusyQueryReport implements XmlDeserializable
      * $reader->parseInnerTree() will parse the entire sub-tree, and advance to
      * the next element.
      *
-     * @param Reader $reader
-     *
      * @return mixed
      */
     public static function xmlDeserialize(Reader $reader)

--- a/lib/CalDAV/Xml/Request/InviteReply.php
+++ b/lib/CalDAV/Xml/Request/InviteReply.php
@@ -98,8 +98,6 @@ class InviteReply implements XmlDeserializable
      * $reader->parseInnerTree() will parse the entire sub-tree, and advance to
      * the next element.
      *
-     * @param Reader $reader
-     *
      * @return mixed
      */
     public static function xmlDeserialize(Reader $reader)

--- a/lib/CalDAV/Xml/Request/MkCalendar.php
+++ b/lib/CalDAV/Xml/Request/MkCalendar.php
@@ -55,8 +55,6 @@ class MkCalendar implements XmlDeserializable
      * $reader->parseInnerTree() will parse the entire sub-tree, and advance to
      * the next element.
      *
-     * @param Reader $reader
-     *
      * @return mixed
      */
     public static function xmlDeserialize(Reader $reader)

--- a/lib/CalDAV/Xml/Request/Share.php
+++ b/lib/CalDAV/Xml/Request/Share.php
@@ -57,8 +57,6 @@ class Share implements XmlDeserializable
      * $reader->parseInnerTree() will parse the entire sub-tree, and advance to
      * the next element.
      *
-     * @param Reader $reader
-     *
      * @return mixed
      */
     public static function xmlDeserialize(Reader $reader)

--- a/lib/CardDAV/AddressBook.php
+++ b/lib/CardDAV/AddressBook.php
@@ -36,9 +36,6 @@ class AddressBook extends DAV\Collection implements IAddressBook, DAV\IPropertie
 
     /**
      * Constructor.
-     *
-     * @param Backend\BackendInterface $carddavBackend
-     * @param array                    $addressBookInfo
      */
     public function __construct(Backend\BackendInterface $carddavBackend, array $addressBookInfo)
     {
@@ -181,8 +178,6 @@ class AddressBook extends DAV\Collection implements IAddressBook, DAV\IPropertie
      *
      * To update specific properties, call the 'handle' method on this object.
      * Read the PropPatch documentation for more information.
-     *
-     * @param DAV\PropPatch $propPatch
      */
     public function propPatch(DAV\PropPatch $propPatch)
     {

--- a/lib/CardDAV/AddressBookHome.php
+++ b/lib/CardDAV/AddressBookHome.php
@@ -39,8 +39,7 @@ class AddressBookHome extends DAV\Collection implements DAV\IExtendedCollection,
     /**
      * Constructor.
      *
-     * @param Backend\BackendInterface $carddavBackend
-     * @param string                   $principalUri
+     * @param string $principalUri
      */
     public function __construct(Backend\BackendInterface $carddavBackend, $principalUri)
     {
@@ -152,7 +151,6 @@ class AddressBookHome extends DAV\Collection implements DAV\IExtendedCollection,
      * Creates a new address book.
      *
      * @param string $name
-     * @param MkCol  $mkCol
      *
      * @throws DAV\Exception\InvalidResourceType
      */

--- a/lib/CardDAV/AddressBookRoot.php
+++ b/lib/CardDAV/AddressBookRoot.php
@@ -41,9 +41,7 @@ class AddressBookRoot extends DAVACL\AbstractPrincipalCollection
      * actually located in a different path, use the $principalPrefix argument
      * to override this.
      *
-     * @param DAVACL\PrincipalBackend\BackendInterface $principalBackend
-     * @param Backend\BackendInterface                 $carddavBackend
-     * @param string                                   $principalPrefix
+     * @param string $principalPrefix
      */
     public function __construct(DAVACL\PrincipalBackend\BackendInterface $principalBackend, Backend\BackendInterface $carddavBackend, $principalPrefix = 'principals')
     {
@@ -67,8 +65,6 @@ class AddressBookRoot extends DAVACL\AbstractPrincipalCollection
      * The passed array contains principal information, and is guaranteed to
      * at least contain a uri item. Other properties may or may not be
      * supplied by the authentication backend.
-     *
-     * @param array $principal
      *
      * @return \Sabre\DAV\INode
      */

--- a/lib/CardDAV/Backend/AbstractBackend.php
+++ b/lib/CardDAV/Backend/AbstractBackend.php
@@ -26,7 +26,6 @@ abstract class AbstractBackend implements BackendInterface
      * If the backend supports this, it may allow for some speed-ups.
      *
      * @param mixed $addressBookId
-     * @param array $uris
      *
      * @return array
      */

--- a/lib/CardDAV/Backend/BackendInterface.php
+++ b/lib/CardDAV/Backend/BackendInterface.php
@@ -51,8 +51,7 @@ interface BackendInterface
      *
      * Read the PropPatch documentation for more info and examples.
      *
-     * @param string               $addressBookId
-     * @param \Sabre\DAV\PropPatch $propPatch
+     * @param string $addressBookId
      */
     public function updateAddressBook($addressBookId, \Sabre\DAV\PropPatch $propPatch);
 
@@ -64,7 +63,6 @@ interface BackendInterface
      *
      * @param string $principalUri
      * @param string $url          just the 'basename' of the url
-     * @param array  $properties
      *
      * @return mixed
      */
@@ -123,7 +121,6 @@ interface BackendInterface
      * If the backend supports this, it may allow for some speed-ups.
      *
      * @param mixed $addressBookId
-     * @param array $uris
      *
      * @return array
      */

--- a/lib/CardDAV/Backend/PDO.php
+++ b/lib/CardDAV/Backend/PDO.php
@@ -44,8 +44,6 @@ class PDO extends AbstractBackend implements SyncSupport
 
     /**
      * Sets up the object.
-     *
-     * @param \PDO $pdo
      */
     public function __construct(\PDO $pdo)
     {
@@ -93,8 +91,7 @@ class PDO extends AbstractBackend implements SyncSupport
      *
      * Read the PropPatch documentation for more info and examples.
      *
-     * @param string               $addressBookId
-     * @param \Sabre\DAV\PropPatch $propPatch
+     * @param string $addressBookId
      */
     public function updateAddressBook($addressBookId, \Sabre\DAV\PropPatch $propPatch)
     {
@@ -143,7 +140,6 @@ class PDO extends AbstractBackend implements SyncSupport
      *
      * @param string $principalUri
      * @param string $url          just the 'basename' of the url
-     * @param array  $properties
      *
      * @return int Last insert id
      */
@@ -269,7 +265,6 @@ class PDO extends AbstractBackend implements SyncSupport
      * If the backend supports this, it may allow for some speed-ups.
      *
      * @param mixed $addressBookId
-     * @param array $uris
      *
      * @return array
      */

--- a/lib/CardDAV/Card.php
+++ b/lib/CardDAV/Card.php
@@ -41,10 +41,6 @@ class Card extends DAV\File implements ICard, DAVACL\IACL
 
     /**
      * Constructor.
-     *
-     * @param Backend\BackendInterface $carddavBackend
-     * @param array                    $addressBookInfo
-     * @param array                    $cardData
      */
     public function __construct(Backend\BackendInterface $carddavBackend, array $addressBookInfo, array $cardData)
     {

--- a/lib/CardDAV/Plugin.php
+++ b/lib/CardDAV/Plugin.php
@@ -59,8 +59,6 @@ class Plugin extends DAV\ServerPlugin
 
     /**
      * Initializes the plugin.
-     *
-     * @param DAV\Server $server
      */
     public function initialize(DAV\Server $server)
     {
@@ -131,9 +129,6 @@ class Plugin extends DAV\ServerPlugin
 
     /**
      * Adds all CardDAV-specific properties.
-     *
-     * @param DAV\PropFind $propFind
-     * @param DAV\INode    $node
      */
     public function propFindEarly(DAV\PropFind $propFind, DAV\INode $node)
     {
@@ -267,11 +262,10 @@ class Plugin extends DAV\ServerPlugin
      * This plugin uses this method to ensure that Card nodes receive valid
      * vcard data.
      *
-     * @param string    $path
-     * @param DAV\IFile $node
-     * @param resource  $data
-     * @param bool      $modified should be set to true, if this event handler
-     *                            changed &$data
+     * @param string   $path
+     * @param resource $data
+     * @param bool     $modified should be set to true, if this event handler
+     *                           changed &$data
      */
     public function beforeWriteContent($path, DAV\IFile $node, &$data, &$modified)
     {
@@ -288,11 +282,10 @@ class Plugin extends DAV\ServerPlugin
      * This plugin uses this method to ensure that Card nodes receive valid
      * vcard data.
      *
-     * @param string          $path
-     * @param resource        $data
-     * @param DAV\ICollection $parentNode
-     * @param bool            $modified   should be set to true, if this event handler
-     *                                    changed &$data
+     * @param string   $path
+     * @param resource $data
+     * @param bool     $modified should be set to true, if this event handler
+     *                           changed &$data
      */
     public function beforeCreateFile($path, &$data, DAV\ICollection $parentNode, &$modified)
     {
@@ -481,7 +474,6 @@ class Plugin extends DAV\ServerPlugin
      * Validates if a vcard makes it throught a list of filters.
      *
      * @param string $vcardData
-     * @param array  $filters
      * @param string $test      anyof or allof (which means OR or AND)
      *
      * @return bool
@@ -565,8 +557,6 @@ class Plugin extends DAV\ServerPlugin
      *       property. Any subsequence parameters with the same name are
      *       ignored.
      *
-     * @param array  $vProperties
-     * @param array  $filters
      * @param string $test
      *
      * @return bool
@@ -628,8 +618,6 @@ class Plugin extends DAV\ServerPlugin
     /**
      * Validates if a text-filter can be applied to a specific property.
      *
-     * @param array  $texts
-     * @param array  $filters
      * @param string $test
      *
      * @return bool
@@ -672,9 +660,6 @@ class Plugin extends DAV\ServerPlugin
      *
      * This event is scheduled late in the process, after most work for
      * propfind has been done.
-     *
-     * @param DAV\PropFind $propFind
-     * @param DAV\INode    $node
      */
     public function propFindLate(DAV\PropFind $propFind, DAV\INode $node)
     {
@@ -699,8 +684,7 @@ class Plugin extends DAV\ServerPlugin
      * Sabre\DAV\Browser\Plugin. This allows us to generate an interface users
      * can use to create new addressbooks.
      *
-     * @param DAV\INode $node
-     * @param string    $output
+     * @param string $output
      *
      * @return bool
      */
@@ -727,9 +711,6 @@ class Plugin extends DAV\ServerPlugin
      * This event is triggered after GET requests.
      *
      * This is used to transform data into jCal, if this was requested.
-     *
-     * @param RequestInterface  $request
-     * @param ResponseInterface $response
      */
     public function httpAfterGet(RequestInterface $request, ResponseInterface $response)
     {

--- a/lib/CardDAV/VCFExportPlugin.php
+++ b/lib/CardDAV/VCFExportPlugin.php
@@ -32,8 +32,6 @@ class VCFExportPlugin extends DAV\ServerPlugin
 
     /**
      * Initializes the plugin and registers event handlers.
-     *
-     * @param DAV\Server $server
      */
     public function initialize(DAV\Server $server)
     {
@@ -48,9 +46,6 @@ class VCFExportPlugin extends DAV\ServerPlugin
 
     /**
      * Intercepts GET requests on addressbook urls ending with ?export.
-     *
-     * @param RequestInterface  $request
-     * @param ResponseInterface $response
      *
      * @return bool
      */
@@ -111,8 +106,6 @@ class VCFExportPlugin extends DAV\ServerPlugin
 
     /**
      * Merges all vcard objects, and builds one big vcf export.
-     *
-     * @param array $nodes
      *
      * @return string
      */

--- a/lib/CardDAV/Xml/Filter/AddressData.php
+++ b/lib/CardDAV/Xml/Filter/AddressData.php
@@ -43,8 +43,6 @@ class AddressData implements XmlDeserializable
      * $reader->parseInnerTree() will parse the entire sub-tree, and advance to
      * the next element.
      *
-     * @param Reader $reader
-     *
      * @return mixed
      */
     public static function xmlDeserialize(Reader $reader)

--- a/lib/CardDAV/Xml/Filter/ParamFilter.php
+++ b/lib/CardDAV/Xml/Filter/ParamFilter.php
@@ -43,8 +43,6 @@ abstract class ParamFilter implements Element
      * $reader->parseInnerTree() will parse the entire sub-tree, and advance to
      * the next element.
      *
-     * @param Reader $reader
-     *
      * @return mixed
      */
     public static function xmlDeserialize(Reader $reader)

--- a/lib/CardDAV/Xml/Filter/PropFilter.php
+++ b/lib/CardDAV/Xml/Filter/PropFilter.php
@@ -43,8 +43,6 @@ class PropFilter implements XmlDeserializable
      * $reader->parseInnerTree() will parse the entire sub-tree, and advance to
      * the next element.
      *
-     * @param Reader $reader
-     *
      * @return mixed
      */
     public static function xmlDeserialize(Reader $reader)

--- a/lib/CardDAV/Xml/Property/SupportedAddressData.php
+++ b/lib/CardDAV/Xml/Property/SupportedAddressData.php
@@ -33,8 +33,6 @@ class SupportedAddressData implements XmlSerializable
 
     /**
      * Creates the property.
-     *
-     * @param array|null $supportedData
      */
     public function __construct(array $supportedData = null)
     {
@@ -64,8 +62,6 @@ class SupportedAddressData implements XmlSerializable
      * This allows serializers to be re-used for different element names.
      *
      * If you are opening new elements, you must also close them again.
-     *
-     * @param Writer $writer
      */
     public function xmlSerialize(Writer $writer)
     {

--- a/lib/CardDAV/Xml/Property/SupportedCollationSet.php
+++ b/lib/CardDAV/Xml/Property/SupportedCollationSet.php
@@ -34,8 +34,6 @@ class SupportedCollationSet implements XmlSerializable
      * This allows serializers to be re-used for different element names.
      *
      * If you are opening new elements, you must also close them again.
-     *
-     * @param Writer $writer
      */
     public function xmlSerialize(Writer $writer)
     {

--- a/lib/CardDAV/Xml/Request/AddressBookMultiGetReport.php
+++ b/lib/CardDAV/Xml/Request/AddressBookMultiGetReport.php
@@ -71,8 +71,6 @@ class AddressBookMultiGetReport implements XmlDeserializable
      * $reader->parseInnerTree() will parse the entire sub-tree, and advance to
      * the next element.
      *
-     * @param Reader $reader
-     *
      * @return mixed
      */
     public static function xmlDeserialize(Reader $reader)

--- a/lib/CardDAV/Xml/Request/AddressBookQueryReport.php
+++ b/lib/CardDAV/Xml/Request/AddressBookQueryReport.php
@@ -115,8 +115,6 @@ class AddressBookQueryReport implements XmlDeserializable
      * $reader->parseInnerTree() will parse the entire sub-tree, and advance to
      * the next element.
      *
-     * @param Reader $reader
-     *
      * @return mixed
      */
     public static function xmlDeserialize(Reader $reader)

--- a/lib/DAV/Auth/Backend/AbstractBasic.php
+++ b/lib/DAV/Auth/Backend/AbstractBasic.php
@@ -86,9 +86,6 @@ abstract class AbstractBasic implements BackendInterface
      *
      * principals/users/[username]
      *
-     * @param RequestInterface  $request
-     * @param ResponseInterface $response
-     *
      * @return array
      */
     public function check(RequestInterface $request, ResponseInterface $response)
@@ -126,9 +123,6 @@ abstract class AbstractBasic implements BackendInterface
      * WWW-Authenticate headers may already have been set, and you'll want to
      * append your own WWW-Authenticate header instead of overwriting the
      * existing one.
-     *
-     * @param RequestInterface  $request
-     * @param ResponseInterface $response
      */
     public function challenge(RequestInterface $request, ResponseInterface $response)
     {

--- a/lib/DAV/Auth/Backend/AbstractBearer.php
+++ b/lib/DAV/Auth/Backend/AbstractBearer.php
@@ -79,9 +79,6 @@ abstract class AbstractBearer implements BackendInterface
      *
      * principals/users/[username]
      *
-     * @param RequestInterface  $request
-     * @param ResponseInterface $response
-     *
      * @return array
      */
     public function check(RequestInterface $request, ResponseInterface $response)
@@ -120,9 +117,6 @@ abstract class AbstractBearer implements BackendInterface
      * WWW-Authenticate headers may already have been set, and you'll want to
      * append your own WWW-Authenticate header instead of overwriting the
      * existing one.
-     *
-     * @param RequestInterface  $request
-     * @param ResponseInterface $response
      */
     public function challenge(RequestInterface $request, ResponseInterface $response)
     {

--- a/lib/DAV/Auth/Backend/AbstractDigest.php
+++ b/lib/DAV/Auth/Backend/AbstractDigest.php
@@ -89,9 +89,6 @@ abstract class AbstractDigest implements BackendInterface
      *
      * principals/users/[username]
      *
-     * @param RequestInterface  $request
-     * @param ResponseInterface $response
-     *
      * @return array
      */
     public function check(RequestInterface $request, ResponseInterface $response)
@@ -143,9 +140,6 @@ abstract class AbstractDigest implements BackendInterface
      * WWW-Authenticate headers may already have been set, and you'll want to
      * append your own WWW-Authenticate header instead of overwriting the
      * existing one.
-     *
-     * @param RequestInterface  $request
-     * @param ResponseInterface $response
      */
     public function challenge(RequestInterface $request, ResponseInterface $response)
     {

--- a/lib/DAV/Auth/Backend/Apache.php
+++ b/lib/DAV/Auth/Backend/Apache.php
@@ -52,9 +52,6 @@ class Apache implements BackendInterface
      *
      * principals/users/[username]
      *
-     * @param RequestInterface  $request
-     * @param ResponseInterface $response
-     *
      * @return array
      */
     public function check(RequestInterface $request, ResponseInterface $response)
@@ -89,9 +86,6 @@ class Apache implements BackendInterface
      * WWW-Authenticate headers may already have been set, and you'll want to
      * append your own WWW-Authenticate header instead of overwriting the
      * existing one.
-     *
-     * @param RequestInterface  $request
-     * @param ResponseInterface $response
      */
     public function challenge(RequestInterface $request, ResponseInterface $response)
     {

--- a/lib/DAV/Auth/Backend/BackendInterface.php
+++ b/lib/DAV/Auth/Backend/BackendInterface.php
@@ -40,9 +40,6 @@ interface BackendInterface
      *
      * principals/users/[username]
      *
-     * @param RequestInterface  $request
-     * @param ResponseInterface $response
-     *
      * @return array
      */
     public function check(RequestInterface $request, ResponseInterface $response);
@@ -63,9 +60,6 @@ interface BackendInterface
      * WWW-Authenticate headers may already have been set, and you'll want to
      * append your own WWW-Authenticate header instead of overwriting the
      * existing one.
-     *
-     * @param RequestInterface  $request
-     * @param ResponseInterface $response
      */
     public function challenge(RequestInterface $request, ResponseInterface $response);
 }

--- a/lib/DAV/Auth/Backend/BasicCallBack.php
+++ b/lib/DAV/Auth/Backend/BasicCallBack.php
@@ -30,8 +30,6 @@ class BasicCallBack extends AbstractBasic
      *
      * A callback must be provided to handle checking the username and
      * password.
-     *
-     * @param callable $callBack
      */
     public function __construct(callable $callBack)
     {

--- a/lib/DAV/Auth/Backend/PDO.php
+++ b/lib/DAV/Auth/Backend/PDO.php
@@ -31,8 +31,6 @@ class PDO extends AbstractDigest
      * Creates the backend object.
      *
      * If the filename argument is passed in, it will parse out the specified file fist.
-     *
-     * @param \PDO $pdo
      */
     public function __construct(\PDO $pdo)
     {

--- a/lib/DAV/Auth/Plugin.php
+++ b/lib/DAV/Auth/Plugin.php
@@ -67,8 +67,6 @@ class Plugin extends ServerPlugin
 
     /**
      * Adds an authentication backend to the plugin.
-     *
-     * @param Backend\BackendInterface $authBackend
      */
     public function addBackend(Backend\BackendInterface $authBackend)
     {
@@ -77,8 +75,6 @@ class Plugin extends ServerPlugin
 
     /**
      * Initializes the plugin. This function is automatically called by the server.
-     *
-     * @param Server $server
      */
     public function initialize(Server $server)
     {
@@ -117,9 +113,6 @@ class Plugin extends ServerPlugin
 
     /**
      * This method is called before any HTTP method and forces users to be authenticated.
-     *
-     * @param RequestInterface  $request
-     * @param ResponseInterface $response
      *
      * @return bool
      */
@@ -176,9 +169,6 @@ class Plugin extends ServerPlugin
      * unsuccessful. For every auth backend there will be one reason, so usually
      * there's just one.
      *
-     * @param RequestInterface  $request
-     * @param ResponseInterface $response
-     *
      * @return array
      */
     public function check(RequestInterface $request, ResponseInterface $response)
@@ -214,9 +204,6 @@ class Plugin extends ServerPlugin
      * This method will for example cause a HTTP Basic backend to set a
      * WWW-Authorization header, indicating to the client that it should
      * authenticate.
-     *
-     * @param RequestInterface  $request
-     * @param ResponseInterface $response
      *
      * @return array
      */

--- a/lib/DAV/Browser/GuessContentType.php
+++ b/lib/DAV/Browser/GuessContentType.php
@@ -49,8 +49,6 @@ class GuessContentType extends DAV\ServerPlugin
 
     /**
      * Initializes the plugin.
-     *
-     * @param DAV\Server $server
      */
     public function initialize(DAV\Server $server)
     {
@@ -63,9 +61,6 @@ class GuessContentType extends DAV\ServerPlugin
      * Our PROPFIND handler.
      *
      * Here we set a contenttype, if the node didn't already have one.
-     *
-     * @param PropFind $propFind
-     * @param INode    $node
      */
     public function propFind(PropFind $propFind, INode $node)
     {

--- a/lib/DAV/Browser/HtmlOutput.php
+++ b/lib/DAV/Browser/HtmlOutput.php
@@ -28,8 +28,6 @@ interface HtmlOutput
      * The baseUri parameter is a url to the root of the application, and can
      * be used to construct local links.
      *
-     * @param HtmlOutputHelper $html
-     *
      * @return string
      */
     public function toHtml(HtmlOutputHelper $html);

--- a/lib/DAV/Browser/HtmlOutputHelper.php
+++ b/lib/DAV/Browser/HtmlOutputHelper.php
@@ -42,7 +42,6 @@ class HtmlOutputHelper
      * that can be used to make output a lot shorter.
      *
      * @param string $baseUri
-     * @param array  $namespaceMap
      */
     public function __construct($baseUri, array $namespaceMap)
     {

--- a/lib/DAV/Browser/MapGetToPropFind.php
+++ b/lib/DAV/Browser/MapGetToPropFind.php
@@ -29,8 +29,6 @@ class MapGetToPropFind extends DAV\ServerPlugin
 
     /**
      * Initializes the plugin and subscribes to events.
-     *
-     * @param DAV\Server $server
      */
     public function initialize(DAV\Server $server)
     {
@@ -40,9 +38,6 @@ class MapGetToPropFind extends DAV\ServerPlugin
 
     /**
      * This method intercepts GET requests to non-files, and changes it into an HTTP PROPFIND request.
-     *
-     * @param RequestInterface  $request
-     * @param ResponseInterface $response
      *
      * @return bool
      */

--- a/lib/DAV/Browser/Plugin.php
+++ b/lib/DAV/Browser/Plugin.php
@@ -70,8 +70,6 @@ class Plugin extends DAV\ServerPlugin
 
     /**
      * Initializes the plugin and subscribes to events.
-     *
-     * @param DAV\Server $server
      */
     public function initialize(DAV\Server $server)
     {
@@ -88,9 +86,6 @@ class Plugin extends DAV\ServerPlugin
      * This method intercepts GET requests that have ?sabreAction=info
      * appended to the URL.
      *
-     * @param RequestInterface  $request
-     * @param ResponseInterface $response
-     *
      * @return bool
      */
     public function httpGetEarly(RequestInterface $request, ResponseInterface $response)
@@ -103,9 +98,6 @@ class Plugin extends DAV\ServerPlugin
 
     /**
      * This method intercepts GET requests to collections and returns the html.
-     *
-     * @param RequestInterface  $request
-     * @param ResponseInterface $response
      *
      * @return bool
      */
@@ -159,9 +151,6 @@ class Plugin extends DAV\ServerPlugin
 
     /**
      * Handles POST requests for tree operations.
-     *
-     * @param RequestInterface  $request
-     * @param ResponseInterface $response
      *
      * @return bool
      */
@@ -499,9 +488,8 @@ HTML;
      * This specifically generates the interfaces for creating new files, and
      * creating new directories.
      *
-     * @param DAV\INode $node
-     * @param mixed     $output
-     * @param string    $path
+     * @param mixed  $output
+     * @param string $path
      */
     public function htmlActionsPanel(DAV\INode $node, &$output, $path)
     {
@@ -630,7 +618,6 @@ HTML;
     /**
      * Maps a resource type to a human-readable string and icon.
      *
-     * @param array     $resourceTypes
      * @param DAV\INode $node
      *
      * @return array

--- a/lib/DAV/Client.php
+++ b/lib/DAV/Client.php
@@ -112,8 +112,6 @@ class Client extends HTTP\Client
      *  requests to 'discover' this information.
      *
      *  Encoding is a bitmap with one of the ENCODING constants.
-     *
-     * @param array $settings
      */
     public function __construct(array $settings)
     {
@@ -192,7 +190,6 @@ class Client extends HTTP\Client
      * made to the server to also return all child resources.
      *
      * @param string $url
-     * @param array  $properties
      * @param int    $depth
      *
      * @return array
@@ -261,7 +258,6 @@ class Client extends HTTP\Client
      * attempt is made to delete the property.
      *
      * @param string $url
-     * @param array  $properties
      *
      * @return bool
      */
@@ -359,7 +355,6 @@ class Client extends HTTP\Client
      * @param string               $method
      * @param string               $url
      * @param string|resource|null $body
-     * @param array                $headers
      *
      * @throws clientException, in case a curl error occurred
      *
@@ -414,7 +409,6 @@ class Client extends HTTP\Client
      *      .. etc ..
      *   ]
      * ]
-     *
      *
      * @param string $body xml body
      *

--- a/lib/DAV/CorePlugin.php
+++ b/lib/DAV/CorePlugin.php
@@ -27,8 +27,6 @@ class CorePlugin extends ServerPlugin
 
     /**
      * Sets up the plugin.
-     *
-     * @param Server $server
      */
     public function initialize(Server $server)
     {
@@ -69,9 +67,6 @@ class CorePlugin extends ServerPlugin
 
     /**
      * This is the default implementation for the GET method.
-     *
-     * @param RequestInterface  $request
-     * @param ResponseInterface $response
      *
      * @return bool
      */
@@ -210,9 +205,6 @@ class CorePlugin extends ServerPlugin
     /**
      * HTTP OPTIONS.
      *
-     * @param RequestInterface  $request
-     * @param ResponseInterface $response
-     *
      * @return bool
      */
     public function httpOptions(RequestInterface $request, ResponseInterface $response)
@@ -244,9 +236,6 @@ class CorePlugin extends ServerPlugin
      * HTTP response headers, without the body. This is used by clients to
      * determine if a remote file was changed, so they can use a local cached
      * version, instead of downloading it again
-     *
-     * @param RequestInterface  $request
-     * @param ResponseInterface $response
      *
      * @return bool
      */
@@ -281,9 +270,6 @@ class CorePlugin extends ServerPlugin
      * HTTP Delete.
      *
      * The HTTP delete method, deletes a given uri
-     *
-     * @param RequestInterface  $request
-     * @param ResponseInterface $response
      */
     public function httpDelete(RequestInterface $request, ResponseInterface $response)
     {
@@ -314,9 +300,6 @@ class CorePlugin extends ServerPlugin
      * The response body is also an xml document, containing information about every uri resource and the requested properties
      *
      * It has to return a HTTP 207 Multi-status status code
-     *
-     * @param RequestInterface  $request
-     * @param ResponseInterface $response
      */
     public function httpPropFind(RequestInterface $request, ResponseInterface $response)
     {
@@ -373,9 +356,6 @@ class CorePlugin extends ServerPlugin
      *
      * This method is called to update properties on a Node. The request is an XML body with all the mutations.
      * In this XML body it is specified which properties should be set/updated and/or deleted
-     *
-     * @param RequestInterface  $request
-     * @param ResponseInterface $response
      *
      * @return bool
      */
@@ -442,9 +422,6 @@ class CorePlugin extends ServerPlugin
      * This HTTP method updates a file, or creates a new one.
      *
      * If a new resource was created, a 201 Created status code should be returned. If an existing resource is updated, it's a 204 No Content
-     *
-     * @param RequestInterface  $request
-     * @param ResponseInterface $response
      *
      * @return bool
      */
@@ -546,9 +523,6 @@ class CorePlugin extends ServerPlugin
      *
      * The MKCOL method is used to create a new collection (directory) on the server
      *
-     * @param RequestInterface  $request
-     * @param ResponseInterface $response
-     *
      * @return bool
      */
     public function httpMkcol(RequestInterface $request, ResponseInterface $response)
@@ -607,9 +581,6 @@ class CorePlugin extends ServerPlugin
      *
      * This method moves one uri to a different uri. A lot of the actual request processing is done in getCopyMoveInfo
      *
-     * @param RequestInterface  $request
-     * @param ResponseInterface $response
-     *
      * @return bool
      */
     public function httpMove(RequestInterface $request, ResponseInterface $response)
@@ -663,9 +634,6 @@ class CorePlugin extends ServerPlugin
      * This method copies one uri to a different uri, and works much like the MOVE request
      * A lot of the actual request processing is done in getCopyMoveInfo
      *
-     * @param RequestInterface  $request
-     * @param ResponseInterface $response
-     *
      * @return bool
      */
     public function httpCopy(RequestInterface $request, ResponseInterface $response)
@@ -702,9 +670,6 @@ class CorePlugin extends ServerPlugin
      * Although the REPORT method is not part of the standard WebDAV spec (it's from rfc3253)
      * It's used in a lot of extensions, so it made sense to implement it into the core.
      *
-     * @param RequestInterface  $request
-     * @param ResponseInterface $response
-     *
      * @return bool
      */
     public function httpReport(RequestInterface $request, ResponseInterface $response)
@@ -733,8 +698,7 @@ class CorePlugin extends ServerPlugin
      * Here we check if a user attempted to update a protected property and
      * ensure that the process fails if this is the case.
      *
-     * @param string    $path
-     * @param PropPatch $propPatch
+     * @param string $path
      */
     public function propPatchProtectedPropertyCheck($path, PropPatch $propPatch)
     {
@@ -757,8 +721,7 @@ class CorePlugin extends ServerPlugin
      * Here we check if a node implements IProperties and let the node handle
      * updating of (some) properties.
      *
-     * @param string    $path
-     * @param PropPatch $propPatch
+     * @param string $path
      */
     public function propPatchNodeUpdate($path, PropPatch $propPatch)
     {
@@ -774,9 +737,6 @@ class CorePlugin extends ServerPlugin
      * This method is called when properties are retrieved.
      *
      * Here we add all the default properties.
-     *
-     * @param PropFind $propFind
-     * @param INode    $node
      */
     public function propFind(PropFind $propFind, INode $node)
     {
@@ -832,9 +792,6 @@ class CorePlugin extends ServerPlugin
      *
      * This event is called a bit later, so plugins have a chance first to
      * populate the result.
-     *
-     * @param PropFind $propFind
-     * @param INode    $node
      */
     public function propFindNode(PropFind $propFind, INode $node)
     {
@@ -851,9 +808,6 @@ class CorePlugin extends ServerPlugin
      *
      * This specific handler is called very late in the process, because we
      * want other systems to first have a chance to handle the properties.
-     *
-     * @param PropFind $propFind
-     * @param INode    $node
      */
     public function propFindLate(PropFind $propFind, INode $node)
     {

--- a/lib/DAV/Exception.php
+++ b/lib/DAV/Exception.php
@@ -31,9 +31,6 @@ class Exception extends \Exception
 
     /**
      * This method allows the exception to include additional information into the WebDAV error response.
-     *
-     * @param Server      $server
-     * @param \DOMElement $errorNode
      */
     public function serialize(Server $server, \DOMElement $errorNode)
     {
@@ -43,8 +40,6 @@ class Exception extends \Exception
      * This method allows the exception to return any extra HTTP response headers.
      *
      * The headers must be returned as an array.
-     *
-     * @param Server $server
      *
      * @return array
      */

--- a/lib/DAV/Exception/ConflictingLock.php
+++ b/lib/DAV/Exception/ConflictingLock.php
@@ -20,9 +20,6 @@ class ConflictingLock extends Locked
 {
     /**
      * This method allows the exception to include additional information into the WebDAV error response.
-     *
-     * @param DAV\Server  $server
-     * @param \DOMElement $errorNode
      */
     public function serialize(DAV\Server $server, \DOMElement $errorNode)
     {

--- a/lib/DAV/Exception/InvalidResourceType.php
+++ b/lib/DAV/Exception/InvalidResourceType.php
@@ -20,9 +20,6 @@ class InvalidResourceType extends Forbidden
 {
     /**
      * This method allows the exception to include additional information into the WebDAV error response.
-     *
-     * @param \Sabre\DAV\Server $server
-     * @param \DOMElement       $errorNode
      */
     public function serialize(\Sabre\DAV\Server $server, \DOMElement $errorNode)
     {

--- a/lib/DAV/Exception/InvalidSyncToken.php
+++ b/lib/DAV/Exception/InvalidSyncToken.php
@@ -25,9 +25,6 @@ class InvalidSyncToken extends Forbidden
 {
     /**
      * This method allows the exception to include additional information into the WebDAV error response.
-     *
-     * @param DAV\Server  $server
-     * @param \DOMElement $errorNode
      */
     public function serialize(DAV\Server $server, \DOMElement $errorNode)
     {

--- a/lib/DAV/Exception/LockTokenMatchesRequestUri.php
+++ b/lib/DAV/Exception/LockTokenMatchesRequestUri.php
@@ -27,9 +27,6 @@ class LockTokenMatchesRequestUri extends Conflict
 
     /**
      * This method allows the exception to include additional information into the WebDAV error response.
-     *
-     * @param DAV\Server  $server
-     * @param \DOMElement $errorNode
      */
     public function serialize(DAV\Server $server, \DOMElement $errorNode)
     {

--- a/lib/DAV/Exception/Locked.php
+++ b/lib/DAV/Exception/Locked.php
@@ -51,9 +51,6 @@ class Locked extends DAV\Exception
 
     /**
      * This method allows the exception to include additional information into the WebDAV error response.
-     *
-     * @param DAV\Server  $server
-     * @param \DOMElement $errorNode
      */
     public function serialize(DAV\Server $server, \DOMElement $errorNode)
     {

--- a/lib/DAV/Exception/MethodNotAllowed.php
+++ b/lib/DAV/Exception/MethodNotAllowed.php
@@ -32,8 +32,6 @@ class MethodNotAllowed extends DAV\Exception
      *
      * The headers must be returned as an array.
      *
-     * @param \Sabre\DAV\Server $server
-     *
      * @return array
      */
     public function getHTTPHeaders(\Sabre\DAV\Server $server)

--- a/lib/DAV/Exception/PreconditionFailed.php
+++ b/lib/DAV/Exception/PreconditionFailed.php
@@ -53,9 +53,6 @@ class PreconditionFailed extends DAV\Exception
 
     /**
      * This method allows the exception to include additional information into the WebDAV error response.
-     *
-     * @param DAV\Server  $server
-     * @param \DOMElement $errorNode
      */
     public function serialize(DAV\Server $server, \DOMElement $errorNode)
     {

--- a/lib/DAV/Exception/ReportNotSupported.php
+++ b/lib/DAV/Exception/ReportNotSupported.php
@@ -19,9 +19,6 @@ class ReportNotSupported extends UnsupportedMediaType
 {
     /**
      * This method allows the exception to include additional information into the WebDAV error response.
-     *
-     * @param DAV\Server  $server
-     * @param \DOMElement $errorNode
      */
     public function serialize(DAV\Server $server, \DOMElement $errorNode)
     {

--- a/lib/DAV/Exception/TooManyMatches.php
+++ b/lib/DAV/Exception/TooManyMatches.php
@@ -25,9 +25,6 @@ class TooManyMatches extends Forbidden
 {
     /**
      * This method allows the exception to include additional information into the WebDAV error response.
-     *
-     * @param DAV\Server  $server
-     * @param \DOMElement $errorNode
      */
     public function serialize(DAV\Server $server, \DOMElement $errorNode)
     {

--- a/lib/DAV/IExtendedCollection.php
+++ b/lib/DAV/IExtendedCollection.php
@@ -36,7 +36,6 @@ interface IExtendedCollection extends ICollection
      * property for you.
      *
      * @param string $name
-     * @param MkCol  $mkCol
      *
      * @throws Exception\InvalidResourceType
      */

--- a/lib/DAV/IProperties.php
+++ b/lib/DAV/IProperties.php
@@ -23,8 +23,6 @@ interface IProperties extends INode
      *
      * To update specific properties, call the 'handle' method on this object.
      * Read the PropPatch documentation for more information.
-     *
-     * @param PropPatch $propPatch
      */
     public function propPatch(PropPatch $propPatch);
 

--- a/lib/DAV/Locks/Backend/BackendInterface.php
+++ b/lib/DAV/Locks/Backend/BackendInterface.php
@@ -35,8 +35,7 @@ interface BackendInterface
     /**
      * Locks a uri.
      *
-     * @param string         $uri
-     * @param Locks\LockInfo $lockInfo
+     * @param string $uri
      *
      * @return bool
      */
@@ -45,8 +44,7 @@ interface BackendInterface
     /**
      * Removes a lock from a uri.
      *
-     * @param string         $uri
-     * @param Locks\LockInfo $lockInfo
+     * @param string $uri
      *
      * @return bool
      */

--- a/lib/DAV/Locks/Backend/File.php
+++ b/lib/DAV/Locks/Backend/File.php
@@ -82,8 +82,7 @@ class File extends AbstractBackend
     /**
      * Locks a uri.
      *
-     * @param string   $uri
-     * @param LockInfo $lockInfo
+     * @param string $uri
      *
      * @return bool
      */
@@ -113,8 +112,7 @@ class File extends AbstractBackend
     /**
      * Removes a lock from a uri.
      *
-     * @param string   $uri
-     * @param LockInfo $lockInfo
+     * @param string $uri
      *
      * @return bool
      */
@@ -166,8 +164,6 @@ class File extends AbstractBackend
 
     /**
      * Saves the lockdata.
-     *
-     * @param array $newData
      */
     protected function putData(array $newData)
     {

--- a/lib/DAV/Locks/Backend/PDO.php
+++ b/lib/DAV/Locks/Backend/PDO.php
@@ -34,8 +34,6 @@ class PDO extends AbstractBackend
 
     /**
      * Constructor.
-     *
-     * @param \PDO $pdo
      */
     public function __construct(\PDO $pdo)
     {
@@ -111,8 +109,7 @@ class PDO extends AbstractBackend
     /**
      * Locks a uri.
      *
-     * @param string   $uri
-     * @param LockInfo $lockInfo
+     * @param string $uri
      *
      * @return bool
      */
@@ -161,8 +158,7 @@ class PDO extends AbstractBackend
     /**
      * Removes a lock from a uri.
      *
-     * @param string   $uri
-     * @param LockInfo $lockInfo
+     * @param string $uri
      *
      * @return bool
      */

--- a/lib/DAV/Locks/Plugin.php
+++ b/lib/DAV/Locks/Plugin.php
@@ -40,8 +40,6 @@ class Plugin extends DAV\ServerPlugin
 
     /**
      * __construct.
-     *
-     * @param Backend\BackendInterface $locksBackend
      */
     public function __construct(Backend\BackendInterface $locksBackend)
     {
@@ -52,8 +50,6 @@ class Plugin extends DAV\ServerPlugin
      * Initializes the plugin.
      *
      * This method is automatically called by the Server class after addPlugin.
-     *
-     * @param DAV\Server $server
      */
     public function initialize(DAV\Server $server)
     {
@@ -84,9 +80,6 @@ class Plugin extends DAV\ServerPlugin
     /**
      * This method is called after most properties have been found
      * it allows us to add in any Lock-related properties.
-     *
-     * @param DAV\PropFind $propFind
-     * @param DAV\INode    $node
      */
     public function propFind(DAV\PropFind $propFind, DAV\INode $node)
     {
@@ -158,9 +151,6 @@ class Plugin extends DAV\ServerPlugin
      * If a lock is to be refreshed, no body should be supplied and there should be a valid If header containing the lock
      *
      * Additionally, a lock can be requested for a non-existent file. In these case we're obligated to create an empty file as per RFC4918:S7.3
-     *
-     * @param RequestInterface  $request
-     * @param ResponseInterface $response
      *
      * @return bool
      */
@@ -260,9 +250,6 @@ class Plugin extends DAV\ServerPlugin
      *
      * This WebDAV method allows you to remove a lock from a node. The client should provide a valid locktoken through the Lock-token http header
      * The server should return 204 (No content) on success
-     *
-     * @param RequestInterface  $request
-     * @param ResponseInterface $response
      */
     public function httpUnlock(RequestInterface $request, ResponseInterface $response)
     {
@@ -318,8 +305,7 @@ class Plugin extends DAV\ServerPlugin
      * All the locking information is supplied in the lockInfo object. The object has a suggested timeout, but this can be safely ignored
      * It is important that if the existing timeout is ignored, the property is overwritten, as this needs to be sent back to the client
      *
-     * @param string   $uri
-     * @param LockInfo $lockInfo
+     * @param string $uri
      *
      * @return bool
      */
@@ -337,8 +323,7 @@ class Plugin extends DAV\ServerPlugin
      *
      * This method removes a lock from a uri. It is assumed all the supplied information is correct and verified
      *
-     * @param string   $uri
-     * @param LockInfo $lockInfo
+     * @param string $uri
      *
      * @return bool
      */
@@ -380,8 +365,6 @@ class Plugin extends DAV\ServerPlugin
     /**
      * Generates the response for successful LOCK requests.
      *
-     * @param LockInfo $lockInfo
-     *
      * @return string
      */
     protected function generateLockResponse(LockInfo $lockInfo)
@@ -401,8 +384,7 @@ class Plugin extends DAV\ServerPlugin
      * must be present in the request, and reject requests without the proper
      * tokens.
      *
-     * @param RequestInterface $request
-     * @param mixed            $conditions
+     * @param mixed $conditions
      */
     public function validateTokens(RequestInterface $request, &$conditions)
     {

--- a/lib/DAV/Mount/Plugin.php
+++ b/lib/DAV/Mount/Plugin.php
@@ -28,8 +28,6 @@ class Plugin extends DAV\ServerPlugin
 
     /**
      * Initializes the plugin and registers event handles.
-     *
-     * @param DAV\Server $server
      */
     public function initialize(DAV\Server $server)
     {
@@ -40,9 +38,6 @@ class Plugin extends DAV\ServerPlugin
     /**
      * 'beforeMethod' event handles. This event handles intercepts GET requests ending
      * with ?mount.
-     *
-     * @param RequestInterface  $request
-     * @param ResponseInterface $response
      *
      * @return bool
      */
@@ -67,8 +62,7 @@ class Plugin extends DAV\ServerPlugin
     /**
      * Generates the davmount response.
      *
-     * @param ResponseInterface $response
-     * @param string            $uri      absolute uri
+     * @param string $uri absolute uri
      */
     public function davMount(ResponseInterface $response, $uri)
     {

--- a/lib/DAV/PartialUpdate/Plugin.php
+++ b/lib/DAV/PartialUpdate/Plugin.php
@@ -39,8 +39,6 @@ class Plugin extends DAV\ServerPlugin
      * Initializes the plugin.
      *
      * This method is automatically called by the Server class after addPlugin.
-     *
-     * @param DAV\Server $server
      */
     public function initialize(DAV\Server $server)
     {
@@ -106,9 +104,6 @@ class Plugin extends DAV\ServerPlugin
      * The WebDAV patch request can be used to modify only a part of an
      * existing resource. If the resource does not exist yet and the first
      * offset is not 0, the request fails
-     *
-     * @param RequestInterface  $request
-     * @param ResponseInterface $response
      */
     public function httpPatch(RequestInterface $request, ResponseInterface $response)
     {
@@ -190,8 +185,6 @@ class Plugin extends DAV\ServerPlugin
      * [2,10,15] - update bytes 10, 11, 12, 13, 14, 15
      * [2,10,null] - update bytes 10 until the end of the patch body
      * [3,-5] - update from 5 bytes from the end of the file.
-     *
-     * @param RequestInterface $request
      *
      * @return array|null
      */

--- a/lib/DAV/PropFind.php
+++ b/lib/DAV/PropFind.php
@@ -38,7 +38,6 @@ class PropFind
      * Creates the PROPFIND object.
      *
      * @param string $path
-     * @param array  $properties
      * @param int    $depth
      * @param int    $requestType
      */

--- a/lib/DAV/PropPatch.php
+++ b/lib/DAV/PropPatch.php
@@ -82,7 +82,6 @@ class PropPatch
      * code associated with the operation.
      *
      * @param string|string[] $properties
-     * @param callable        $callback
      */
     public function handle($properties, callable $callback)
     {
@@ -112,8 +111,6 @@ class PropPatch
      * Call this function if you wish to handle _all_ properties that haven't
      * been handled by anything else yet. Note that you effectively claim with
      * this that you promise to process _all_ properties that are coming in.
-     *
-     * @param callable $callback
      */
     public function handleRemaining(callable $callback)
     {
@@ -250,8 +247,7 @@ class PropPatch
     /**
      * Executes a property callback with the single-property syntax.
      *
-     * @param string   $propertyName
-     * @param callable $callback
+     * @param string $propertyName
      */
     private function doCallBackSingleProp($propertyName, callable $callback)
     {
@@ -281,9 +277,6 @@ class PropPatch
 
     /**
      * Executes a property callback with the multi-property syntax.
-     *
-     * @param array    $propertyList
-     * @param callable $callback
      */
     private function doCallBackMultiProp(array $propertyList, callable $callback)
     {

--- a/lib/DAV/PropertyStorage/Backend/BackendInterface.php
+++ b/lib/DAV/PropertyStorage/Backend/BackendInterface.php
@@ -32,8 +32,7 @@ interface BackendInterface
      * However, you can also support the 'allprops' property here. In that
      * case, you should check for $propFind->isAllProps().
      *
-     * @param string   $path
-     * @param PropFind $propFind
+     * @param string $path
      */
     public function propFind($path, PropFind $propFind);
 
@@ -46,8 +45,7 @@ interface BackendInterface
      * Usually you would want to call 'handleRemaining' on this object, to get;
      * a list of all properties that need to be stored.
      *
-     * @param string    $path
-     * @param PropPatch $propPatch
+     * @param string $path
      */
     public function propPatch($path, PropPatch $propPatch);
 

--- a/lib/DAV/PropertyStorage/Backend/PDO.php
+++ b/lib/DAV/PropertyStorage/Backend/PDO.php
@@ -53,8 +53,6 @@ class PDO implements BackendInterface
 
     /**
      * Creates the PDO property storage engine.
-     *
-     * @param \PDO $pdo
      */
     public function __construct(\PDO $pdo)
     {
@@ -74,8 +72,7 @@ class PDO implements BackendInterface
      * However, you can also support the 'allprops' property here. In that
      * case, you should check for $propFind->isAllProps().
      *
-     * @param string   $path
-     * @param PropFind $propFind
+     * @param string $path
      */
     public function propFind($path, PropFind $propFind)
     {
@@ -115,8 +112,7 @@ class PDO implements BackendInterface
      * Usually you would want to call 'handleRemaining' on this object, to get;
      * a list of all properties that need to be stored.
      *
-     * @param string    $path
-     * @param PropPatch $propPatch
+     * @param string $path
      */
     public function propPatch($path, PropPatch $propPatch)
     {

--- a/lib/DAV/PropertyStorage/Plugin.php
+++ b/lib/DAV/PropertyStorage/Plugin.php
@@ -46,8 +46,6 @@ class Plugin extends ServerPlugin
 
     /**
      * Creates the plugin.
-     *
-     * @param Backend\BackendInterface $backend
      */
     public function __construct(Backend\BackendInterface $backend)
     {
@@ -61,8 +59,6 @@ class Plugin extends ServerPlugin
      * addPlugin is called.
      *
      * This method should set up the required event subscriptions.
-     *
-     * @param Server $server
      */
     public function initialize(Server $server)
     {
@@ -77,9 +73,6 @@ class Plugin extends ServerPlugin
      *
      * If there's any requested properties that don't have a value yet, this
      * plugin will look in the property storage backend to find them.
-     *
-     * @param PropFind $propFind
-     * @param INode    $node
      */
     public function propFind(PropFind $propFind, INode $node)
     {
@@ -97,8 +90,7 @@ class Plugin extends ServerPlugin
      * If there's any updated properties that haven't been stored, the
      * propertystorage backend can handle it.
      *
-     * @param string    $path
-     * @param PropPatch $propPatch
+     * @param string $path
      */
     public function propPatch($path, PropPatch $propPatch)
     {

--- a/lib/DAV/Server.php
+++ b/lib/DAV/Server.php
@@ -393,8 +393,6 @@ class Server implements LoggerAwareInterface, EmitterInterface
      * Adds a plugin to the server.
      *
      * For more information, console the documentation of Sabre\DAV\ServerPlugin
-     *
-     * @param ServerPlugin $plugin
      */
     public function addPlugin(ServerPlugin $plugin)
     {
@@ -447,9 +445,7 @@ class Server implements LoggerAwareInterface, EmitterInterface
     /**
      * Handles a http request, and execute a method based on its name.
      *
-     * @param RequestInterface  $request
-     * @param ResponseInterface $response
-     * @param bool              $sendResponse whether to send the HTTP response to the DAV client
+     * @param bool $sendResponse whether to send the HTTP response to the DAV client
      */
     public function invokeMethod(RequestInterface $request, ResponseInterface $response, $sendResponse = true)
     {
@@ -708,8 +704,6 @@ class Server implements LoggerAwareInterface, EmitterInterface
      *   * destination - Destination path
      *   * destinationExists - Whether or not the destination is an existing url (and should therefore be overwritten)
      *
-     * @param RequestInterface $request
-     *
      * @throws Exception\BadRequest           upon missing or broken request headers
      * @throws Exception\UnsupportedMediaType when trying to copy into a
      *                                        non-collection
@@ -882,8 +876,7 @@ class Server implements LoggerAwareInterface, EmitterInterface
     /**
      * Small helper to support PROPFIND with DEPTH_INFINITY.
      *
-     * @param PropFind $propFind
-     * @param array    $yieldFirst
+     * @param array $yieldFirst
      *
      * @return \Traversable
      */
@@ -1014,9 +1007,6 @@ class Server implements LoggerAwareInterface, EmitterInterface
      * The result is returned as an array, with paths for it's keys.
      * The result may be returned out of order.
      *
-     * @param array $paths
-     * @param array $propertyNames
-     *
      * @return array
      */
     public function getPropertiesForMultiplePaths(array $paths, array $propertyNames = [])
@@ -1052,9 +1042,6 @@ class Server implements LoggerAwareInterface, EmitterInterface
      * It could be useful to call this, if you already have an instance of your
      * target node and simply want to run through the system to get a correct
      * list of properties.
-     *
-     * @param PropFind $propFind
-     * @param INode    $node
      *
      * @return bool
      */
@@ -1162,8 +1149,7 @@ class Server implements LoggerAwareInterface, EmitterInterface
     /**
      * Use this method to create a new collection.
      *
-     * @param string $uri   The new uri
-     * @param MkCol  $mkCol
+     * @param string $uri The new uri
      *
      * @return array|null
      */
@@ -1260,7 +1246,6 @@ class Server implements LoggerAwareInterface, EmitterInterface
      * as their values.
      *
      * @param string $path
-     * @param array  $properties
      *
      * @return array
      */
@@ -1290,9 +1275,6 @@ class Server implements LoggerAwareInterface, EmitterInterface
      * Normally this method will throw 412 Precondition Failed for failures
      * related to If-None-Match, If-Match and If-Unmodified Since. It will
      * set the status to 304 Not Modified for If-Modified_since.
-     *
-     * @param RequestInterface  $request
-     * @param ResponseInterface $response
      *
      * @return bool
      */
@@ -1564,8 +1546,6 @@ class Server implements LoggerAwareInterface, EmitterInterface
      *    ],
      * ]
      *
-     * @param RequestInterface $request
-     *
      * @return array
      */
     public function getIfConditions(RequestInterface $request)
@@ -1618,8 +1598,6 @@ class Server implements LoggerAwareInterface, EmitterInterface
     /**
      * Returns an array with resourcetypes for a node.
      *
-     * @param INode $node
-     *
      * @return array
      */
     public function getResourceTypeForNode(INode $node)
@@ -1664,9 +1642,7 @@ class Server implements LoggerAwareInterface, EmitterInterface
     }
 
     /**
-     * @param Writer $w
      * @param $fileProperties
-     * @param bool $strip404s
      */
     private function writeMultiStatus(Writer $w, $fileProperties, bool $strip404s)
     {

--- a/lib/DAV/ServerPlugin.php
+++ b/lib/DAV/ServerPlugin.php
@@ -22,8 +22,6 @@ abstract class ServerPlugin
      * addPlugin is called.
      *
      * This method should set up the required event subscriptions.
-     *
-     * @param Server $server
      */
     abstract public function initialize(Server $server);
 

--- a/lib/DAV/Sharing/Plugin.php
+++ b/lib/DAV/Sharing/Plugin.php
@@ -79,8 +79,6 @@ class Plugin extends ServerPlugin
      * addPlugin is called.
      *
      * This method should set up the required event subscriptions.
-     *
-     * @param Server $server
      */
     public function initialize(Server $server)
     {
@@ -139,9 +137,6 @@ class Plugin extends ServerPlugin
      * This event is triggered when properties are requested for nodes.
      *
      * This allows us to inject any sharings-specific properties.
-     *
-     * @param PropFind $propFind
-     * @param INode    $node
      */
     public function propFind(PropFind $propFind, INode $node)
     {
@@ -160,9 +155,6 @@ class Plugin extends ServerPlugin
 
     /**
      * We intercept this to handle POST requests on shared resources.
-     *
-     * @param RequestInterface  $request
-     * @param ResponseInterface $response
      *
      * @return bool|null
      */
@@ -207,9 +199,6 @@ class Plugin extends ServerPlugin
      * hat are supported on a particular node.
      *
      * We need to add a number of privileges for scheduling purposes.
-     *
-     * @param INode $node
-     * @param array $supportedPrivilegeSet
      */
     public function getSupportedPrivilegeSet(INode $node, array &$supportedPrivilegeSet)
     {
@@ -245,7 +234,6 @@ class Plugin extends ServerPlugin
      * This method is used to generate HTML output for the
      * DAV\Browser\Plugin.
      *
-     * @param INode  $node
      * @param string $output
      * @param string $path
      *

--- a/lib/DAV/SimpleCollection.php
+++ b/lib/DAV/SimpleCollection.php
@@ -58,8 +58,6 @@ class SimpleCollection extends Collection
 
     /**
      * Adds a new childnode to this collection.
-     *
-     * @param INode $child
      */
     public function addChild(INode $child)
     {

--- a/lib/DAV/Sync/Plugin.php
+++ b/lib/DAV/Sync/Plugin.php
@@ -48,8 +48,6 @@ class Plugin extends DAV\ServerPlugin
      * Initializes the plugin.
      *
      * This is when the plugin registers it's hooks.
-     *
-     * @param DAV\Server $server
      */
     public function initialize(DAV\Server $server)
     {
@@ -97,8 +95,7 @@ class Plugin extends DAV\ServerPlugin
     /**
      * This method handles the {DAV:}sync-collection HTTP REPORT.
      *
-     * @param string               $uri
-     * @param SyncCollectionReport $report
+     * @param string $uri
      */
     public function syncCollection($uri, SyncCollectionReport $report)
     {
@@ -143,10 +140,6 @@ class Plugin extends DAV\ServerPlugin
      *
      * @param string $syncToken
      * @param string $collectionUrl
-     * @param array  $added
-     * @param array  $modified
-     * @param array  $deleted
-     * @param array  $properties
      */
     protected function sendSyncCollectionResponse($syncToken, $collectionUrl, array $added, array $modified, array $deleted, array $properties)
     {
@@ -183,9 +176,6 @@ class Plugin extends DAV\ServerPlugin
     /**
      * This method is triggered whenever properties are requested for a node.
      * We intercept this to see if we must return a {DAV:}sync-token.
-     *
-     * @param DAV\PropFind $propFind
-     * @param DAV\INode    $node
      */
     public function propFind(DAV\PropFind $propFind, DAV\INode $node)
     {
@@ -204,8 +194,7 @@ class Plugin extends DAV\ServerPlugin
      * It's a moment where this plugin can check all the supplied lock tokens
      * in the If: header, and check if they are valid.
      *
-     * @param RequestInterface $request
-     * @param array            $conditions
+     * @param array $conditions
      */
     public function validateTokens(RequestInterface $request, &$conditions)
     {

--- a/lib/DAV/TemporaryFileFilterPlugin.php
+++ b/lib/DAV/TemporaryFileFilterPlugin.php
@@ -90,8 +90,6 @@ class TemporaryFileFilterPlugin extends ServerPlugin
      *
      * This is called automatically be the Server class after this plugin is
      * added with Sabre\DAV\Server::addPlugin()
-     *
-     * @param Server $server
      */
     public function initialize(Server $server)
     {
@@ -105,9 +103,6 @@ class TemporaryFileFilterPlugin extends ServerPlugin
      *
      * This method intercepts any GET, DELETE, PUT and PROPFIND calls to
      * filenames that are known to match the 'temporary file' regex.
-     *
-     * @param RequestInterface  $request
-     * @param ResponseInterface $response
      *
      * @return bool
      */
@@ -137,11 +132,10 @@ class TemporaryFileFilterPlugin extends ServerPlugin
      * This is used to deal with HTTP LOCK requests which create a new
      * file.
      *
-     * @param string      $uri
-     * @param resource    $data
-     * @param ICollection $parent
-     * @param bool        $modified should be set to true, if this event handler
-     *                              changed &$data
+     * @param string   $uri
+     * @param resource $data
+     * @param bool     $modified should be set to true, if this event handler
+     *                           changed &$data
      *
      * @return bool
      */
@@ -190,9 +184,7 @@ class TemporaryFileFilterPlugin extends ServerPlugin
      * If the file doesn't exist, it will return false which will kick in
      * the regular system for the GET method.
      *
-     * @param RequestInterface  $request
-     * @param ResponseInterface $hR
-     * @param string            $tempLocation
+     * @param string $tempLocation
      *
      * @return bool
      */
@@ -214,9 +206,7 @@ class TemporaryFileFilterPlugin extends ServerPlugin
     /**
      * This method handles the PUT method.
      *
-     * @param RequestInterface  $request
-     * @param ResponseInterface $hR
-     * @param string            $tempLocation
+     * @param string $tempLocation
      *
      * @return bool
      */
@@ -242,9 +232,7 @@ class TemporaryFileFilterPlugin extends ServerPlugin
      * If the file didn't exist, it will return false, which will make the
      * standard HTTP DELETE handler kick in.
      *
-     * @param RequestInterface  $request
-     * @param ResponseInterface $hR
-     * @param string            $tempLocation
+     * @param string $tempLocation
      *
      * @return bool
      */
@@ -268,9 +256,7 @@ class TemporaryFileFilterPlugin extends ServerPlugin
      * for which properties were requested, and just sends back a default
      * set of properties.
      *
-     * @param RequestInterface  $request
-     * @param ResponseInterface $hR
-     * @param string            $tempLocation
+     * @param string $tempLocation
      *
      * @return bool
      */

--- a/lib/DAV/Tree.php
+++ b/lib/DAV/Tree.php
@@ -37,8 +37,6 @@ class Tree
      * Creates the object.
      *
      * This method expects the rootObject to be passed as a parameter
-     *
-     * @param ICollection $rootNode
      */
     public function __construct(ICollection $rootNode)
     {
@@ -288,9 +286,7 @@ class Tree
     /**
      * copyNode.
      *
-     * @param INode       $source
-     * @param ICollection $destinationParent
-     * @param string      $destinationName
+     * @param string $destinationName
      */
     protected function copyNode(INode $source, ICollection $destinationParent, $destinationName = null)
     {

--- a/lib/DAV/Xml/Element/Prop.php
+++ b/lib/DAV/Xml/Element/Prop.php
@@ -39,8 +39,6 @@ class Prop implements XmlDeserializable
      * $reader->parseInnerTree() will parse the entire sub-tree, and advance to
      * the next element.
      *
-     * @param Reader $reader
-     *
      * @return mixed
      */
     public static function xmlDeserialize(Reader $reader)
@@ -78,8 +76,6 @@ class Prop implements XmlDeserializable
      * This method returns arn array with 2 properties:
      *   * name - A clark-notation XML element name.
      *   * value - The parsed value.
-     *
-     * @param Reader $reader
      *
      * @return array
      */

--- a/lib/DAV/Xml/Element/Response.php
+++ b/lib/DAV/Xml/Element/Response.php
@@ -59,7 +59,6 @@ class Response implements Element
      * deleted.
      *
      * @param string $href
-     * @param array  $responseProperties
      * @param string $httpStatus
      */
     public function __construct($href, array $responseProperties, $httpStatus = null)
@@ -110,8 +109,6 @@ class Response implements Element
      *
      * Important note 2: If you are writing any new elements, you are also
      * responsible for closing them.
-     *
-     * @param Writer $writer
      */
     public function xmlSerialize(Writer $writer)
     {
@@ -166,8 +163,6 @@ class Response implements Element
      *
      * $reader->parseInnerTree() will parse the entire sub-tree, and advance to
      * the next element.
-     *
-     * @param Reader $reader
      *
      * @return mixed
      */

--- a/lib/DAV/Xml/Element/Sharee.php
+++ b/lib/DAV/Xml/Element/Sharee.php
@@ -84,8 +84,6 @@ class Sharee implements Element
      * Creates the object.
      *
      * $properties will be used to populate all internal properties.
-     *
-     * @param array $properties
      */
     public function __construct(array $properties = [])
     {
@@ -113,8 +111,6 @@ class Sharee implements Element
      * This allows serializers to be re-used for different element names.
      *
      * If you are opening new elements, you must also close them again.
-     *
-     * @param Writer $writer
      */
     public function xmlSerialize(Writer $writer)
     {
@@ -156,8 +152,6 @@ class Sharee implements Element
      *
      * $reader->parseInnerTree() will parse the entire sub-tree, and advance to
      * the next element.
-     *
-     * @param Reader $reader
      *
      * @return mixed
      */

--- a/lib/DAV/Xml/Property/Complex.php
+++ b/lib/DAV/Xml/Property/Complex.php
@@ -37,8 +37,6 @@ class Complex extends XmlFragment
      * $reader->parseInnerTree() will parse the entire sub-tree, and advance to
      * the next element.
      *
-     * @param Reader $reader
-     *
      * @return mixed
      */
     public static function xmlDeserialize(Reader $reader)

--- a/lib/DAV/Xml/Property/GetLastModified.php
+++ b/lib/DAV/Xml/Property/GetLastModified.php
@@ -68,8 +68,6 @@ class GetLastModified implements Element
      *
      * Important note 2: If you are writing any new elements, you are also
      * responsible for closing them.
-     *
-     * @param Writer $writer
      */
     public function xmlSerialize(Writer $writer)
     {
@@ -95,8 +93,6 @@ class GetLastModified implements Element
      *
      * $reader->parseInnerTree() will parse the entire sub-tree, and advance to
      * the next element.
-     *
-     * @param Reader $reader
      *
      * @return mixed
      */

--- a/lib/DAV/Xml/Property/Href.php
+++ b/lib/DAV/Xml/Property/Href.php
@@ -87,8 +87,6 @@ class Href implements Element, HtmlOutput
      * This allows serializers to be re-used for different element names.
      *
      * If you are opening new elements, you must also close them again.
-     *
-     * @param Writer $writer
      */
     public function xmlSerialize(Writer $writer)
     {
@@ -108,8 +106,6 @@ class Href implements Element, HtmlOutput
      *
      * The baseUri parameter is a url to the root of the application, and can
      * be used to construct local links.
-     *
-     * @param HtmlOutputHelper $html
      *
      * @return string
      */
@@ -140,8 +136,6 @@ class Href implements Element, HtmlOutput
      *
      * $reader->parseInnerTree() will parse the entire sub-tree, and advance to
      * the next element.
-     *
-     * @param Reader $reader
      *
      * @return mixed
      */

--- a/lib/DAV/Xml/Property/Invite.php
+++ b/lib/DAV/Xml/Property/Invite.php
@@ -56,8 +56,6 @@ class Invite implements XmlSerializable
      * This allows serializers to be re-used for different element names.
      *
      * If you are opening new elements, you must also close them again.
-     *
-     * @param Writer $writer
      */
     public function xmlSerialize(Writer $writer)
     {

--- a/lib/DAV/Xml/Property/LockDiscovery.php
+++ b/lib/DAV/Xml/Property/LockDiscovery.php
@@ -62,8 +62,6 @@ class LockDiscovery implements XmlSerializable
      *
      * Important note 2: If you are writing any new elements, you are also
      * responsible for closing them.
-     *
-     * @param Writer $writer
      */
     public function xmlSerialize(Writer $writer)
     {

--- a/lib/DAV/Xml/Property/ResourceType.php
+++ b/lib/DAV/Xml/Property/ResourceType.php
@@ -90,8 +90,6 @@ class ResourceType extends Element\Elements implements HtmlOutput
      * $reader->parseInnerTree() will parse the entire sub-tree, and advance to
      * the next element.
      *
-     * @param Reader $reader
-     *
      * @return mixed
      */
     public static function xmlDeserialize(Reader $reader)
@@ -110,8 +108,6 @@ class ResourceType extends Element\Elements implements HtmlOutput
      *
      * The baseUri parameter is a url to the root of the application, and can
      * be used to construct local links.
-     *
-     * @param HtmlOutputHelper $html
      *
      * @return string
      */

--- a/lib/DAV/Xml/Property/ShareAccess.php
+++ b/lib/DAV/Xml/Property/ShareAccess.php
@@ -71,8 +71,6 @@ class ShareAccess implements Element
      * This allows serializers to be re-used for different element names.
      *
      * If you are opening new elements, you must also close them again.
-     *
-     * @param Writer $writer
      */
     public function xmlSerialize(Writer $writer)
     {
@@ -112,8 +110,6 @@ class ShareAccess implements Element
      *
      * $reader->parseInnerTree() will parse the entire sub-tree, and advance to
      * the next element.
-     *
-     * @param Reader $reader
      *
      * @return mixed
      */

--- a/lib/DAV/Xml/Property/SupportedLock.php
+++ b/lib/DAV/Xml/Property/SupportedLock.php
@@ -37,8 +37,6 @@ class SupportedLock implements XmlSerializable
      * This allows serializers to be re-used for different element names.
      *
      * If you are opening new elements, you must also close them again.
-     *
-     * @param Writer $writer
      */
     public function xmlSerialize(Writer $writer)
     {

--- a/lib/DAV/Xml/Property/SupportedMethodSet.php
+++ b/lib/DAV/Xml/Property/SupportedMethodSet.php
@@ -81,8 +81,6 @@ class SupportedMethodSet implements XmlSerializable, HtmlOutput
      * This allows serializers to be re-used for different element names.
      *
      * If you are opening new elements, you must also close them again.
-     *
-     * @param Writer $writer
      */
     public function xmlSerialize(Writer $writer)
     {
@@ -103,8 +101,6 @@ class SupportedMethodSet implements XmlSerializable, HtmlOutput
      *
      * The baseUri parameter is a url to the root of the application, and can
      * be used to construct local links.
-     *
-     * @param HtmlOutputHelper $html
      *
      * @return string
      */

--- a/lib/DAV/Xml/Property/SupportedReportSet.php
+++ b/lib/DAV/Xml/Property/SupportedReportSet.php
@@ -109,8 +109,6 @@ class SupportedReportSet implements XmlSerializable, HtmlOutput
      * This allows serializers to be re-used for different element names.
      *
      * If you are opening new elements, you must also close them again.
-     *
-     * @param Writer $writer
      */
     public function xmlSerialize(Writer $writer)
     {
@@ -133,8 +131,6 @@ class SupportedReportSet implements XmlSerializable, HtmlOutput
      *
      * The baseUri parameter is a url to the root of the application, and can
      * be used to construct local links.
-     *
-     * @param HtmlOutputHelper $html
      *
      * @return string
      */

--- a/lib/DAV/Xml/Request/Lock.php
+++ b/lib/DAV/Xml/Request/Lock.php
@@ -56,8 +56,6 @@ class Lock implements XmlDeserializable
      * $reader->parseInnerTree() will parse the entire sub-tree, and advance to
      * the next element.
      *
-     * @param Reader $reader
-     *
      * @return mixed
      */
     public static function xmlDeserialize(Reader $reader)

--- a/lib/DAV/Xml/Request/MkCol.php
+++ b/lib/DAV/Xml/Request/MkCol.php
@@ -56,8 +56,6 @@ class MkCol implements XmlDeserializable
      * $reader->parseInnerTree() will parse the entire sub-tree, and advance to
      * the next element.
      *
-     * @param Reader $reader
-     *
      * @return mixed
      */
     public static function xmlDeserialize(Reader $reader)

--- a/lib/DAV/Xml/Request/PropFind.php
+++ b/lib/DAV/Xml/Request/PropFind.php
@@ -53,8 +53,6 @@ class PropFind implements XmlDeserializable
      * $reader->parseInnerTree() will parse the entire sub-tree, and advance to
      * the next element.
      *
-     * @param Reader $reader
-     *
      * @return mixed
      */
     public static function xmlDeserialize(Reader $reader)

--- a/lib/DAV/Xml/Request/PropPatch.php
+++ b/lib/DAV/Xml/Request/PropPatch.php
@@ -45,8 +45,6 @@ class PropPatch implements Element
      * This allows serializers to be re-used for different element names.
      *
      * If you are opening new elements, you must also close them again.
-     *
-     * @param Writer $writer
      */
     public function xmlSerialize(Writer $writer)
     {
@@ -80,8 +78,6 @@ class PropPatch implements Element
      *
      * $reader->parseInnerTree() will parse the entire sub-tree, and advance to
      * the next element.
-     *
-     * @param Reader $reader
      *
      * @return mixed
      */

--- a/lib/DAV/Xml/Request/ShareResource.php
+++ b/lib/DAV/Xml/Request/ShareResource.php
@@ -56,8 +56,6 @@ class ShareResource implements XmlDeserializable
      * $reader->parseInnerTree() will parse the entire sub-tree, and advance to
      * the next element.
      *
-     * @param Reader $reader
-     *
      * @return mixed
      */
     public static function xmlDeserialize(Reader $reader)

--- a/lib/DAV/Xml/Request/SyncCollectionReport.php
+++ b/lib/DAV/Xml/Request/SyncCollectionReport.php
@@ -68,8 +68,6 @@ class SyncCollectionReport implements XmlDeserializable
      * $reader->parseInnerTree() will parse the entire sub-tree, and advance to
      * the next element.
      *
-     * @param Reader $reader
-     *
      * @return mixed
      */
     public static function xmlDeserialize(Reader $reader)

--- a/lib/DAV/Xml/Response/MultiStatus.php
+++ b/lib/DAV/Xml/Response/MultiStatus.php
@@ -80,8 +80,6 @@ class MultiStatus implements Element
      *
      * Important note 2: If you are writing any new elements, you are also
      * responsible for closing them.
-     *
-     * @param Writer $writer
      */
     public function xmlSerialize(Writer $writer)
     {
@@ -110,8 +108,6 @@ class MultiStatus implements Element
      *
      * $reader->parseInnerTree() will parse the entire sub-tree, and advance to
      * the next element.
-     *
-     * @param Reader $reader
      *
      * @return mixed
      */

--- a/lib/DAVACL/ACLTrait.php
+++ b/lib/DAVACL/ACLTrait.php
@@ -69,8 +69,6 @@ trait ACLTrait
      * Updates the ACL.
      *
      * This method will receive a list of new ACE's as an array argument.
-     *
-     * @param array $acl
      */
     public function setACL(array $acl)
     {

--- a/lib/DAVACL/AbstractPrincipalCollection.php
+++ b/lib/DAVACL/AbstractPrincipalCollection.php
@@ -51,9 +51,7 @@ abstract class AbstractPrincipalCollection extends DAV\Collection implements IPr
      * default is 'principals', if your principals are stored in a different
      * collection, override $principalPrefix
      *
-     *
-     * @param PrincipalBackend\BackendInterface $principalBackend
-     * @param string                            $principalPrefix
+     * @param string $principalPrefix
      */
     public function __construct(PrincipalBackend\BackendInterface $principalBackend, $principalPrefix = 'principals')
     {
@@ -67,8 +65,6 @@ abstract class AbstractPrincipalCollection extends DAV\Collection implements IPr
      * The passed array contains principal information, and is guaranteed to
      * at least contain a uri item. Other properties may or may not be
      * supplied by the authentication backend.
-     *
-     * @param array $principalInfo
      *
      * @return DAV\INode
      */
@@ -142,7 +138,6 @@ abstract class AbstractPrincipalCollection extends DAV\Collection implements IPr
      * This method should simply return a list of 'child names', which may be
      * used to call $this->getChild in the future.
      *
-     * @param array  $searchProperties
      * @param string $test
      *
      * @return array

--- a/lib/DAVACL/Exception/AceConflict.php
+++ b/lib/DAVACL/Exception/AceConflict.php
@@ -20,9 +20,6 @@ class AceConflict extends DAV\Exception\Conflict
      * Adds in extra information in the xml response.
      *
      * This method adds the {DAV:}no-ace-conflict element as defined in rfc3744
-     *
-     * @param DAV\Server  $server
-     * @param \DOMElement $errorNode
      */
     public function serialize(DAV\Server $server, \DOMElement $errorNode)
     {

--- a/lib/DAVACL/Exception/NeedPrivileges.php
+++ b/lib/DAVACL/Exception/NeedPrivileges.php
@@ -36,7 +36,6 @@ class NeedPrivileges extends DAV\Exception\Forbidden
      * Constructor.
      *
      * @param string $uri
-     * @param array  $privileges
      */
     public function __construct($uri, array $privileges)
     {
@@ -50,9 +49,6 @@ class NeedPrivileges extends DAV\Exception\Forbidden
      * Adds in extra information in the xml response.
      *
      * This method adds the {DAV:}need-privileges element as defined in rfc3744
-     *
-     * @param DAV\Server  $server
-     * @param \DOMElement $errorNode
      */
     public function serialize(DAV\Server $server, \DOMElement $errorNode)
     {

--- a/lib/DAVACL/Exception/NoAbstract.php
+++ b/lib/DAVACL/Exception/NoAbstract.php
@@ -20,9 +20,6 @@ class NoAbstract extends DAV\Exception\PreconditionFailed
      * Adds in extra information in the xml response.
      *
      * This method adds the {DAV:}no-abstract element as defined in rfc3744
-     *
-     * @param DAV\Server  $server
-     * @param \DOMElement $errorNode
      */
     public function serialize(DAV\Server $server, \DOMElement $errorNode)
     {

--- a/lib/DAVACL/Exception/NotRecognizedPrincipal.php
+++ b/lib/DAVACL/Exception/NotRecognizedPrincipal.php
@@ -20,9 +20,6 @@ class NotRecognizedPrincipal extends DAV\Exception\PreconditionFailed
      * Adds in extra information in the xml response.
      *
      * This method adds the {DAV:}recognized-principal element as defined in rfc3744
-     *
-     * @param DAV\Server  $server
-     * @param \DOMElement $errorNode
      */
     public function serialize(DAV\Server $server, \DOMElement $errorNode)
     {

--- a/lib/DAVACL/Exception/NotSupportedPrivilege.php
+++ b/lib/DAVACL/Exception/NotSupportedPrivilege.php
@@ -20,9 +20,6 @@ class NotSupportedPrivilege extends DAV\Exception\PreconditionFailed
      * Adds in extra information in the xml response.
      *
      * This method adds the {DAV:}not-supported-privilege element as defined in rfc3744
-     *
-     * @param DAV\Server  $server
-     * @param \DOMElement $errorNode
      */
     public function serialize(DAV\Server $server, \DOMElement $errorNode)
     {

--- a/lib/DAVACL/FS/HomeCollection.php
+++ b/lib/DAVACL/FS/HomeCollection.php
@@ -42,9 +42,8 @@ class HomeCollection extends AbstractPrincipalCollection implements IACL
     /**
      * Creates the home collection.
      *
-     * @param BackendInterface $principalBackend
-     * @param string           $storagePath      where the actual files are stored
-     * @param string           $principalPrefix  list of principals to iterate
+     * @param string $storagePath     where the actual files are stored
+     * @param string $principalPrefix list of principals to iterate
      */
     public function __construct(BackendInterface $principalBackend, $storagePath, $principalPrefix = 'principals')
     {
@@ -70,8 +69,6 @@ class HomeCollection extends AbstractPrincipalCollection implements IACL
      * The passed array contains principal information, and is guaranteed to
      * at least contain a uri item. Other properties may or may not be
      * supplied by the authentication backend.
-     *
-     * @param array $principalInfo
      *
      * @return \Sabre\DAV\INode
      */

--- a/lib/DAVACL/IACL.php
+++ b/lib/DAVACL/IACL.php
@@ -53,8 +53,6 @@ interface IACL extends DAV\INode
      * Updates the ACL.
      *
      * This method will receive a list of new ACE's as an array argument.
-     *
-     * @param array $acl
      */
     public function setACL(array $acl);
 

--- a/lib/DAVACL/IPrincipal.php
+++ b/lib/DAVACL/IPrincipal.php
@@ -60,8 +60,6 @@ interface IPrincipal extends DAV\INode
      * The list of members is always overwritten, never appended to.
      *
      * This method should throw an exception if the members could not be set.
-     *
-     * @param array $principals
      */
     public function setGroupMemberSet(array $principals);
 

--- a/lib/DAVACL/IPrincipalCollection.php
+++ b/lib/DAVACL/IPrincipalCollection.php
@@ -37,7 +37,6 @@ interface IPrincipalCollection extends DAV\ICollection
      * This method should simply return a list of 'child names', which may be
      * used to call $this->getChild in the future.
      *
-     * @param array  $searchProperties
      * @param string $test
      *
      * @return array

--- a/lib/DAVACL/Plugin.php
+++ b/lib/DAVACL/Plugin.php
@@ -269,8 +269,6 @@ class Plugin extends DAV\ServerPlugin
      * Sets the default ACL rules.
      *
      * These rules are used for all nodes that don't implement the IACL interface.
-     *
-     * @param array $acl
      */
     public function setDefaultAcl(array $acl)
     {
@@ -763,8 +761,6 @@ class Plugin extends DAV\ServerPlugin
      * Sets up the plugin.
      *
      * This method is automatically called by the server class.
-     *
-     * @param DAV\Server $server
      */
     public function initialize(DAV\Server $server)
     {
@@ -829,9 +825,6 @@ class Plugin extends DAV\ServerPlugin
 
     /**
      * Triggered before any method is handled.
-     *
-     * @param RequestInterface  $request
-     * @param ResponseInterface $response
      */
     public function beforeMethod(RequestInterface $request, ResponseInterface $response)
     {
@@ -923,8 +916,7 @@ class Plugin extends DAV\ServerPlugin
     /**
      * Triggered before a node is unlocked.
      *
-     * @param string             $uri
-     * @param DAV\Locks\LockInfo $lock
+     * @param string $uri
      * @TODO: not yet implemented
      */
     public function beforeUnlock($uri, DAV\Locks\LockInfo $lock)
@@ -934,8 +926,6 @@ class Plugin extends DAV\ServerPlugin
     /**
      * Triggered before properties are looked up in specific nodes.
      *
-     * @param DAV\PropFind $propFind
-     * @param DAV\INode    $node
      * @TODO really should be broken into multiple methods, or even a class.
      *
      * @return bool
@@ -1044,8 +1034,7 @@ class Plugin extends DAV\ServerPlugin
      * This method intercepts PROPPATCH methods and make sure the
      * group-member-set is updated correctly.
      *
-     * @param string        $path
-     * @param DAV\PropPatch $propPatch
+     * @param string $path
      */
     public function propPatch($path, DAV\PropPatch $propPatch)
     {
@@ -1117,9 +1106,6 @@ class Plugin extends DAV\ServerPlugin
 
     /**
      * This method is responsible for handling the 'ACL' event.
-     *
-     * @param RequestInterface  $request
-     * @param ResponseInterface $response
      *
      * @return bool
      */
@@ -1211,8 +1197,7 @@ class Plugin extends DAV\ServerPlugin
      * or a principal URL, the principal URL and principal URLs of groups that
      * principal belongs to.
      *
-     * @param string                           $path
-     * @param Xml\Request\PrincipalMatchReport $report
+     * @param string $path
      */
     protected function principalMatchReport($path, Xml\Request\PrincipalMatchReport $report)
     {
@@ -1434,8 +1419,7 @@ class Plugin extends DAV\ServerPlugin
      * clients to search for groups of principals, based on the value of one
      * or more properties.
      *
-     * @param string                                    $path
-     * @param Xml\Request\PrincipalPropertySearchReport $report
+     * @param string $path
      */
     protected function principalPropertySearchReport($path, Xml\Request\PrincipalPropertySearchReport $report)
     {
@@ -1473,8 +1457,7 @@ class Plugin extends DAV\ServerPlugin
      * is used to for example generate a UI with ACL rules, allowing you
      * to show names for principals for every entry.
      *
-     * @param string                                $path
-     * @param Xml\Request\AclPrincipalPropSetReport $report
+     * @param string $path
      */
     protected function aclPrincipalPropSetReport($path, Xml\Request\AclPrincipalPropSetReport $report)
     {
@@ -1520,8 +1503,7 @@ class Plugin extends DAV\ServerPlugin
      * DAV\Browser\Plugin. This allows us to generate an interface users
      * can use to create new calendars.
      *
-     * @param DAV\INode $node
-     * @param string    $output
+     * @param string $output
      *
      * @return bool
      */

--- a/lib/DAVACL/Principal.php
+++ b/lib/DAVACL/Principal.php
@@ -42,9 +42,6 @@ class Principal extends DAV\Node implements IPrincipal, DAV\IProperties, IACL
 
     /**
      * Creates the principal object.
-     *
-     * @param PrincipalBackend\BackendInterface $principalBackend
-     * @param array                             $principalProperties
      */
     public function __construct(PrincipalBackend\BackendInterface $principalBackend, array $principalProperties = [])
     {
@@ -119,8 +116,6 @@ class Principal extends DAV\Node implements IPrincipal, DAV\IProperties, IACL
      * The list of members is always overwritten, never appended to.
      *
      * This method should throw an exception if the members could not be set.
-     *
-     * @param array $groupMembers
      */
     public function setGroupMemberSet(array $groupMembers)
     {
@@ -181,8 +176,6 @@ class Principal extends DAV\Node implements IPrincipal, DAV\IProperties, IACL
      *
      * To update specific properties, call the 'handle' method on this object.
      * Read the PropPatch documentation for more information.
-     *
-     * @param DAV\PropPatch $propPatch
      */
     public function propPatch(DAV\PropPatch $propPatch)
     {

--- a/lib/DAVACL/PrincipalBackend/BackendInterface.php
+++ b/lib/DAVACL/PrincipalBackend/BackendInterface.php
@@ -59,8 +59,7 @@ interface BackendInterface
      *
      * Read the PropPatch documentation for more info and examples.
      *
-     * @param string               $path
-     * @param \Sabre\DAV\PropPatch $propPatch
+     * @param string $path
      */
     public function updatePrincipal($path, \Sabre\DAV\PropPatch $propPatch);
 
@@ -89,7 +88,6 @@ interface BackendInterface
      * from working.
      *
      * @param string $prefixPath
-     * @param array  $searchProperties
      * @param string $test
      *
      * @return array
@@ -140,7 +138,6 @@ interface BackendInterface
      * The principals should be passed as a list of uri's.
      *
      * @param string $principal
-     * @param array  $members
      */
     public function setGroupMemberSet($principal, array $members);
 }

--- a/lib/DAVACL/PrincipalBackend/CreatePrincipalSupport.php
+++ b/lib/DAVACL/PrincipalBackend/CreatePrincipalSupport.php
@@ -24,7 +24,6 @@ interface CreatePrincipalSupport extends BackendInterface
      * of the principal.
      *
      * @param string $path
-     * @param MkCol  $mkCol
      */
     public function createPrincipal($path, MkCol $mkCol);
 }

--- a/lib/DAVACL/PrincipalBackend/PDO.php
+++ b/lib/DAVACL/PrincipalBackend/PDO.php
@@ -11,7 +11,6 @@ use Sabre\Uri;
 /**
  * PDO principal backend.
  *
- *
  * This backend assumes all principals are in a single collection. The default collection
  * is 'principals/', but this can be overridden.
  *
@@ -65,8 +64,6 @@ class PDO extends AbstractBackend implements CreatePrincipalSupport
 
     /**
      * Sets up the backend.
-     *
-     * @param \PDO $pdo
      */
     public function __construct(\PDO $pdo)
     {
@@ -176,8 +173,7 @@ class PDO extends AbstractBackend implements CreatePrincipalSupport
      *
      * Read the PropPatch documentation for more info and examples.
      *
-     * @param string        $path
-     * @param DAV\PropPatch $propPatch
+     * @param string $path
      */
     public function updatePrincipal($path, DAV\PropPatch $propPatch)
     {
@@ -233,7 +229,6 @@ class PDO extends AbstractBackend implements CreatePrincipalSupport
      * from working.
      *
      * @param string $prefixPath
-     * @param array  $searchProperties
      * @param string $test
      *
      * @return array
@@ -400,7 +395,6 @@ class PDO extends AbstractBackend implements CreatePrincipalSupport
      * The principals should be passed as a list of uri's.
      *
      * @param string $principal
-     * @param array  $members
      */
     public function setGroupMemberSet($principal, array $members)
     {
@@ -439,7 +433,6 @@ class PDO extends AbstractBackend implements CreatePrincipalSupport
      * of the principal.
      *
      * @param string $path
-     * @param MkCol  $mkCol
      */
     public function createPrincipal($path, MkCol $mkCol)
     {

--- a/lib/DAVACL/PrincipalCollection.php
+++ b/lib/DAVACL/PrincipalCollection.php
@@ -29,8 +29,6 @@ class PrincipalCollection extends AbstractPrincipalCollection implements IExtend
      * at least contain a uri item. Other properties may or may not be
      * supplied by the authentication backend.
      *
-     * @param array $principal
-     *
      * @return \Sabre\DAV\INode
      */
     public function getChildForPrincipal(array $principal)
@@ -58,7 +56,6 @@ class PrincipalCollection extends AbstractPrincipalCollection implements IExtend
      * property for you.
      *
      * @param string $name
-     * @param MkCol  $mkCol
      *
      * @throws InvalidResourceType
      */

--- a/lib/DAVACL/Xml/Property/Acl.php
+++ b/lib/DAVACL/Xml/Property/Acl.php
@@ -58,8 +58,7 @@ class Acl implements Element, HtmlOutput
      * are already full urls. If this is kept to true, the servers base url
      * will automatically be prefixed.
      *
-     * @param array $privileges
-     * @param bool  $prefixBaseUrl
+     * @param bool $prefixBaseUrl
      */
     public function __construct(array $privileges, $prefixBaseUrl = true)
     {
@@ -92,8 +91,6 @@ class Acl implements Element, HtmlOutput
      * This allows serializers to be re-used for different element names.
      *
      * If you are opening new elements, you must also close them again.
-     *
-     * @param Writer $writer
      */
     public function xmlSerialize(Writer $writer)
     {
@@ -112,8 +109,6 @@ class Acl implements Element, HtmlOutput
      *
      * The baseUri parameter is a url to the root of the application, and can
      * be used to construct local links.
-     *
-     * @param HtmlOutputHelper $html
      *
      * @return string
      */
@@ -160,8 +155,6 @@ class Acl implements Element, HtmlOutput
      *
      * $reader->parseInnerTree() will parse the entire sub-tree, and advance to
      * the next element.
-     *
-     * @param Reader $reader
      *
      * @return mixed
      */
@@ -226,9 +219,6 @@ class Acl implements Element, HtmlOutput
 
     /**
      * Serializes a single access control entry.
-     *
-     * @param Writer $writer
-     * @param array  $ace
      */
     private function serializeAce(Writer $writer, array $ace)
     {

--- a/lib/DAVACL/Xml/Property/AclRestrictions.php
+++ b/lib/DAVACL/Xml/Property/AclRestrictions.php
@@ -33,8 +33,6 @@ class AclRestrictions implements XmlSerializable
      * This allows serializers to be re-used for different element names.
      *
      * If you are opening new elements, you must also close them again.
-     *
-     * @param Writer $writer
      */
     public function xmlSerialize(Writer $writer)
     {

--- a/lib/DAVACL/Xml/Property/CurrentUserPrivilegeSet.php
+++ b/lib/DAVACL/Xml/Property/CurrentUserPrivilegeSet.php
@@ -33,8 +33,6 @@ class CurrentUserPrivilegeSet implements Element, HtmlOutput
      * Creates the object.
      *
      * Pass the privileges in clark-notation
-     *
-     * @param array $privileges
      */
     public function __construct(array $privileges)
     {
@@ -56,8 +54,6 @@ class CurrentUserPrivilegeSet implements Element, HtmlOutput
      * This allows serializers to be re-used for different element names.
      *
      * If you are opening new elements, you must also close them again.
-     *
-     * @param Writer $writer
      */
     public function xmlSerialize(Writer $writer)
     {
@@ -109,8 +105,6 @@ class CurrentUserPrivilegeSet implements Element, HtmlOutput
      * $reader->parseInnerTree() will parse the entire sub-tree, and advance to
      * the next element.
      *
-     * @param Reader $reader
-     *
      * @return mixed
      */
     public static function xmlDeserialize(Reader $reader)
@@ -138,8 +132,6 @@ class CurrentUserPrivilegeSet implements Element, HtmlOutput
      *
      * The baseUri parameter is a url to the root of the application, and can
      * be used to construct local links.
-     *
-     * @param HtmlOutputHelper $html
      *
      * @return string
      */

--- a/lib/DAVACL/Xml/Property/Principal.php
+++ b/lib/DAVACL/Xml/Property/Principal.php
@@ -98,8 +98,6 @@ class Principal extends DAV\Xml\Property\Href
      * This allows serializers to be re-used for different element names.
      *
      * If you are opening new elements, you must also close them again.
-     *
-     * @param Writer $writer
      */
     public function xmlSerialize(Writer $writer)
     {
@@ -129,8 +127,6 @@ class Principal extends DAV\Xml\Property\Href
      *
      * The baseUri parameter is a url to the root of the application, and can
      * be used to construct local links.
-     *
-     * @param HtmlOutputHelper $html
      *
      * @return string
      */
@@ -165,8 +161,6 @@ class Principal extends DAV\Xml\Property\Href
      *
      * $reader->parseInnerTree() will parse the entire sub-tree, and advance to
      * the next element.
-     *
-     * @param Reader $reader
      *
      * @return mixed
      */

--- a/lib/DAVACL/Xml/Property/SupportedPrivilegeSet.php
+++ b/lib/DAVACL/Xml/Property/SupportedPrivilegeSet.php
@@ -34,8 +34,6 @@ class SupportedPrivilegeSet implements XmlSerializable, HtmlOutput
 
     /**
      * Constructor.
-     *
-     * @param array $privileges
      */
     public function __construct(array $privileges)
     {
@@ -67,8 +65,6 @@ class SupportedPrivilegeSet implements XmlSerializable, HtmlOutput
      * This allows serializers to be re-used for different element names.
      *
      * If you are opening new elements, you must also close them again.
-     *
-     * @param Writer $writer
      */
     public function xmlSerialize(Writer $writer)
     {
@@ -85,8 +81,6 @@ class SupportedPrivilegeSet implements XmlSerializable, HtmlOutput
      *
      * The baseUri parameter is a url to the root of the application, and can
      * be used to construct local links.
-     *
-     * @param HtmlOutputHelper $html
      *
      * @return string
      */
@@ -124,7 +118,6 @@ class SupportedPrivilegeSet implements XmlSerializable, HtmlOutput
      *
      * This is a recursive function.
      *
-     * @param Writer $writer
      * @param string $privName
      * @param array  $privilege
      */

--- a/lib/DAVACL/Xml/Request/AclPrincipalPropSetReport.php
+++ b/lib/DAVACL/Xml/Request/AclPrincipalPropSetReport.php
@@ -41,8 +41,6 @@ class AclPrincipalPropSetReport implements XmlDeserializable
      * $reader->parseInnerTree() will parse the entire sub-tree, and advance to
      * the next element.
      *
-     * @param Reader $reader
-     *
      * @return mixed
      */
     public static function xmlDeserialize(Reader $reader)

--- a/lib/DAVACL/Xml/Request/ExpandPropertyReport.php
+++ b/lib/DAVACL/Xml/Request/ExpandPropertyReport.php
@@ -52,8 +52,6 @@ class ExpandPropertyReport implements XmlDeserializable
      * $reader->parseInnerTree() will parse the entire sub-tree, and advance to
      * the next element.
      *
-     * @param Reader $reader
-     *
      * @return mixed
      */
     public static function xmlDeserialize(Reader $reader)

--- a/lib/DAVACL/Xml/Request/PrincipalMatchReport.php
+++ b/lib/DAVACL/Xml/Request/PrincipalMatchReport.php
@@ -72,8 +72,6 @@ class PrincipalMatchReport implements XmlDeserializable
      * $reader->parseInnerTree() will parse the entire sub-tree, and advance to
      * the next element.
      *
-     * @param Reader $reader
-     *
      * @return mixed
      */
     public static function xmlDeserialize(Reader $reader)

--- a/lib/DAVACL/Xml/Request/PrincipalPropertySearchReport.php
+++ b/lib/DAVACL/Xml/Request/PrincipalPropertySearchReport.php
@@ -73,8 +73,6 @@ class PrincipalPropertySearchReport implements XmlDeserializable
      * $reader->parseInnerTree() will parse the entire sub-tree, and advance to
      * the next element.
      *
-     * @param Reader $reader
-     *
      * @return mixed
      */
     public static function xmlDeserialize(Reader $reader)

--- a/lib/DAVACL/Xml/Request/PrincipalSearchPropertySetReport.php
+++ b/lib/DAVACL/Xml/Request/PrincipalSearchPropertySetReport.php
@@ -40,8 +40,6 @@ class PrincipalSearchPropertySetReport implements XmlDeserializable
      * $reader->parseInnerTree() will parse the entire sub-tree, and advance to
      * the next element.
      *
-     * @param Reader $reader
-     *
      * @return mixed
      */
     public static function xmlDeserialize(Reader $reader)

--- a/tests/Sabre/CalDAV/Backend/Mock.php
+++ b/tests/Sabre/CalDAV/Backend/Mock.php
@@ -65,7 +65,6 @@ class Mock extends AbstractBackend
      *
      * @param string $principalUri
      * @param string $calendarUri
-     * @param array  $properties
      *
      * @return string|int
      */
@@ -94,8 +93,7 @@ class Mock extends AbstractBackend
      *
      * Read the PropPatch documentation for more info and examples.
      *
-     * @param mixed                $calendarId
-     * @param \Sabre\DAV\PropPatch $propPatch
+     * @param mixed $calendarId
      */
     public function updateCalendar($calendarId, \Sabre\DAV\PropPatch $propPatch)
     {

--- a/tests/Sabre/CalDAV/Backend/MockSharing.php
+++ b/tests/Sabre/CalDAV/Backend/MockSharing.php
@@ -78,8 +78,7 @@ class MockSharing extends Mock implements NotificationSupport, SharingSupport
      *
      * This may be called by a client once it deems a notification handled.
      *
-     * @param string                $principalUri
-     * @param NotificationInterface $notification
+     * @param string $principalUri
      */
     public function deleteNotification($principalUri, NotificationInterface $notification)
     {

--- a/tests/Sabre/CalDAV/Backend/MockSubscriptionSupport.php
+++ b/tests/Sabre/CalDAV/Backend/MockSubscriptionSupport.php
@@ -71,7 +71,6 @@ class MockSubscriptionSupport extends Mock implements SubscriptionSupport
      *
      * @param string $principalUri
      * @param string $uri
-     * @param array  $properties
      *
      * @return mixed
      */

--- a/tests/Sabre/CalDAV/CalendarObjectTest.php
+++ b/tests/Sabre/CalDAV/CalendarObjectTest.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Sabre\CalDAV;
 
-
-
 class CalendarObjectTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/tests/Sabre/CalDAV/CalendarTest.php
+++ b/tests/Sabre/CalDAV/CalendarTest.php
@@ -6,8 +6,6 @@ namespace Sabre\CalDAV;
 
 use Sabre\DAV\PropPatch;
 
-
-
 class CalendarTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/tests/Sabre/CalDAV/ExpandEventsDTSTARTandDTENDTest.php
+++ b/tests/Sabre/CalDAV/ExpandEventsDTSTARTandDTENDTest.php
@@ -10,7 +10,6 @@ use Sabre\VObject;
 /**
  * This unittests is created to find out why recurring events have wrong DTSTART value.
  *
- *
  * @copyright Copyright (C) fruux GmbH (https://fruux.com/)
  * @author Evert Pot (http://evertpot.com/)
  * @license http://sabre.io/license/ Modified BSD License

--- a/tests/Sabre/CalDAV/ValidateICalTest.php
+++ b/tests/Sabre/CalDAV/ValidateICalTest.php
@@ -8,8 +8,6 @@ use Sabre\DAV;
 use Sabre\DAVACL;
 use Sabre\HTTP;
 
-
-
 class ValidateICalTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/tests/Sabre/CardDAV/AddressBookQueryTest.php
+++ b/tests/Sabre/CardDAV/AddressBookQueryTest.php
@@ -7,9 +7,6 @@ namespace Sabre\CardDAV;
 use Sabre\DAV;
 use Sabre\HTTP;
 
-
-
-
 class AddressBookQueryTest extends AbstractPluginTest
 {
     public function testQuery()

--- a/tests/Sabre/CardDAV/Backend/Mock.php
+++ b/tests/Sabre/CardDAV/Backend/Mock.php
@@ -69,8 +69,7 @@ class Mock extends AbstractBackend
      *
      * Read the PropPatch documentation for more info and examples.
      *
-     * @param string               $addressBookId
-     * @param \Sabre\DAV\PropPatch $propPatch
+     * @param string $addressBookId
      */
     public function updateAddressBook($addressBookId, \Sabre\DAV\PropPatch $propPatch)
     {

--- a/tests/Sabre/CardDAV/MultiGetTest.php
+++ b/tests/Sabre/CardDAV/MultiGetTest.php
@@ -7,8 +7,6 @@ namespace Sabre\CardDAV;
 use Sabre\DAV;
 use Sabre\HTTP;
 
-
-
 class MultiGetTest extends AbstractPluginTest
 {
     public function testMultiGet()

--- a/tests/Sabre/CardDAV/ValidateFilterTest.php
+++ b/tests/Sabre/CardDAV/ValidateFilterTest.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Sabre\CardDAV;
 
-
-
 class ValidateFilterTest extends AbstractPluginTest
 {
     /**

--- a/tests/Sabre/CardDAV/ValidateVCardTest.php
+++ b/tests/Sabre/CardDAV/ValidateVCardTest.php
@@ -8,8 +8,6 @@ use Sabre\DAV;
 use Sabre\DAVACL;
 use Sabre\HTTP;
 
-
-
 class ValidateVCardTest extends \PHPUnit\Framework\TestCase
 {
     protected $server;

--- a/tests/Sabre/DAV/Auth/Backend/Mock.php
+++ b/tests/Sabre/DAV/Auth/Backend/Mock.php
@@ -44,9 +44,6 @@ class Mock implements BackendInterface
      *
      * principals/users/[username]
      *
-     * @param RequestInterface  $request
-     * @param ResponseInterface $response
-     *
      * @return array
      */
     public function check(RequestInterface $request, ResponseInterface $response)
@@ -77,9 +74,6 @@ class Mock implements BackendInterface
      * WWW-Authenticate headers may already have been set, and you'll want to
      * append your own WWW-Authenticate header instead of overwriting the
      * existing one.
-     *
-     * @param RequestInterface  $request
-     * @param ResponseInterface $response
      */
     public function challenge(RequestInterface $request, ResponseInterface $response)
     {

--- a/tests/Sabre/DAV/Browser/GuessContentTypeTest.php
+++ b/tests/Sabre/DAV/Browser/GuessContentTypeTest.php
@@ -6,7 +6,6 @@ namespace Sabre\DAV\Browser;
 
 use Sabre\DAV;
 
-
 class GuessContentTypeTest extends DAV\AbstractServer
 {
     public function setUp()

--- a/tests/Sabre/DAV/Browser/MapGetToPropFindTest.php
+++ b/tests/Sabre/DAV/Browser/MapGetToPropFindTest.php
@@ -7,8 +7,6 @@ namespace Sabre\DAV\Browser;
 use Sabre\DAV;
 use Sabre\HTTP;
 
-
-
 class MapGetToPropFindTest extends DAV\AbstractServer
 {
     public function setUp()

--- a/tests/Sabre/DAV/Browser/PluginTest.php
+++ b/tests/Sabre/DAV/Browser/PluginTest.php
@@ -7,8 +7,6 @@ namespace Sabre\DAV\Browser;
 use Sabre\DAV;
 use Sabre\HTTP;
 
-
-
 class PluginTest extends DAV\AbstractServer
 {
     protected $plugin;

--- a/tests/Sabre/DAV/ClientTest.php
+++ b/tests/Sabre/DAV/ClientTest.php
@@ -6,8 +6,6 @@ namespace Sabre\DAV;
 
 use Sabre\HTTP\Response;
 
-
-
 class ClientTest extends \PHPUnit\Framework\TestCase
 {
     public function setUp()

--- a/tests/Sabre/DAV/FSExt/FileTest.php
+++ b/tests/Sabre/DAV/FSExt/FileTest.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Sabre\DAV\FSExt;
 
-
-
 class FileTest extends \PHPUnit\Framework\TestCase
 {
     public function setUp()

--- a/tests/Sabre/DAV/FSExt/ServerTest.php
+++ b/tests/Sabre/DAV/FSExt/ServerTest.php
@@ -7,8 +7,6 @@ namespace Sabre\DAV\FSExt;
 use Sabre\DAV;
 use Sabre\HTTP;
 
-
-
 class ServerTest extends DAV\AbstractServer
 {
     protected function getRootNode()

--- a/tests/Sabre/DAV/GetIfConditionsTest.php
+++ b/tests/Sabre/DAV/GetIfConditionsTest.php
@@ -6,9 +6,6 @@ namespace Sabre\DAV;
 
 use Sabre\HTTP;
 
-
-
-
 class GetIfConditionsTest extends AbstractServer
 {
     public function testNoConditions()

--- a/tests/Sabre/DAV/Issue33Test.php
+++ b/tests/Sabre/DAV/Issue33Test.php
@@ -6,8 +6,6 @@ namespace Sabre\DAV;
 
 use Sabre\HTTP;
 
-
-
 class Issue33Test extends \PHPUnit\Framework\TestCase
 {
     public function setUp()

--- a/tests/Sabre/DAV/Locks/Backend/FileTest.php
+++ b/tests/Sabre/DAV/Locks/Backend/FileTest.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Sabre\DAV\Locks\Backend;
 
-
-
 class FileTest extends AbstractTest
 {
     public function getBackend()

--- a/tests/Sabre/DAV/Locks/Backend/Mock.php
+++ b/tests/Sabre/DAV/Locks/Backend/Mock.php
@@ -61,8 +61,7 @@ class Mock extends AbstractBackend
     /**
      * Locks a uri.
      *
-     * @param string   $uri
-     * @param LockInfo $lockInfo
+     * @param string $uri
      *
      * @return bool
      */
@@ -92,8 +91,7 @@ class Mock extends AbstractBackend
     /**
      * Removes a lock from a uri.
      *
-     * @param string   $uri
-     * @param LockInfo $lockInfo
+     * @param string $uri
      *
      * @return bool
      */
@@ -126,8 +124,6 @@ class Mock extends AbstractBackend
 
     /**
      * Saves the lockdata.
-     *
-     * @param array $newData
      */
     protected function putData(array $newData)
     {

--- a/tests/Sabre/DAV/Locks/MSWordTest.php
+++ b/tests/Sabre/DAV/Locks/MSWordTest.php
@@ -7,9 +7,6 @@ namespace Sabre\DAV\Locks;
 use Sabre\DAV;
 use Sabre\HTTP;
 
-
-
-
 class MSWordTest extends \PHPUnit\Framework\TestCase
 {
     public function tearDown()

--- a/tests/Sabre/DAV/Locks/PluginTest.php
+++ b/tests/Sabre/DAV/Locks/PluginTest.php
@@ -7,8 +7,6 @@ namespace Sabre\DAV\Locks;
 use Sabre\DAV;
 use Sabre\HTTP;
 
-
-
 class PluginTest extends DAV\AbstractServer
 {
     /**

--- a/tests/Sabre/DAV/Mock/Collection.php
+++ b/tests/Sabre/DAV/Mock/Collection.php
@@ -31,7 +31,6 @@ class Collection extends DAV\Collection
      * Creates the object.
      *
      * @param string     $name
-     * @param array      $children
      * @param Collection $parent
      */
     public function __construct($name, array $children = [], Collection $parent = null)
@@ -120,8 +119,6 @@ class Collection extends DAV\Collection
 
     /**
      * Adds an already existing node to this collection.
-     *
-     * @param \Sabre\DAV\INode $node
      */
     public function addNode(\Sabre\DAV\INode $node)
     {

--- a/tests/Sabre/DAV/Mock/PropertiesCollection.php
+++ b/tests/Sabre/DAV/Mock/PropertiesCollection.php
@@ -24,8 +24,6 @@ class PropertiesCollection extends Collection implements IProperties
      * Creates the object.
      *
      * @param string $name
-     * @param array  $children
-     * @param array  $properties
      */
     public function __construct($name, array $children, array $properties = [])
     {
@@ -41,8 +39,6 @@ class PropertiesCollection extends Collection implements IProperties
      *
      * To update specific properties, call the 'handle' method on this object.
      * Read the PropPatch documentation for more information.
-     *
-     * @param PropPatch $proppatch
      *
      * @return bool|array
      */

--- a/tests/Sabre/DAV/MockLogger.php
+++ b/tests/Sabre/DAV/MockLogger.php
@@ -23,7 +23,6 @@ class MockLogger extends AbstractLogger
      *
      * @param mixed  $level
      * @param string $message
-     * @param array  $context
      */
     public function log($level, $message, array $context = [])
     {

--- a/tests/Sabre/DAV/Mount/PluginTest.php
+++ b/tests/Sabre/DAV/Mount/PluginTest.php
@@ -7,8 +7,6 @@ namespace Sabre\DAV\Mount;
 use Sabre\DAV;
 use Sabre\HTTP;
 
-
-
 class PluginTest extends DAV\AbstractServer
 {
     public function setUp()

--- a/tests/Sabre/DAV/ObjectTreeTest.php
+++ b/tests/Sabre/DAV/ObjectTreeTest.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Sabre\DAV;
 
-
-
 class ObjectTreeTest extends \PHPUnit\Framework\TestCase
 {
     protected $tree;

--- a/tests/Sabre/DAV/PartialUpdate/PluginTest.php
+++ b/tests/Sabre/DAV/PartialUpdate/PluginTest.php
@@ -6,8 +6,6 @@ namespace Sabre\DAV\PartialUpdate;
 
 use Sabre\HTTP;
 
-
-
 class PluginTest extends \Sabre\DAVServerTest
 {
     protected $node;

--- a/tests/Sabre/DAV/PropertyStorage/Backend/Mock.php
+++ b/tests/Sabre/DAV/PropertyStorage/Backend/Mock.php
@@ -21,8 +21,7 @@ class Mock implements BackendInterface
      * as this will give you the _exact_ list of properties that need to be
      * fetched, and haven't yet.
      *
-     * @param string   $path
-     * @param PropFind $propFind
+     * @param string $path
      */
     public function propFind($path, PropFind $propFind)
     {
@@ -44,8 +43,7 @@ class Mock implements BackendInterface
      * Usually you would want to call 'handleRemaining' on this object, to get;
      * a list of all properties that need to be stored.
      *
-     * @param string    $path
-     * @param PropPatch $propPatch
+     * @param string $path
      */
     public function propPatch($path, PropPatch $propPatch)
     {

--- a/tests/Sabre/DAV/ServerEventsTest.php
+++ b/tests/Sabre/DAV/ServerEventsTest.php
@@ -6,8 +6,6 @@ namespace Sabre\DAV;
 
 use Sabre\HTTP;
 
-
-
 class ServerEventsTest extends AbstractServer
 {
     private $tempPath;

--- a/tests/Sabre/DAV/ServerPluginTest.php
+++ b/tests/Sabre/DAV/ServerPluginTest.php
@@ -6,9 +6,6 @@ namespace Sabre\DAV;
 
 use Sabre\HTTP;
 
-
-
-
 class ServerPluginTest extends AbstractServer
 {
     /**

--- a/tests/Sabre/DAV/ServerPreconditionsTest.php
+++ b/tests/Sabre/DAV/ServerPreconditionsTest.php
@@ -6,7 +6,6 @@ namespace Sabre\DAV;
 
 use Sabre\HTTP;
 
-
 class ServerPreconditionsTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/tests/Sabre/DAV/ServerPropsInfiniteDepthTest.php
+++ b/tests/Sabre/DAV/ServerPropsInfiniteDepthTest.php
@@ -6,8 +6,6 @@ namespace Sabre\DAV;
 
 use Sabre\HTTP;
 
-
-
 class ServerPropsInfiniteDepthTest extends AbstractServer
 {
     protected function getRootNode()

--- a/tests/Sabre/DAV/ServerPropsTest.php
+++ b/tests/Sabre/DAV/ServerPropsTest.php
@@ -6,9 +6,6 @@ namespace Sabre\DAV;
 
 use Sabre\HTTP;
 
-
-
-
 class ServerPropsTest extends AbstractServer
 {
     protected function getRootNode()

--- a/tests/Sabre/DAV/Sync/PluginTest.php
+++ b/tests/Sabre/DAV/Sync/PluginTest.php
@@ -7,8 +7,6 @@ namespace Sabre\DAV\Sync;
 use Sabre\DAV;
 use Sabre\HTTP;
 
-
-
 class PluginTest extends \Sabre\DAVServerTest
 {
     protected $collection;

--- a/tests/Sabre/DAV/TreeTest.php
+++ b/tests/Sabre/DAV/TreeTest.php
@@ -203,8 +203,6 @@ class TreeFileTester extends File implements IProperties
      *
      * To update specific properties, call the 'handle' method on this object.
      * Read the PropPatch documentation for more information.
-     *
-     * @param PropPatch $propPatch
      */
     public function propPatch(PropPatch $propPatch)
     {
@@ -220,8 +218,6 @@ class TreeMultiGetTester extends TreeDirectoryTester implements IMultiGet
      * It must return an array with Node objects.
      *
      * If any children are not found, you do not have to return them.
-     *
-     * @param array $paths
      *
      * @return array
      */

--- a/tests/Sabre/DAVACL/ExpandPropertiesTest.php
+++ b/tests/Sabre/DAVACL/ExpandPropertiesTest.php
@@ -7,8 +7,6 @@ namespace Sabre\DAVACL;
 use Sabre\DAV;
 use Sabre\HTTP;
 
-
-
 class ExpandPropertiesTest extends \PHPUnit\Framework\TestCase
 {
     public function getServer()

--- a/tests/Sabre/DAVACL/PluginAdminTest.php
+++ b/tests/Sabre/DAVACL/PluginAdminTest.php
@@ -7,9 +7,6 @@ namespace Sabre\DAVACL;
 use Sabre\DAV;
 use Sabre\HTTP;
 
-
-
-
 class PluginAdminTest extends \PHPUnit\Framework\TestCase
 {
     public $server;

--- a/tests/Sabre/DAVACL/PrincipalBackend/Mock.php
+++ b/tests/Sabre/DAVACL/PrincipalBackend/Mock.php
@@ -126,8 +126,7 @@ class Mock extends AbstractBackend
      *
      * Read the PropPatch documentation for more info and examples.
      *
-     * @param string               $path
-     * @param \Sabre\DAV\PropPatch $propPatch
+     * @param string $path
      */
     public function updatePrincipal($path, \Sabre\DAV\PropPatch $propPatch)
     {

--- a/tests/Sabre/DAVACL/PrincipalPropertySearchTest.php
+++ b/tests/Sabre/DAVACL/PrincipalPropertySearchTest.php
@@ -7,8 +7,6 @@ namespace Sabre\DAVACL;
 use Sabre\DAV;
 use Sabre\HTTP;
 
-
-
 class PrincipalPropertySearchTest extends \PHPUnit\Framework\TestCase
 {
     public function getServer()

--- a/tests/Sabre/DAVACL/PrincipalSearchPropertySetTest.php
+++ b/tests/Sabre/DAVACL/PrincipalSearchPropertySetTest.php
@@ -7,8 +7,6 @@ namespace Sabre\DAVACL;
 use Sabre\DAV;
 use Sabre\HTTP;
 
-
-
 class PrincipalSearchPropertySetTest extends \PHPUnit\Framework\TestCase
 {
     public function getServer()

--- a/tests/Sabre/DAVACL/SimplePluginTest.php
+++ b/tests/Sabre/DAVACL/SimplePluginTest.php
@@ -7,9 +7,6 @@ namespace Sabre\DAVACL;
 use Sabre\DAV;
 use Sabre\HTTP;
 
-
-
-
 class SimplePluginTest extends \PHPUnit\Framework\TestCase
 {
     public function testValues()

--- a/tests/Sabre/HTTP/SapiMock.php
+++ b/tests/Sabre/HTTP/SapiMock.php
@@ -19,8 +19,6 @@ class SapiMock extends Sapi
 
     /**
      * Overriding this so nothing is ever echo'd.
-     *
-     * @param ResponseInterface $response
      */
     public static function sendResponse(ResponseInterface $response)
     {


### PR DESCRIPTION
PR #1232 introduced some empty lines that cause Pretty-CI to fail.

Add `php-cs-fixer` to the Travis CI (like in other sabre-io repos). It runs v2.16.1. Pretty-CI seems to be running 2.14.0, so it did not fuss about so much stuff.

`php-cs-fixer` found lots of params in PHPdoc to remove! (which already have their type specified in the function args) CI will tell us if it is OK.