### PR TITLE
A more secure and generalized approach for PDO Basic Auth Backend

### DIFF
--- a/lib/DAV/Auth/Backend/PDOBasicAuth.php
+++ b/lib/DAV/Auth/Backend/PDOBasicAuth.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Sabre\DAV\Auth\Backend;
+
+/**
+ * This is an authentication backend that uses a database to manage passwords.
+ *
+ * @copyright Copyright (C) fruux GmbH (https://fruux.com/)
+ * @author Evert Pot (http://evertpot.com/)
+ * @license http://sabre.io/license/ Modified BSD License
+ */
+class PDOBasicAuth extends AbstractBasic {
+
+    /**
+     * Reference to PDO connection
+     *
+     * @var PDO
+     */
+    protected $pdo;
+
+    /**
+     * PDO table name we'll be using
+     *
+     * @var string
+     */
+    protected $tableName;
+
+    /**
+     * PDO digest column name we'll be using
+     * (i.e. digest, password, password_hash)
+     *
+     * @var string
+     */
+    protected $digestColumn;
+
+    /**
+     * Digest prefix:
+     * if the backend you are using for is prefixing 
+     * your password hashes set this option to your prefix to 
+     * cut it off before verfiying 
+     *
+     * @var string
+     */
+    protected $digestPrefix;
+
+
+    /**
+     * Creates the backend object.
+     *
+     * If the filename argument is passed in, it will parse out the specified file fist.
+     *
+     * @param \PDO $pdo
+     */
+    function __construct(\PDO $pdo, array $options = []) {
+
+	    $this->pdo = $pdo;
+		if(isset($options['tableName'])){
+			$this->tableName = $options['tableName'];
+		}
+		else{
+			$this->tableName = 'user';
+		}
+		if(isset($options['digestColumn'])){
+			$this->digestColumn = $options['digestColumn'];
+		}
+		else{
+			$this->digestColumn = 'digest';
+		}
+		if(isset($options['digestPrefix'])){
+			$this->digestPrefix = $options['digestPrefix'];
+		}
+    }
+
+    /**
+     * Validates a username and password
+     *
+     * This method should return true or false depending on if login
+     * succeeded.
+     *
+     * @param string $username
+     * @param string $password
+     * @return bool
+     */
+	function validateUserPass($username, $password){
+		$stmt = $this->pdo->prepare('SELECT ' . $this->digestColumn . ' FROM ' . $this->tableName . ' WHERE email = ?');
+		$stmt->execute([$username]);
+		$result = $stmt->fetchAll();
+
+		if (!count($result)) {
+			return false;
+		}
+
+		$digest = $result[0]['password'];
+
+		if(isset($this->digestPrefix)){
+			$digest = substr($digest, strlen($this->digestPrefix));
+		}
+
+		if (password_verify($password, $digest)){
+			return true;
+		}
+		return false;
+	}
+
+}
+


### PR DESCRIPTION
Hello,

motivated by the currently insecure password hashing in sabre/dav (as discussed in [Baikal #514](https://github.com/sabre-io/Baikal/issues/514)), I developed this PR. It allows administrators to choose any password hashing function supported by `password_verify()` (among others, this includes  the state of the art hashes bcrypt and Argon).

Furthermore this PR is about generalized approach on using the PDO Backend with Basic Authentication. The supplied Backend allows the customization of:
* tableName :  table in which the user information is stored,
* digestColumn : table column in which the digest/passoword hash is stored,
* digestPrefix : if your user management Backend prefixes your digests, you can specify it so it will be removed before verfiying it.

I think this covers a large part of use cases and would benefit a lot of sabre/dav users.

Best Regards.