### PR TITLE
RFC 4918 compliance: Remove unexpected propstat

### DIFF
--- a/lib/DAV/Xml/Element/Response.php
+++ b/lib/DAV/Xml/Element/Response.php
@@ -112,12 +112,14 @@ class Response implements Element
      */
     public function xmlSerialize(Writer $writer)
     {
+        $empty = true;
+
         if ($status = $this->getHTTPStatus()) {
+            $empty = false;
             $writer->writeElement('{DAV:}status', 'HTTP/1.1 '.$status.' '.\Sabre\HTTP\Response::$statusCodes[$status]);
         }
         $writer->writeElement('{DAV:}href', $writer->contextUri.\Sabre\HTTP\encodePath($this->getHref()));
 
-        $empty = true;
 
         foreach ($this->getResponseProperties() as $status => $properties) {
             // Skipping empty lists

--- a/tests/Sabre/DAVACL/PrincipalMatchTest.php
+++ b/tests/Sabre/DAVACL/PrincipalMatchTest.php
@@ -30,10 +30,6 @@ XML;
 <d:multistatus xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns">
     <d:status>HTTP/1.1 200 OK</d:status>
     <d:href>/principals/user1</d:href>
-    <d:propstat>
-        <d:prop/>
-        <d:status>HTTP/1.1 418 I'm a teapot</d:status>
-    </d:propstat>
 </d:multistatus>
 XML;
 


### PR DESCRIPTION
According to RFC 4918, there is two types of response elements:

See section 14.24, response XML Element:
```
<!ELEMENT response (href, ((href*, status)|(propstat+)),
                       error?, responsedescription? , location?) >
```

Type 1 contains one or more href and one status child elements.

Type 2 contains one href and one or more propstat child elements.

Both types may contain further optional elements.

For Type 1, sabre/dav inserts a spurious propstat element, which violated the element definition by RFC 4918.

You can also see examples for such type 1 response elements in RFC 4918, for example 9.6.2 example:

```
>>Request
DELETE /container/ HTTP/1.1 Host: www.example.com

>>Response
HTTP/1.1 207 Multi-Status
Content-Type: application/xml; charset="utf-8" Content-Length: xxxx
<?xml version="1.0" encoding="utf-8" ?> <d:multistatus xmlns:d="DAV:">
<d:response> <d:href>http://www.example.com/container/resource3</d:href> <d:status>HTTP/1.1 423 Locked</d:status> <d:error><d:lock-token-submitted/></d:error>
       </d:response>
     </d:multistatus>
```

This issue may cause failure with clients that validate the received XML against the RFC specification.