### PR TITLE
Support multiget addressdata filter

### DIFF
--- a/lib/CardDAV/Plugin.php
+++ b/lib/CardDAV/Plugin.php
@@ -242,7 +242,8 @@ class Plugin extends DAV\ServerPlugin
             if (isset($props['200']['{'.self::NS_CARDDAV.'}address-data'])) {
                 $props['200']['{'.self::NS_CARDDAV.'}address-data'] = $this->convertVCard(
                     $props[200]['{'.self::NS_CARDDAV.'}address-data'],
-                    $vcardType
+                    $vcardType,
+                    $report->addressDataProperties
                 );
             }
             $propertyList[] = $props;

--- a/lib/DAV/Xml/Element/Response.php
+++ b/lib/DAV/Xml/Element/Response.php
@@ -112,12 +112,14 @@ class Response implements Element
      */
     public function xmlSerialize(Writer $writer)
     {
+        $empty = true;
+
         if ($status = $this->getHTTPStatus()) {
+            $empty = false;
             $writer->writeElement('{DAV:}status', 'HTTP/1.1 '.$status.' '.\Sabre\HTTP\Response::$statusCodes[$status]);
         }
         $writer->writeElement('{DAV:}href', $writer->contextUri.\Sabre\HTTP\encodePath($this->getHref()));
 
-        $empty = true;
 
         foreach ($this->getResponseProperties() as $status => $properties) {
             // Skipping empty lists

--- a/lib/DAV/Xml/Element/Response.php
+++ b/lib/DAV/Xml/Element/Response.php
@@ -120,7 +120,6 @@ class Response implements Element
         }
         $writer->writeElement('{DAV:}href', $writer->contextUri.\Sabre\HTTP\encodePath($this->getHref()));
 
-
         foreach ($this->getResponseProperties() as $status => $properties) {
             // Skipping empty lists
             if (!$properties || (!ctype_digit($status) && !is_int($status))) {

--- a/tests/Sabre/DAVACL/PrincipalMatchTest.php
+++ b/tests/Sabre/DAVACL/PrincipalMatchTest.php
@@ -30,10 +30,6 @@ XML;
 <d:multistatus xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns">
     <d:status>HTTP/1.1 200 OK</d:status>
     <d:href>/principals/user1</d:href>
-    <d:propstat>
-        <d:prop/>
-        <d:status>HTTP/1.1 418 I'm a teapot</d:status>
-    </d:propstat>
 </d:multistatus>
 XML;
 


### PR DESCRIPTION
Support filtering returned address object properties in multiget report
    
Analog to addressbook-query report, multiget also supports returning only partial address objects. This can be useful to carddav clients to have fast syncs by excluding large properties like PHOTO and fetching those only when needed.
