### PR TITLE
Latest php cs fixer 2.17.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ matrix:
   include:
     - name: 'PHP8'
       dist: bionic
-      php: nightly
+      php: 8.0
       env:
         - RUN_PHPCSFIXER="FALSE"
         - REPORT_COVERAGE="FALSE"

--- a/bin/build.php
+++ b/bin/build.php
@@ -32,7 +32,7 @@ if ($argc > 2) {
 
 if (!isset($tasks[$currentTask])) {
     echo 'Task not found: ',  $currentTask, "\n";
-    die(1);
+    exit(1);
 }
 
 // Creating the dependency graph
@@ -43,7 +43,7 @@ while (count($oldTaskList) > 0) {
     foreach ($oldTaskList as $task => $foo) {
         if (!isset($tasks[$task])) {
             echo 'Dependency not found: '.$task, "\n";
-            die(1);
+            exit(1);
         }
         $dependencies = $tasks[$task];
 
@@ -107,7 +107,7 @@ function test()
     system(__DIR__.'/phpunit --configuration '.$baseDir.'/tests/phpunit.xml.dist --stop-on-failure', $code);
     if (0 != $code) {
         echo "PHPUnit reported error code $code\n";
-        die(1);
+        exit(1);
     }
 }
 
@@ -139,7 +139,7 @@ function buildzip()
     system('cd build/SabreDAV; composer install -n', $code);
     if (0 !== $code) {
         echo "Composer reported error code $code\n";
-        die(1);
+        exit(1);
     }
 
     echo "  Removing pointless files\n";

--- a/bin/migrateto20.php
+++ b/bin/migrateto20.php
@@ -72,7 +72,7 @@ switch ($driver) {
         break;
     default:
         echo 'Error: unsupported driver: '.$driver."\n";
-        die(-1);
+        exit(-1);
 }
 
 foreach (['calendar', 'addressbook'] as $itemType) {
@@ -130,7 +130,6 @@ foreach (['calendar', 'addressbook'] as $itemType) {
                 break;
 
             case 'sqlite':
-
                 $pdo->exec("ALTER TABLE $tableName RENAME TO $tableNameOld");
 
                 switch ($itemType) {
@@ -370,7 +369,6 @@ CREATE TABLE cards (
             break;
 
         case 'sqlite':
-
             $pdo->exec('
 CREATE TABLE cards (
     id integer primary key asc,
@@ -395,7 +393,6 @@ CREATE TABLE cards (
             break;
 
         case 'sqlite':
-
             $pdo->exec('
                 ALTER TABLE cards ADD etag text;
                 ALTER TABLE cards ADD size integer;

--- a/bin/migrateto21.php
+++ b/bin/migrateto21.php
@@ -73,7 +73,7 @@ switch ($driver) {
         break;
     default:
         echo 'Error: unsupported driver: '.$driver."\n";
-        die(-1);
+        exit(-1);
 }
 
 echo "Upgrading 'calendarobjects'\n";

--- a/bin/migrateto30.php
+++ b/bin/migrateto30.php
@@ -72,7 +72,7 @@ switch ($driver) {
         break;
     default:
         echo 'Error: unsupported driver: '.$driver."\n";
-        die(-1);
+        exit(-1);
 }
 
 echo "Upgrading 'propertystorage'\n";

--- a/bin/migrateto32.php
+++ b/bin/migrateto32.php
@@ -75,7 +75,7 @@ switch ($driver) {
         break;
     default:
         echo 'Error: unsupported driver: '.$driver."\n";
-        die(-1);
+        exit(-1);
 }
 
 echo "Creating 'calendarinstances'\n";

--- a/bin/sabredav.php
+++ b/bin/sabredav.php
@@ -20,7 +20,7 @@ class CliLog
 $log = new CliLog();
 
 if ('cli-server' !== php_sapi_name()) {
-    die('This script is intended to run on the built-in php webserver');
+    exit('This script is intended to run on the built-in php webserver');
 }
 
 // Finding composer

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "ext-json": "*"
     },
     "require-dev" : {
-        "friendsofphp/php-cs-fixer": "^2.16.7",
+        "friendsofphp/php-cs-fixer": "^2.17.1",
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit" : "^7.5 || ^8.5 || ^9.0",
         "evert/phpdoc-md" : "~0.1.0",

--- a/lib/CalDAV/Backend/PDO.php
+++ b/lib/CalDAV/Backend/PDO.php
@@ -7,6 +7,7 @@ namespace Sabre\CalDAV\Backend;
 use Sabre\CalDAV;
 use Sabre\DAV;
 use Sabre\DAV\Exception\Forbidden;
+use Sabre\DAV\PropPatch;
 use Sabre\DAV\Xml\Element\Sharee;
 use Sabre\VObject;
 
@@ -289,7 +290,7 @@ SQL
      *
      * @param mixed $calendarId
      */
-    public function updateCalendar($calendarId, \Sabre\DAV\PropPatch $propPatch)
+    public function updateCalendar($calendarId, PropPatch $propPatch)
     {
         if (!is_array($calendarId)) {
             throw new \InvalidArgumentException('The value passed to $calendarId is expected to be an array with a calendarId and an instanceId');
@@ -1153,10 +1154,9 @@ SQL;
      *
      * Read the PropPatch documentation for more info and examples.
      *
-     * @param mixed                $subscriptionId
-     * @param \Sabre\DAV\PropPatch $propPatch
+     * @param mixed $subscriptionId
      */
-    public function updateSubscription($subscriptionId, DAV\PropPatch $propPatch)
+    public function updateSubscription($subscriptionId, PropPatch $propPatch)
     {
         $supportedProperties = array_keys($this->subscriptionPropertyMap);
         $supportedProperties[] = '{http://calendarserver.org/ns/}source';

--- a/lib/CalDAV/CalendarQueryValidator.php
+++ b/lib/CalDAV/CalendarQueryValidator.php
@@ -258,11 +258,9 @@ class CalendarQueryValidator
             case 'VEVENT':
             case 'VTODO':
             case 'VJOURNAL':
-
                 return $component->isInTimeRange($start, $end);
 
             case 'VALARM':
-
                 // If the valarm is wrapped in a recurring event, we need to
                 // expand the recursions, and validate each.
                 //

--- a/lib/CalDAV/SharingPlugin.php
+++ b/lib/CalDAV/SharingPlugin.php
@@ -213,7 +213,6 @@ class SharingPlugin extends DAV\ServerPlugin
             // Both the DAV:share-resource and CALENDARSERVER:share requests
             // behave identically.
             case '{'.Plugin::NS_CALENDARSERVER.'}share':
-
                 $sharingPlugin = $this->server->getPlugin('sharing');
                 $sharingPlugin->shareResource($path, $message->sharees);
 
@@ -228,7 +227,6 @@ class SharingPlugin extends DAV\ServerPlugin
             // The invite-reply document is sent when the user replies to an
             // invitation of a calendar share.
             case '{'.Plugin::NS_CALENDARSERVER.'}invite-reply':
-
                 // This only works on the calendar-home-root node.
                 if (!$node instanceof CalendarHome) {
                     return;
@@ -272,7 +270,6 @@ class SharingPlugin extends DAV\ServerPlugin
                 return false;
 
             case '{'.Plugin::NS_CALENDARSERVER.'}publish-calendar':
-
                 // We can only deal with IShareableCalendar objects
                 if (!$node instanceof ISharedCalendar) {
                     return;
@@ -300,7 +297,6 @@ class SharingPlugin extends DAV\ServerPlugin
                 return false;
 
             case '{'.Plugin::NS_CALENDARSERVER.'}unpublish-calendar':
-
                 // We can only deal with IShareableCalendar objects
                 if (!$node instanceof ISharedCalendar) {
                     return;

--- a/lib/CalDAV/Xml/Filter/CalendarData.php
+++ b/lib/CalDAV/Xml/Filter/CalendarData.php
@@ -60,7 +60,6 @@ class CalendarData implements XmlDeserializable
         foreach ($elems as $elem) {
             switch ($elem['name']) {
                 case '{'.Plugin::NS_CALDAV.'}expand':
-
                     $result['expand'] = [
                         'start' => isset($elem['attributes']['start']) ? DateTimeParser::parseDateTime($elem['attributes']['start']) : null,
                         'end' => isset($elem['attributes']['end']) ? DateTimeParser::parseDateTime($elem['attributes']['end']) : null,

--- a/lib/CardDAV/Backend/PDO.php
+++ b/lib/CardDAV/Backend/PDO.php
@@ -6,6 +6,7 @@ namespace Sabre\CardDAV\Backend;
 
 use Sabre\CardDAV;
 use Sabre\DAV;
+use Sabre\DAV\PropPatch;
 
 /**
  * PDO CardDAV backend.
@@ -93,7 +94,7 @@ class PDO extends AbstractBackend implements SyncSupport
      *
      * @param string $addressBookId
      */
-    public function updateAddressBook($addressBookId, \Sabre\DAV\PropPatch $propPatch)
+    public function updateAddressBook($addressBookId, PropPatch $propPatch)
     {
         $supportedProperties = [
             '{DAV:}displayname',

--- a/lib/CardDAV/Xml/Request/AddressBookQueryReport.php
+++ b/lib/CardDAV/Xml/Request/AddressBookQueryReport.php
@@ -146,7 +146,6 @@ class AddressBookQueryReport implements XmlDeserializable
                     }
                     break;
                 case '{'.Plugin::NS_CARDDAV.'}filter':
-
                     if (!is_null($newProps['filters'])) {
                         throw new BadRequest('You can only include 1 {'.Plugin::NS_CARDDAV.'}filter element');
                     }

--- a/lib/DAV/Browser/Plugin.php
+++ b/lib/DAV/Browser/Plugin.php
@@ -209,7 +209,6 @@ class Plugin extends DAV\ServerPlugin
 
                 // @codeCoverageIgnoreStart
                 case 'put':
-
                     if ($_FILES) {
                         $file = current($_FILES);
                     } else {

--- a/lib/DAV/Exception/MethodNotAllowed.php
+++ b/lib/DAV/Exception/MethodNotAllowed.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Sabre\DAV\Exception;
 
 use Sabre\DAV;
+use Sabre\DAV\Server;
 
 /**
  * MethodNotAllowed.
@@ -34,7 +35,7 @@ class MethodNotAllowed extends DAV\Exception
      *
      * @return array
      */
-    public function getHTTPHeaders(\Sabre\DAV\Server $server)
+    public function getHTTPHeaders(Server $server)
     {
         $methods = $server->getAllowedMethods($server->getRequestUri());
 

--- a/lib/DAV/Server.php
+++ b/lib/DAV/Server.php
@@ -25,8 +25,8 @@ use Sabre\Xml\Writer;
  */
 class Server implements LoggerAwareInterface, EmitterInterface
 {
-    use WildcardEmitterTrait;
     use LoggerAwareTrait;
+    use WildcardEmitterTrait;
 
     /**
      * Infinity is used for some request supporting the HTTP Depth header and indicates that the operation should traverse the entire tree.

--- a/lib/DAV/Sharing/Plugin.php
+++ b/lib/DAV/Sharing/Plugin.php
@@ -179,7 +179,6 @@ class Plugin extends ServerPlugin
 
         switch ($documentType) {
             case '{DAV:}share-resource':
-
                 $this->shareResource($path, $message->sharees);
                 $response->setStatus(200);
                 // Adding this because sending a response body may cause issues,

--- a/lib/DAV/Xml/Property/GetLastModified.php
+++ b/lib/DAV/Xml/Property/GetLastModified.php
@@ -98,7 +98,6 @@ class GetLastModified implements Element
      */
     public static function xmlDeserialize(Reader $reader)
     {
-        return
-            new self(new DateTime($reader->parseInnerTree()));
+        return new self(new DateTime($reader->parseInnerTree()));
     }
 }

--- a/lib/DAV/Xml/Property/ResourceType.php
+++ b/lib/DAV/Xml/Property/ResourceType.php
@@ -94,8 +94,7 @@ class ResourceType extends Element\Elements implements HtmlOutput
      */
     public static function xmlDeserialize(Reader $reader)
     {
-        return
-            new self(parent::xmlDeserialize($reader));
+        return new self(parent::xmlDeserialize($reader));
     }
 
     /**

--- a/tests/Sabre/CalDAV/Backend/AbstractTest.php
+++ b/tests/Sabre/CalDAV/Backend/AbstractTest.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace Sabre\CalDAV\Backend;
 
-use
-    Sabre\DAV\PropPatch;
+use Sabre\DAV\PropPatch;
 
 class AbstractTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/Sabre/CalDAV/Backend/Mock.php
+++ b/tests/Sabre/CalDAV/Backend/Mock.php
@@ -6,6 +6,7 @@ namespace Sabre\CalDAV\Backend;
 
 use Sabre\CalDAV;
 use Sabre\DAV;
+use Sabre\DAV\PropPatch;
 
 class Mock extends AbstractBackend
 {
@@ -95,7 +96,7 @@ class Mock extends AbstractBackend
      *
      * @param mixed $calendarId
      */
-    public function updateCalendar($calendarId, \Sabre\DAV\PropPatch $propPatch)
+    public function updateCalendar($calendarId, PropPatch $propPatch)
     {
         $propPatch->handleRemaining(function ($props) use ($calendarId) {
             foreach ($this->calendars as $k => $calendar) {

--- a/tests/Sabre/DAV/HttpGetTest.php
+++ b/tests/Sabre/DAV/HttpGetTest.php
@@ -85,7 +85,7 @@ class HttpGetTest extends DAVServerTest
         $this->assertEquals(404, $response->getStatus());
     }
 
-    public function testGet404_aswell()
+    public function testGet404AsWell()
     {
         $request = new HTTP\Request('GET', '/file1/subfile');
         $response = $this->request($request);

--- a/tests/Sabre/DAV/Mock/Collection.php
+++ b/tests/Sabre/DAV/Mock/Collection.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Sabre\DAV\Mock;
 
 use Sabre\DAV;
+use Sabre\DAV\INode;
 
 /**
  * Mock Collection.
@@ -41,7 +42,7 @@ class Collection extends DAV\Collection
                 $this->children[] = new File($key, $value, $this);
             } elseif (is_array($value)) {
                 $this->children[] = new self($key, $value, $this);
-            } elseif ($value instanceof \Sabre\DAV\INode) {
+            } elseif ($value instanceof INode) {
                 $this->children[] = $value;
             } else {
                 throw new \InvalidArgumentException('Unknown value passed in $children');
@@ -113,7 +114,7 @@ class Collection extends DAV\Collection
     /**
      * Returns an array with all the child nodes.
      *
-     * @return \Sabre\DAV\INode[]
+     * @return INode[]
      */
     public function getChildren()
     {
@@ -123,7 +124,7 @@ class Collection extends DAV\Collection
     /**
      * Adds an already existing node to this collection.
      */
-    public function addNode(\Sabre\DAV\INode $node)
+    public function addNode(INode $node)
     {
         $this->children[] = $node;
     }

--- a/tests/Sabre/DAV/StringUtilTest.php
+++ b/tests/Sabre/DAV/StringUtilTest.php
@@ -84,7 +84,7 @@ class StringUtilTest extends \PHPUnit\Framework\TestCase
         StringUtil::textMatch('foobar', 'foo', 'i;octet', 'booh');
     }
 
-    public function testEnsureUTF8_ascii()
+    public function testEnsureUTF8Ascii()
     {
         $inputString = 'harkema';
         $outputString = 'harkema';
@@ -95,7 +95,7 @@ class StringUtilTest extends \PHPUnit\Framework\TestCase
         );
     }
 
-    public function testEnsureUTF8_latin1()
+    public function testEnsureUTF8Latin1()
     {
         $inputString = "m\xfcnster";
         $outputString = 'münster';
@@ -106,7 +106,7 @@ class StringUtilTest extends \PHPUnit\Framework\TestCase
         );
     }
 
-    public function testEnsureUTF8_utf8()
+    public function testEnsureUTF8UTF8()
     {
         $inputString = "m\xc3\xbcnster";
         $outputString = 'münster';

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -10,12 +10,6 @@
 >
 
   <testsuites>
-      <testsuite name="sabre-event">
-          <directory>../vendor/sabre/event/tests/</directory>
-      </testsuite>
-      <testsuite name="sabre-uri">
-          <directory>../vendor/sabre/uri/tests/</directory>
-      </testsuite>
       <testsuite name="sabre-xml">
         <directory>../vendor/sabre/xml/tests/Sabre/Xml/</directory>
       </testsuite>


### PR DESCRIPTION
PR #1314 got errors from php-cs-fixer because the latest php-cs-fixer finds more things.

1) Adjust the code for the latest php-cs-fixer and update the required version of php-cs-fixer in composer.json (we do not want to bother running some old version of that)

2) Explicitly select PHP 8.0 in CI

3) Remove test suites that have no tests folder - the latest version of phpunit checks and fails if there is a test suite mentioned in `phpunit.xml` that does not exist. The tests of `event` and `uri` have actually not been running inside `dav` CI for a few years. Now CI tells us about this. The tests for these repos were removed from the distribution a while ago, in PRs https://github.com/sabre-io/event/pull/54 and https://github.com/sabre-io/uri/pull/29

This gets CI green in `sabre-io/dav`. We can separately discuss if we really do want to be running those tests of `event` and `uri` inside `dav` CI. If so, we can revert those PRs, which will put the `tests` folder back into the distribution of those repos.