### PR TITLE
Fix: don't remove lock on dir when deleting a child node

### DIFF
--- a/lib/DAV/Locks/Plugin.php
+++ b/lib/DAV/Locks/Plugin.php
@@ -295,6 +295,10 @@ class Plugin extends DAV\ServerPlugin
     {
         $locks = $this->getLocks($path, $includeChildren = true);
         foreach ($locks as $lock) {
+            // don't delete a lock on a parent dir
+            if (0 !== strpos($lock->uri, $path)) {
+                continue;
+            }
             $this->unlockNode($path, $lock);
         }
     }


### PR DESCRIPTION
Current behavior:
1) lock /somedir/
2) delete /somedir/somefile.txt (with token)
3) put /somedir/newfile.txt (with token)
   => ERROR precondition failed

Expected/Fixed behavior:
Step 3) should be executed under the LOCK.