### PR TITLE
Test with PHP8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,14 @@ env:
 
 matrix:
   include:
+    - name: 'PHP8'
+      dist: focal
+      php: nightly
+      addons:
+        postgresql: '12'
+      env:
+        - RUN_PHPCSFIXER="FALSE"
+        - REPORT_COVERAGE="FALSE"
     - name: 'PHPStan'
       php: 7.4
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ env:
     - SABRE_MYSQLUSER="root"
     - SABRE_MYSQLPASS=""
     - SABRE_MYSQLDSN="mysql:host=127.0.0.1;dbname=sabredav_test"
+    - RUN_PHPCSFIXER="TRUE"
+    - RUN_PHPUNIT="TRUE"
     - RUN_PHPSTAN="FALSE"
   matrix:
     - PREFER_LOWEST="" TEST_DEPS="" REPORT_COVERAGE="TRUE" WITH_COVERAGE="--coverage-clover=coverage.xml"
@@ -26,6 +28,8 @@ matrix:
     - name: 'PHPStan'
       php: 7.4
       env:
+        - RUN_PHPCSFIXER="FALSE"
+        - RUN_PHPUNIT="FALSE"
         - RUN_PHPSTAN="TRUE"
         - REPORT_COVERAGE="FALSE"
     - name: 'Test with streaming propfind'
@@ -43,15 +47,16 @@ before_script:
   - mysql -u root -h 127.0.0.1 -e 'create database sabredav_test'
   - psql -c "create database sabredav_test" -U postgres
   - psql -c "create user sabredav with PASSWORD 'sabredav';GRANT ALL PRIVILEGES ON DATABASE sabredav_test TO sabredav" -U postgres
+  - if [ $RUN_PHPCSFIXER == "FALSE" ]; then composer remove --dev friendsofphp/php-cs-fixer; fi
   - composer update $PREFER_LOWEST
 
 addons:
   postgresql: "9.5"
 
 script:
-  - if [ $RUN_PHPSTAN == "FALSE" ]; then php vendor/bin/php-cs-fixer fix --dry-run --diff; fi
-  - if [ $RUN_PHPSTAN == "FALSE" ]; then php vendor/bin/phpunit --configuration tests/phpunit.xml $WITH_COVERAGE $TEST_DEPS; fi
-  - if [ $RUN_PHPSTAN == "FALSE"  ]; then rm -f ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini; fi
+  - if [ $RUN_PHPCSFIXER == "TRUE" ]; then php vendor/bin/php-cs-fixer fix --dry-run --diff; fi
+  - if [ $RUN_PHPUNIT == "TRUE" ]; then php vendor/bin/phpunit --configuration tests/phpunit.xml $WITH_COVERAGE $TEST_DEPS; fi
+  - if [ $RUN_PHPUNIT == "TRUE"  ]; then rm -f ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini; fi
   - if [ $RUN_PHPSTAN == "TRUE" ]; then composer phpstan; fi
 
 after_success:

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.1.0",
+        "php": "^7.1.0 || ^8.0",
         "sabre/vobject": "^4.2.1",
         "sabre/event" : "^5.0",
         "sabre/xml"  : "^2.0.1",

--- a/lib/CalDAV/Schedule/Plugin.php
+++ b/lib/CalDAV/Schedule/Plugin.php
@@ -609,7 +609,7 @@ class Plugin extends ServerPlugin
      * @param bool             $modified  a marker to indicate that the original object
      *                                    modified by this process
      */
-    protected function processICalendarChange($oldObject = null, VCalendar $newObject, array $addresses, array $ignore = [], &$modified = false)
+    protected function processICalendarChange($oldObject, VCalendar $newObject, array $addresses, array $ignore = [], &$modified = false)
     {
         $broker = new ITip\Broker();
         $messages = $broker->parseEvent($newObject, $addresses, $oldObject);


### PR DESCRIPTION
1) sort out variables in `.travis.yml` for selecting to run php-cs-fixer, phpunit and phpstan
2) Add a matrix entry to run just phpunit on Ubuntu 20.04 "focal" with "nightly" PHP (which is the way to get PHP 8.0 at the moment) Note: `focal` does not have `postgresql` available by default, so `addons` `postgresql` needs to be specified in `.travis.yml`
3) When not running php-cs-fixer, explicitly remove it from `composer.json` (because php-cs-fixer does not yet support PHP 8.0, so composer cannot sort out dependencies if we have PHP 8.0 and php-cs-fixer 2.* together)
4) Remove default value from oldObject parameter to processICalendarChange
fixes error https://travis-ci.org/github/sabre-io/dav/jobs/732659316 
```
1) Sabre\CalDAV\Schedule\DeliverNewEventTest::testDelivery
Required parameter $newObject follows optional parameter $oldObject
/home/travis/build/sabre-io/dav/lib/CalDAV/Schedule/Plugin.php:612
/home/travis/build/sabre-io/dav/tests/Sabre/DAVServerTest.php:144
/home/travis/build/sabre-io/dav/tests/Sabre/DAVServerTest.php:119
/home/travis/build/sabre-io/dav/tests/Sabre/CalDAV/Schedule/DeliverNewEventTest.php:19
```
