### PR TITLE
Fix #1254 - add missing MIME-Version header

### DIFF
--- a/lib/CalDAV/Schedule/IMipPlugin.php
+++ b/lib/CalDAV/Schedule/IMipPlugin.php
@@ -130,6 +130,7 @@ class IMipPlugin extends DAV\ServerPlugin
         $headers = [
             'Reply-To: '.$sender,
             'From: '.$iTipMessage->senderName.' <'.$this->senderEmail.'>',
+            'MIME-Version: 1.0',
             'Content-Type: text/calendar; charset=UTF-8; method='.$iTipMessage->method,
         ];
         if (DAV\Server::$exposeVersion) {

--- a/tests/Sabre/CalDAV/Schedule/IMipPluginTest.php
+++ b/tests/Sabre/CalDAV/Schedule/IMipPluginTest.php
@@ -50,6 +50,7 @@ ICS;
                 'headers' => [
                     'Reply-To: Sender <sender@example.org>',
                     'From: Sender <system@example.org>',
+                    'MIME-Version: 1.0',
                     'Content-Type: text/calendar; charset=UTF-8; method=REPLY',
                     'X-Sabre-Version: '.\Sabre\DAV\Version::VERSION,
                 ],
@@ -118,6 +119,7 @@ ICS;
                 'headers' => [
                     'Reply-To: Sender <sender@example.org>',
                     'From: Sender <system@example.org>',
+                    'MIME-Version: 1.0',
                     'Content-Type: text/calendar; charset=UTF-8; method=REQUEST',
                     'X-Sabre-Version: '.\Sabre\DAV\Version::VERSION,
                 ],
@@ -158,6 +160,7 @@ ICS;
                 'headers' => [
                     'Reply-To: Sender <sender@example.org>',
                     'From: Sender <system@example.org>',
+                    'MIME-Version: 1.0',
                     'Content-Type: text/calendar; charset=UTF-8; method=CANCEL',
                     'X-Sabre-Version: '.\Sabre\DAV\Version::VERSION,
                 ],


### PR DESCRIPTION
When IMipPlugin is used to send emails for an event, it adds a Content-Type header, but forgets to add also a MIME-Version header which can trigger some spam engines. This PR fixes it and will address #1254 .