### PR TITLE
Test code is not part of vobject distribution - do not run vobject tests in CI

### DIFF
--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -16,9 +16,6 @@
       <testsuite name="sabre-http">
           <directory>../vendor/sabre/http/tests/HTTP</directory>
       </testsuite>
-      <testsuite name="sabre-vobject">
-          <directory>../vendor/sabre/vobject/tests/VObject</directory>
-      </testsuite>
 
       <testsuite name="sabre-dav">
           <directory>Sabre/DAV</directory>


### PR DESCRIPTION
Issue #1327 

Why do we run the unit tests of the dependencies in the CI here in `sabre/dav` ?
