### PR TITLE
Properly fix "Trying to access array offset on value of type bool"

### DIFF
--- a/lib/CalDAV/Backend/PDO.php
+++ b/lib/CalDAV/Backend/PDO.php
@@ -790,7 +790,7 @@ SQL
                 // If start time OR the end time is not specified, we can do a
                 // 100% accurate mysql query.
                 if (!$filters['prop-filters'] && !$filters['comp-filters'][0]['comp-filters'] && !$filters['comp-filters'][0]['prop-filters'] && $timeRange) {
-                    if (!$timeRange['start'] || !$timeRange['end']) {
+                    if ((array_key_exists('start', $timeRange) && !$timeRange['start']) || (array_key_exists('end', $timeRange) && !$timeRange['end'])) {
                         $requirePostFilter = false;
                     }
                 }
@@ -812,11 +812,11 @@ SQL
             $values['componenttype'] = $componentType;
         }
 
-        if ($timeRange && $timeRange['start']) {
+        if ($timeRange && array_key_exists('start', $timeRange) && $timeRange['start']) {
             $query .= ' AND lastoccurence > :startdate';
             $values['startdate'] = $timeRange['start']->getTimeStamp();
         }
-        if ($timeRange && $timeRange['end']) {
+        if ($timeRange && array_key_exists('end', $timeRange) && $timeRange['end']) {
             $query .= ' AND firstoccurence < :enddate';
             $values['enddate'] = $timeRange['end']->getTimeStamp();
         }

--- a/lib/CalDAV/Backend/PDO.php
+++ b/lib/CalDAV/Backend/PDO.php
@@ -789,8 +789,10 @@ SQL
 
                 // If start time OR the end time is not specified, we can do a
                 // 100% accurate mysql query.
-                if (!$filters['prop-filters'] && !$filters['comp-filters'][0]['comp-filters'] && !$filters['comp-filters'][0]['prop-filters'] && (!$timeRange['start'] || !$timeRange['end'])) {
-                    $requirePostFilter = false;
+                if (!$filters['prop-filters'] && !$filters['comp-filters'][0]['comp-filters'] && !$filters['comp-filters'][0]['prop-filters'] && $timeRange) {
+                    if (!$timeRange['start'] || !$timeRange['end']) {
+                        $requirePostFilter = false;
+                    }
                 }
             }
         }

--- a/lib/CalDAV/CalendarQueryValidator.php
+++ b/lib/CalDAV/CalendarQueryValidator.php
@@ -69,7 +69,15 @@ class CalendarQueryValidator
 
             if ($filter['time-range']) {
                 foreach ($parent->{$filter['name']} as $subComponent) {
-                    if ($this->validateTimeRange($subComponent, $filter['time-range']['start'], $filter['time-range']['end'])) {
+                    $start = null;
+                    $end = null;
+                    if (array_key_exists('start', $filter['time-range'])) {
+                        $start = $filter['time-range']['start'];
+                    }
+                    if (array_key_exists('end', $filter['time-range'])) {
+                        $end = $filter['time-range']['end'];
+                    }
+                    if ($this->validateTimeRange($subComponent, $start, $end)) {
                         continue 2;
                     }
                 }

--- a/lib/CalDAV/CalendarQueryValidator.php
+++ b/lib/CalDAV/CalendarQueryValidator.php
@@ -138,7 +138,15 @@ class CalendarQueryValidator
 
             if ($filter['time-range']) {
                 foreach ($parent->{$filter['name']} as $subComponent) {
-                    if ($this->validateTimeRange($subComponent, $filter['time-range']['start'], $filter['time-range']['end'])) {
+                    $start = null;
+                    $end = null;
+                    if (array_key_exists('start', $filter['time-range'])) {
+                        $start = $filter['time-range']['start'];
+                    }
+                    if (array_key_exists('end', $filter['time-range'])) {
+                        $end = $filter['time-range']['end'];
+                    }
+                    if ($this->validateTimeRange($subComponent, $start, $end)) {
                         continue 2;
                     }
                 }

--- a/tests/Sabre/CalDAV/Backend/AbstractPDOTest.php
+++ b/tests/Sabre/CalDAV/Backend/AbstractPDOTest.php
@@ -780,7 +780,7 @@ abstract class AbstractPDOTest extends \PHPUnit\Framework\TestCase
         ], $backend->calendarQuery([1, 1], $filters));
     }
 
-    public function testCalendarQueryTimeRangeNoEnd()
+    public function testCalendarQueryTimeRangeEndNull()
     {
         $backend = new PDO($this->pdo);
         $backend->createCalendarObject([1, 1], 'todo', "BEGIN:VCALENDAR\r\nBEGIN:VTODO\r\nEND:VTODO\r\nEND:VCALENDAR\r\n");
@@ -809,6 +809,94 @@ abstract class AbstractPDOTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals([
             'event2',
         ], $backend->calendarQuery([1, 1], $filters));
+    }
+
+    public function testCalendarQueryTimeRangeNoEnd()
+    {
+        $backend = new PDO($this->pdo);
+        $backend->createCalendarObject([1, 1], 'todo', "BEGIN:VCALENDAR\r\nBEGIN:VTODO\r\nEND:VTODO\r\nEND:VCALENDAR\r\n");
+        $backend->createCalendarObject([1, 1], 'event', "BEGIN:VCALENDAR\r\nBEGIN:VEVENT\r\nDTSTART:20120101\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n");
+        $backend->createCalendarObject([1, 1], 'event2', "BEGIN:VCALENDAR\r\nBEGIN:VEVENT\r\nDTSTART:20120103\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n");
+
+        $filters = [
+            'name' => 'VCALENDAR',
+            'comp-filters' => [
+                [
+                    'name' => 'VEVENT',
+                    'comp-filters' => [],
+                    'prop-filters' => [],
+                    'is-not-defined' => false,
+                    'time-range' => [
+                        'start' => new \DateTime('20120102'),
+                    ],
+                ],
+            ],
+            'prop-filters' => [],
+            'is-not-defined' => false,
+            'time-range' => null,
+        ];
+
+        $this->assertEquals([
+            'event2',
+        ], $backend->calendarQuery([1, 1], $filters));
+    }
+
+    public function testCalendarQueryTimeRangeNoStart()
+    {
+        $backend = new PDO($this->pdo);
+        $backend->createCalendarObject([1, 1], 'todo', "BEGIN:VCALENDAR\r\nBEGIN:VTODO\r\nEND:VTODO\r\nEND:VCALENDAR\r\n");
+        $backend->createCalendarObject([1, 1], 'event', "BEGIN:VCALENDAR\r\nBEGIN:VEVENT\r\nDTSTART:20120101\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n");
+        $backend->createCalendarObject([1, 1], 'event2', "BEGIN:VCALENDAR\r\nBEGIN:VEVENT\r\nDTSTART:20120103\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n");
+
+        $filters = [
+            'name' => 'VCALENDAR',
+            'comp-filters' => [
+                [
+                    'name' => 'VEVENT',
+                    'comp-filters' => [],
+                    'prop-filters' => [],
+                    'is-not-defined' => false,
+                    'time-range' => [
+                        'end' => new \DateTime('20120102'),
+                    ],
+                ],
+            ],
+            'prop-filters' => [],
+            'is-not-defined' => false,
+            'time-range' => null,
+        ];
+
+        $this->assertEquals([
+            'event',
+        ], $backend->calendarQuery([1, 1], $filters));
+    }
+
+    public function testCalendarQueryTimeRangeNotSpecified()
+    {
+        $backend = new PDO($this->pdo);
+        $backend->createCalendarObject([1, 1], 'todo', "BEGIN:VCALENDAR\r\nBEGIN:VTODO\r\nEND:VTODO\r\nEND:VCALENDAR\r\n");
+        $backend->createCalendarObject([1, 1], 'event', "BEGIN:VCALENDAR\r\nBEGIN:VEVENT\r\nDTSTART:20120101\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n");
+        $backend->createCalendarObject([1, 1], 'event2', "BEGIN:VCALENDAR\r\nBEGIN:VEVENT\r\nDTSTART:20120103\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n");
+
+        $filters = [
+            'name' => 'VCALENDAR',
+            'comp-filters' => [
+                [
+                    'name' => 'VEVENT',
+                    'comp-filters' => [],
+                    'prop-filters' => [],
+                    'is-not-defined' => false,
+                    'time-range' => false,
+                ],
+            ],
+            'prop-filters' => [],
+            'is-not-defined' => false,
+            'time-range' => null,
+        ];
+
+        $result = $backend->calendarQuery([1, 1], $filters);
+        $this->assertTrue(in_array('event', $result));
+        $this->assertTrue(in_array('event2', $result));
     }
 
     public function testGetChanges()


### PR DESCRIPTION
Since php74, we must properly ensure that array is not null/false before checking any of its column ranges

This properly fixes the "Trying to access array offset on value of type bool" when no time range is specified to filter our calendar events. It also preserves the accurate filtering query when time range is specified