### PR TITLE
CalDAV to sync properly when limit is set in PDO backend

### DIFF
--- a/lib/CalDAV/Calendar.php
+++ b/lib/CalDAV/Calendar.php
@@ -396,7 +396,8 @@ class Calendar implements ICalendar, DAV\IProperties, DAV\Sync\ISyncCollection, 
      *   'deleted' => [
      *      'foo.php.bak',
      *      'old.txt'
-     *   ]
+     *   ],
+     *   'result_truncated' : true
      * ];
      *
      * The syncToken property should reflect the *current* syncToken of the
@@ -405,6 +406,9 @@ class Calendar implements ICalendar, DAV\IProperties, DAV\Sync\ISyncCollection, 
      *
      * If the syncToken is specified as null, this is an initial sync, and all
      * members should be reported.
+     *
+     * If result is truncated due to server limitation or limit by client,
+     * set result_truncated to true, otherwise set to false or do not add the key.
      *
      * The modified property is an array of nodenames that have changed since
      * the last token.
@@ -422,12 +426,17 @@ class Calendar implements ICalendar, DAV\IProperties, DAV\Sync\ISyncCollection, 
      * should be treated as infinite.
      *
      * If the limit (infinite or not) is higher than you're willing to return,
-     * you should throw a Sabre\DAV\Exception\TooMuchMatches() exception.
+     * the result should be truncated to fit the limit.
+     * Note that even when the result is truncated, syncToken must be consistent
+     * with the truncated result, not the result before truncation.
+     * (See RFC6578 Section 3.6 for detail)
      *
      * If the syncToken is expired (due to data cleanup) or unknown, you must
      * return null.
      *
      * The limit is 'suggestive'. You are free to ignore it.
+     * TODO: RFC6578 Setion 3.7 says that the server must fail when the server
+     * cannot truncate according to the limit, so it may not be just suggestive.
      *
      * @param string $syncToken
      * @param int    $syncLevel

--- a/tests/Sabre/CalDAV/Backend/AbstractPDOTest.php
+++ b/tests/Sabre/CalDAV/Backend/AbstractPDOTest.php
@@ -943,6 +943,34 @@ abstract class AbstractPDOTest extends \PHPUnit\Framework\TestCase
             'deleted' => [],
             'added' => ['todo1.ics', 'todo3.ics'],
         ], $result);
+
+        $backend->createCalendarObject($id, 'todo7.ics', $dummyTodo);
+        $backend->createCalendarObject($id, 'todo8.ics', $dummyTodo);
+        $backend->createCalendarObject($id, 'todo9.ics', $dummyTodo);
+
+        $currentToken = $result['syncToken'];
+
+        $result = $backend->getChangesForCalendar($id, $currentToken, 1, 2);
+
+        // according to RFC6578 Section 3.6, the result including syncToken must correpsond to one time (syncToken=8 here)
+        $this->assertEquals([
+            'syncToken' => 8,
+            'modified' => [],
+            'deleted' => [],
+            'added' => ['todo7.ics', 'todo8.ics'],
+            'result_truncated' => true,
+        ], $result);
+
+        $currentToken = $result['syncToken'];
+
+        $result = $backend->getChangesForCalendar($id, $currentToken, 1, 2);
+
+        $this->assertEquals([
+            'syncToken' => 9,
+            'modified' => [],
+            'deleted' => [],
+            'added' => ['todo9.ics'],
+        ], $result);
     }
 
     /**

--- a/tests/Sabre/DAV/Sync/MockSyncCollection.php
+++ b/tests/Sabre/DAV/Sync/MockSyncCollection.php
@@ -127,6 +127,8 @@ class MockSyncCollection extends DAV\SimpleCollection implements ISyncCollection
         $modified = [];
         $deleted = [];
 
+        $result_truncated = false;
+
         foreach ($this->changeLog as $token => $change) {
             if ($token > $syncToken) {
                 $added = array_merge($added, $change['added']);
@@ -143,6 +145,7 @@ class MockSyncCollection extends DAV\SimpleCollection implements ISyncCollection
                     if (0 === $left) {
                         break;
                     }
+                    $result_truncated = true;
                     if ($left < 0) {
                         $modified = array_slice($modified, 0, $left);
                     }
@@ -158,11 +161,17 @@ class MockSyncCollection extends DAV\SimpleCollection implements ISyncCollection
             }
         }
 
-        return [
+        $result = [
             'syncToken' => $this->token,
             'added' => $added,
             'modified' => $modified,
             'deleted' => $deleted,
         ];
+
+        if ($result_truncated) {
+            $result += ['result_truncated' => $result_truncated];
+        }
+
+        return $result;
     }
 }

--- a/tests/Sabre/DAV/Sync/PluginTest.php
+++ b/tests/Sabre/DAV/Sync/PluginTest.php
@@ -224,13 +224,18 @@ BLA;
         );
 
         $responses = $multiStatus->getResponses();
-        $this->assertEquals(1, count($responses), 'We expected exactly 1 {DAV:}response');
+        $this->assertEquals(2, count($responses), 'We expected exactly 2 {DAV:}responses');
 
         $response = $responses[0];
 
         $this->assertEquals('404', $response->getHttpStatus());
         $this->assertEquals('/coll/file3.txt', $response->getHref());
         $this->assertEquals([], $response->getResponseProperties());
+
+        $response = $responses[1];
+
+        $this->assertEquals('507', $response->getHttpStatus());
+        $this->assertEquals('/coll/', $response->getHref());
     }
 
     public function testSubsequentSyncSyncCollectionDepthFallBack()


### PR DESCRIPTION
Hi,

I altered some codes to make CalDAV sync properly even when limit is set. Changes is mainly as below two:

- Return syncToken when limit is set. Current code returns the syncToken of the latest server state. Changed to return the syncToken corresponding to the truncated sync result.
  - When the result limit is designated by client, this is not the consistent as returned result.
  - In [RFC6578 section 3.6](https://tools.ietf.org/html/rfc6578#section-3.6): `the DAV:sync-token value returned in the response MUST represent the correct state for the partial set of
   changes returned.`
  - So, when truncation occurs, client will miss the truncated event even in later sync, since the client receives the syncToken of not received events, and asks server to send the event after that next time.
- When response is truncated, 507 record is added to the response.
  - Defined in [RFC6578 section 3.6](https://tools.ietf.org/html/rfc6578#section-3.6)
  - With this, the client can recognize the result is truncated, and can retry until the client syncs with the latest state.
  - For example, OneCalendar requested once I press sync button in current code. In new code OneCalendar repeated until it reaches the latest state, so I just had to press sync button once.

OneCalendar in Windows Store sends a request with limit 1000, and I checked using this, but with the changes below:

- I defanged the code of Authentication because OneCalendar did not send a request with Digest authentication.
- I overrided the limit to 2 in `lib/CalDAV/Backend/PDO.php` while testing.

I think CardDAV has the same issue, but I did not find an environment to reproduce and test with, so I wrote a code only for CalDAV, PDO backend.

This is my first code around WebDAV, so could you take a look including my understanding is correct or not?