### PR TITLE
CalDAV/PropFilter: set empty array as default value for time-range

### DIFF
--- a/lib/CalDAV/Xml/Filter/PropFilter.php
+++ b/lib/CalDAV/Xml/Filter/PropFilter.php
@@ -53,7 +53,7 @@ class PropFilter implements XmlDeserializable
             'is-not-defined' => false,
             'param-filters' => [],
             'text-match' => null,
-            'time-range' => false,
+            'time-range' => [],
         ];
 
         $att = $reader->parseAttributes();

--- a/tests/Sabre/CalDAV/Xml/Request/CalendarQueryReportTest.php
+++ b/tests/Sabre/CalDAV/Xml/Request/CalendarQueryReportTest.php
@@ -137,14 +137,14 @@ XML;
                         [
                             'name' => 'UID',
                             'is-not-defined' => false,
-                            'time-range' => false,
+                            'time-range' => [],
                             'text-match' => null,
                             'param-filters' => [],
                         ],
                         [
                             'name' => 'X-PROP',
                             'is-not-defined' => false,
-                            'time-range' => false,
+                            'time-range' => [],
                             'text-match' => null,
                             'param-filters' => [
                                 [
@@ -171,7 +171,7 @@ XML;
                         [
                             'name' => 'X-PROP2',
                             'is-not-defined' => true,
-                            'time-range' => false,
+                            'time-range' => [],
                             'text-match' => null,
                             'param-filters' => [],
                         ],
@@ -188,7 +188,7 @@ XML;
                         [
                             'name' => 'X-PROP4',
                             'is-not-defined' => false,
-                            'time-range' => false,
+                            'time-range' => [],
                             'text-match' => [
                                 'negate-condition' => false,
                                 'collation' => 'i;ascii-casemap',


### PR DESCRIPTION
This changes the default value of `time-range` in CalDAV prop filters from `false` (not matching RFC 4791 https://tools.ietf.org/html/rfc4791#section-9.9) to an empty array.

This closes #1299.