### PR TITLE
Avoid invalid time-range

### DIFF
--- a/lib/CalDAV/Backend/PDO.php
+++ b/lib/CalDAV/Backend/PDO.php
@@ -787,6 +787,16 @@ SQL
             if ('VEVENT' == $componentType && isset($filters['comp-filters'][0]['time-range'])) {
                 $timeRange = $filters['comp-filters'][0]['time-range'];
 
+                if (!is_array($timeRange)) {
+                    $timeRange = [];
+                }
+
+                foreach (['start', 'end'] as $value) {
+                    if (!array_key_exists($value, $timeRange)) {
+                        $timeRange[$value] = false;
+                    }
+                }
+
                 // If start time OR the end time is not specified, we can do a
                 // 100% accurate mysql query.
                 if (!$filters['prop-filters'] && !$filters['comp-filters'][0]['comp-filters'] && !$filters['comp-filters'][0]['prop-filters'] && (!$timeRange['start'] || !$timeRange['end'])) {

--- a/tests/Sabre/CalDAV/Backend/AbstractPDOTest.php
+++ b/tests/Sabre/CalDAV/Backend/AbstractPDOTest.php
@@ -780,7 +780,7 @@ abstract class AbstractPDOTest extends \PHPUnit\Framework\TestCase
         ], $backend->calendarQuery([1, 1], $filters));
     }
 
-    public function testCalendarQueryTimeRangeNoEnd()
+    public function testCalendarQueryTimeRangeEndNull()
     {
         $backend = new PDO($this->pdo);
         $backend->createCalendarObject([1, 1], 'todo', "BEGIN:VCALENDAR\r\nBEGIN:VTODO\r\nEND:VTODO\r\nEND:VCALENDAR\r\n");
@@ -809,6 +809,94 @@ abstract class AbstractPDOTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals([
             'event2',
         ], $backend->calendarQuery([1, 1], $filters));
+    }
+
+    public function testCalendarQueryTimeRangeNoEnd()
+    {
+        $backend = new PDO($this->pdo);
+        $backend->createCalendarObject([1, 1], 'todo', "BEGIN:VCALENDAR\r\nBEGIN:VTODO\r\nEND:VTODO\r\nEND:VCALENDAR\r\n");
+        $backend->createCalendarObject([1, 1], 'event', "BEGIN:VCALENDAR\r\nBEGIN:VEVENT\r\nDTSTART:20120101\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n");
+        $backend->createCalendarObject([1, 1], 'event2', "BEGIN:VCALENDAR\r\nBEGIN:VEVENT\r\nDTSTART:20120103\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n");
+
+        $filters = [
+            'name' => 'VCALENDAR',
+            'comp-filters' => [
+                [
+                    'name' => 'VEVENT',
+                    'comp-filters' => [],
+                    'prop-filters' => [],
+                    'is-not-defined' => false,
+                    'time-range' => [
+                        'start' => new \DateTime('20120102'),
+                    ],
+                ],
+            ],
+            'prop-filters' => [],
+            'is-not-defined' => false,
+            'time-range' => null,
+        ];
+
+        $this->assertEquals([
+            'event2',
+        ], $backend->calendarQuery([1, 1], $filters));
+    }
+
+    public function testCalendarQueryTimeRangeNoStart()
+    {
+        $backend = new PDO($this->pdo);
+        $backend->createCalendarObject([1, 1], 'todo', "BEGIN:VCALENDAR\r\nBEGIN:VTODO\r\nEND:VTODO\r\nEND:VCALENDAR\r\n");
+        $backend->createCalendarObject([1, 1], 'event', "BEGIN:VCALENDAR\r\nBEGIN:VEVENT\r\nDTSTART:20120101\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n");
+        $backend->createCalendarObject([1, 1], 'event2', "BEGIN:VCALENDAR\r\nBEGIN:VEVENT\r\nDTSTART:20120103\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n");
+
+        $filters = [
+            'name' => 'VCALENDAR',
+            'comp-filters' => [
+                [
+                    'name' => 'VEVENT',
+                    'comp-filters' => [],
+                    'prop-filters' => [],
+                    'is-not-defined' => false,
+                    'time-range' => [
+                        'end' => new \DateTime('20120102'),
+                    ],
+                ],
+            ],
+            'prop-filters' => [],
+            'is-not-defined' => false,
+            'time-range' => null,
+        ];
+
+        $this->assertEquals([
+            'event',
+        ], $backend->calendarQuery([1, 1], $filters));
+    }
+
+    public function testCalendarQueryTimeRangeNotSpecified()
+    {
+        $backend = new PDO($this->pdo);
+        $backend->createCalendarObject([1, 1], 'todo', "BEGIN:VCALENDAR\r\nBEGIN:VTODO\r\nEND:VTODO\r\nEND:VCALENDAR\r\n");
+        $backend->createCalendarObject([1, 1], 'event', "BEGIN:VCALENDAR\r\nBEGIN:VEVENT\r\nDTSTART:20120101\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n");
+        $backend->createCalendarObject([1, 1], 'event2', "BEGIN:VCALENDAR\r\nBEGIN:VEVENT\r\nDTSTART:20120103\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n");
+
+        $filters = [
+            'name' => 'VCALENDAR',
+            'comp-filters' => [
+                [
+                    'name' => 'VEVENT',
+                    'comp-filters' => [],
+                    'prop-filters' => [],
+                    'is-not-defined' => false,
+                    'time-range' => false,
+                ],
+            ],
+            'prop-filters' => [],
+            'is-not-defined' => false,
+            'time-range' => null,
+        ];
+
+        $result = $backend->calendarQuery([1, 1], $filters);
+        $this->assertTrue(in_array('event', $result));
+        $this->assertTrue(in_array('event2', $result));
     }
 
     public function testGetChanges()


### PR DESCRIPTION
Issue: https://github.com/sabre-io/Baikal/issues/929

It is possible to call `calendarQuery` with all sorts of not-so-valid/expected stuff in `$filters` array.

In particular, it seems that `time-range` gets a boolean value (probably `false` ?) in some cases, rather than being an array with some of `start` and `end` keys. That causes PHP 7.4 to complain when we try to access things like `$timeRange['start']`

When this happens, set it to an array. If `start` or `end` is missing, set to `false` so that these keys exist for the later code to process.

Note: there are plenty of other assumptions made about what exists `$filters` array passed to `calendarQuery`, but I am not attempting to fix the whole universe. For example:
```
        // if no filters were specified, we don't need to filter after a query
        if (!$filters['prop-filters'] && !$filters['comp-filters']) {
            $requirePostFilter = false;
        }
```
If you specify `comp-filters` but leave out `prop-filters` completely, then a message will be emitted on PHP 7.4 complaining about the reference to non-existent array key `prop-filters`.

There are lots of places that can have `array_key_exists` or `isset` checks, and either fill in empty default values or `throw new \InvalidArgumentException`