### PR TITLE
Bump minimum php-cs-fixer version and adjust format of comment

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "ext-json": "*"
     },
     "require-dev" : {
-        "friendsofphp/php-cs-fixer": "~2.16.1",
+        "friendsofphp/php-cs-fixer": "^2.16.3",
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit" : "^7.5 || ^8.5 || ^9.0",
         "evert/phpdoc-md" : "~0.1.0",

--- a/examples/groupwareserver.php
+++ b/examples/groupwareserver.php
@@ -12,7 +12,7 @@
  * statement.
  */
 
-/**
+/*
  * UTC or GMT is easy to work with, and usually recommended for any
  * application.
  */


### PR DESCRIPTION
Fixes #1266 

See issue  https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/4933

Recent patch releases of `php-cs-fixer` have "fixed" the processing of comments at the top of the file (before any code) and now a 2nd comment is not considered part of the header. If the comment is about ordinary code (not about a variable) then the starting `/**` gets changes to `/*` (like it does if it occurs further down in the code)

`v2.16.2` onward behaves differently to `v2.16.1`. There is now `v2.16.3` so require at least a minimum of that `php-cs-fixer` patch level. And apply the comment change that it wants.