### PR TITLE
feat: Added plugin config option in browser plugin

### DIFF
--- a/lib/DAV/Browser/Plugin.php
+++ b/lib/DAV/Browser/Plugin.php
@@ -144,6 +144,19 @@ class Plugin extends DAV\ServerPlugin
                 $response->setBody(
                     $this->generatePluginListing()
                 );
+            case 'pluginConfigs':
+                if (!isset($getVars['pluginName'])){ 
+                  $response->setStatus(400);
+                  $response->setBody('Missing pluginName query param');
+                  return false;
+                }
+                $response->setStatus(200);
+                $response->setHeader('Content-Type', 'text/html; charset=utf-8');
+
+                $response->setBody(
+                    $this->generatePluginConfigs($getVars['pluginName'])
+                );
+
 
                 return false;
         }
@@ -386,6 +399,9 @@ class Plugin extends DAV\ServerPlugin
             if (isset($info['link']) && $info['link']) {
                 $html .= '<a href="'.$this->escapeHTML($info['link']).'"><span class="oi" data-glyph="book"></span></a>';
             }
+            if (isset($info['config']) && $info['config']) {
+                $html .= '<a href="?sabreAction=pluginConfig&pluginName='.$this->escapeHTML($info['name']).'"><span style="padding-left: 0.25rem" class="oi" data-glyph="cog"></span></a>';
+            }
             $html .= '</td></tr>';
         }
         $html .= '</table>';
@@ -394,6 +410,28 @@ class Plugin extends DAV\ServerPlugin
         /* Start of generating actions */
 
         $html .= $this->generateFooter();
+
+        return $html;
+    }
+
+    /**
+     * Generates the optional 'plugins' configuration page if one is available
+     *
+     * @param string pluginName
+     * @return string
+     */
+    public function generatePluginConfigs($pluginName)
+    {
+        $html = '';
+        foreach ($this->server->getPlugins() as $plugin) {
+            $info = $plugin->getPluginInfo();
+            if (isset($info['config']) && $info['config'] && $info['name'] == $pluginName) {
+              $html = $this->generateHeader(sprintf('Plugin - %s', $info['name']));
+              $html .= $plugin->getConfigBrowser();
+              $html .= $this->generateFooter();
+              break;
+            }
+        }
 
         return $html;
     }

--- a/lib/DAV/ServerPlugin.php
+++ b/lib/DAV/ServerPlugin.php
@@ -100,6 +100,15 @@ abstract class ServerPlugin
             'name' => $this->getPluginName(),
             'description' => null,
             'link' => null,
+            'config' => null
         ];
+    }
+
+    /**
+     * Returns a html to display an optional configuration page for the plugin
+     * @return array
+     */
+    public function getConfigBrowser() {
+      return '';
     }
 }

--- a/tests/Sabre/DAV/Browser/PluginTest.php
+++ b/tests/Sabre/DAV/Browser/PluginTest.php
@@ -182,4 +182,10 @@ class PluginTest extends DAV\AbstractServer
 
         $this->assertEquals(404, $this->response->getStatus(), 'Error: '.$this->response->getBodyAsString());
     }
+    public function testGetPluginConfig(){
+      $request = new HTTP\Request('GET', '/?sabreAction=pluginConfigs&pluginName=browser');
+      $this->server->httpRequest = $request;
+      $this->server->exec();
+      $this->assertEquals(200, $this->response->getStatus(), 'Error: '.$this->response->getBodyAsString());
+    }
 }

--- a/tests/Sabre/DAV/ServerPluginTest.php
+++ b/tests/Sabre/DAV/ServerPluginTest.php
@@ -32,6 +32,7 @@ class ServerPluginTest extends AbstractServer
                 'name' => 'Sabre\DAV\ServerPluginMock',
                 'description' => null,
                 'link' => null,
+                'config' => null,
             ], $p->getPluginInfo()
         );
     }


### PR DESCRIPTION
Context: Allows creating a customization configuration page for plugins. 

The following steps must be done to configure the page. 
  - The plugin must implement the `getConfigBrowser` method. The method should return a raw html page.
  - Update the plugin metadata with `config => true` 
    ```
      function getPluginInfo() {
          return [
            'name'        => $this->getPluginName(),
            'description' => 'The plugin provides synchronization between remote storages and iCal events',
            'link'        => 'https://git.aerex.me/Aerex/baikal-storage-plugin',
            'config'      => true
          ];
        }
    ```
After the following steps are made A cog wheel will appear besides the documentation icon



![plugins_config](https://user-images.githubusercontent.com/5360960/108302544-ce34be80-7169-11eb-8d94-066d2df5553d.png)
![plugins_page](https://user-images.githubusercontent.com/5360960/108302547-cecd5500-7169-11eb-8f11-4ec0bdabe322.png)
