### PR TITLE
Release 4.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 ChangeLog
 =========
 
+4.1.1 (2020-07-13)
+-------------------------
+* Fix PHPdoc of Tree:move method
+* Allow using custom SAPI implementations
+* Include baseUri in lock responses
+
 4.1.0 (2020-03-20)
 -------------------------
 * Support PHP 7.4

--- a/lib/DAV/Version.php
+++ b/lib/DAV/Version.php
@@ -16,5 +16,5 @@ class Version
     /**
      * Full version number.
      */
-    public const VERSION = '4.1.0';
+    public const VERSION = '4.1.1';
 }


### PR DESCRIPTION
Includes:
#1269 Tree::move method returns no int
#1271 Allow to use custom SAPI implementations
#1273 Include baseUri in lock responses

And CI will run with the newly-released https://github.com/sabre-io/vobject/releases/tag/4.3.1 and demonstrate that the unit test warning has gone.