### PR TITLE
The baseUri was missing when generating the lock responses. This was …

### DIFF
--- a/lib/DAV/Locks/Plugin.php
+++ b/lib/DAV/Locks/Plugin.php
@@ -371,7 +371,7 @@ class Plugin extends DAV\ServerPlugin
     {
         return $this->server->xml->write('{DAV:}prop', [
             '{DAV:}lockdiscovery' => new DAV\Xml\Property\LockDiscovery([$lockInfo]),
-        ]);
+        ], $this->server->getBaseUri());
     }
 
     /**

--- a/tests/Sabre/DAV/AbstractServer.php
+++ b/tests/Sabre/DAV/AbstractServer.php
@@ -14,7 +14,7 @@ abstract class AbstractServer extends \PHPUnit\Framework\TestCase
     protected $response;
     protected $request;
     /**
-     * @var Sabre\DAV\Server
+     * @var \Sabre\DAV\Server
      */
     protected $server;
     protected $tempDir = SABRE_TEMPDIR;


### PR DESCRIPTION
…leading to wrong responses.