### PR TITLE
CI changes for composer 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,10 +26,8 @@ env:
 matrix:
   include:
     - name: 'PHP8'
-      dist: focal
+      dist: bionic
       php: nightly
-      addons:
-        postgresql: '12'
       env:
         - RUN_PHPCSFIXER="FALSE"
         - REPORT_COVERAGE="FALSE"

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ before_script:
   - mysql -u root -h 127.0.0.1 -e 'create database sabredav_test'
   - psql -c "create database sabredav_test" -U postgres
   - psql -c "create user sabredav with PASSWORD 'sabredav';GRANT ALL PRIVILEGES ON DATABASE sabredav_test TO sabredav" -U postgres
-  - if [ $RUN_PHPCSFIXER == "FALSE" ]; then composer remove --dev friendsofphp/php-cs-fixer; fi
+  - if [ $RUN_PHPCSFIXER == "FALSE" ]; then composer remove --no-update --dev friendsofphp/php-cs-fixer; fi
   - composer update $PREFER_LOWEST
 
 addons:

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "ext-json": "*"
     },
     "require-dev" : {
-        "friendsofphp/php-cs-fixer": "^2.16.3",
+        "friendsofphp/php-cs-fixer": "^2.16.7",
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit" : "^7.5 || ^8.5 || ^9.0",
         "evert/phpdoc-md" : "~0.1.0",


### PR DESCRIPTION
1) fix Travis CI like in https://github.com/sabre-io/skel/pull/17 and the other sabre-io repos
2) postgres on Travis focal (Ubuntu 20.04) is not working. I tried various hints that I found in online discussions, but still no joy. Change the CI for PHP8 to use bionic (Ubuntu 18.04) - that has postgres 12 already pre-installed and ready-to-go.

and this should fetch the new https://github.com/sabre-io/vobject/releases/tag/4.3.3 in CI which will prevent 1 possible unit test error.
