### PR TITLE
Bump master PHP min version to 7.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Build status
 
 | branch       | status | minimum PHP version |
 | ------------ | ------ | ------------------- |
-| master       | [![Build Status](https://travis-ci.org/sabre-io/dav.svg?branch=master)](https://travis-ci.org/sabre-io/dav) | PHP 7.0 |
+| master       | [![Build Status](https://travis-ci.org/sabre-io/dav.svg?branch=master)](https://travis-ci.org/sabre-io/dav) | PHP 7.1 |
 | 3.1          | [![Build Status](https://travis-ci.org/sabre-io/dav.svg?branch=3.0)](https://travis-ci.org/sabre-io/dav) | PHP 5.5 |
 | 3.0          | [![Build Status](https://travis-ci.org/sabre-io/dav.svg?branch=3.0)](https://travis-ci.org/sabre-io/dav) | PHP 5.4 |
 | 2.1          | [![Build Status](https://travis-ci.org/sabre-io/dav.svg?branch=2.1)](https://travis-ci.org/sabre-io/dav) | PHP 5.4 |


### PR DESCRIPTION
to reflect what is now in master.

Maybe this should only done when making an official release that drops PHP 7.0 support.