### PR TITLE
Use phpunit 9 where possible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,17 +18,21 @@ env:
     - SABRE_MYSQLDSN="mysql:host=127.0.0.1;dbname=sabredav_test"
     - RUN_PHPSTAN="FALSE"
   matrix:
-    - PREFER_LOWEST="" TEST_DEPS="" WITH_COVERAGE="--coverage-clover=coverage.xml"
-    - PREFER_LOWEST="--prefer-lowest" TEST_DEPS="tests/Sabre/" $WITH_COVERAGE=""
+    - PREFER_LOWEST="" TEST_DEPS="" REPORT_COVERAGE="TRUE" WITH_COVERAGE="--coverage-clover=coverage.xml"
+    - PREFER_LOWEST="--prefer-lowest" TEST_DEPS="tests/Sabre/" REPORT_COVERAGE="FALSE" WITH_COVERAGE=""
 
 matrix:
   include:
     - name: 'PHPStan'
       php: 7.4
-      env: RUN_PHPSTAN="TRUE"
+      env:
+        - RUN_PHPSTAN="TRUE"
+        - REPORT_COVERAGE="FALSE"
     - name: 'Test with streaming propfind'
       php: 7.2
-      env: RUN_TEST_WITH_STREAMING_PROPFIND="TRUE"
+      env:
+        - RUN_TEST_WITH_STREAMING_PROPFIND="TRUE"
+        - REPORT_COVERAGE="FALSE"
   fast_finish: true
 
 services:
@@ -51,7 +55,7 @@ script:
   - if [ $RUN_PHPSTAN == "TRUE" ]; then composer phpstan; fi
 
 after_success:
-  - bash <(curl -s https://codecov.io/bash)
+  - if [ $REPORT_COVERAGE == "TRUE" ]; then bash <(curl -s https://codecov.io/bash); fi
 
 cache:
   directories:

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
     "require-dev" : {
         "friendsofphp/php-cs-fixer": "~2.16.1",
         "phpstan/phpstan": "^0.12",
-        "phpunit/phpunit" : "^7.5 || ^8.5",
+        "phpunit/phpunit" : "^7.5 || ^8.5 || ^9.0",
         "evert/phpdoc-md" : "~0.1.0",
         "monolog/monolog": "^1.18"
     },


### PR DESCRIPTION
https://phpunit.de/announcements/phpunit-9.html

2nd commit: In Travis, only bother to report/upload coverage if the job actually runs unit tests with coverage enabled.