### PR TITLE
Fix propfind type of subnodes with depth >= 1

### DIFF
--- a/lib/DAV/Server.php
+++ b/lib/DAV/Server.php
@@ -895,7 +895,7 @@ class Server implements LoggerAwareInterface, EmitterInterface
         }
 
         $propertyNames = $propFind->getRequestedProperties();
-        $propFindType = !empty($propertyNames) ? PropFind::NORMAL : PropFind::ALLPROPS;
+        $propFindType = !$propFind->isAllProps() ? PropFind::NORMAL : PropFind::ALLPROPS;
 
         foreach ($this->tree->getChildren($path) as $childNode) {
             if ('' !== $path) {

--- a/tests/Sabre/DAV/AbstractServer.php
+++ b/tests/Sabre/DAV/AbstractServer.php
@@ -42,6 +42,16 @@ abstract class AbstractServer extends \PHPUnit\Framework\TestCase
         return new FS\Directory(SABRE_TEMPDIR);
     }
 
+    protected function getSanitizedBody()
+    {
+        return preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", 'xmlns\\1="urn:DAV"', $this->response->getBodyAsString());
+    }
+
+    protected function getSanitizedBodyAsXml()
+    {
+        return simplexml_load_string($this->getSanitizedBody());
+    }
+
     private function deleteTree($path, $deleteRoot = true)
     {
         foreach (scandir($path) as $node) {

--- a/tests/Sabre/DAV/Locks/PluginTest.php
+++ b/tests/Sabre/DAV/Locks/PluginTest.php
@@ -77,8 +77,7 @@ class PluginTest extends DAV\AbstractServer
 
         $this->assertEquals(200, $this->response->status, 'Got an incorrect status back. Response body: '.$this->response->getBodyAsString());
 
-        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", 'xmlns\\1="urn:DAV"', $this->response->getBodyAsString());
-        $xml = simplexml_load_string($body);
+        $xml = $this->getSanitizedBodyAsXml();
         $xml->registerXPathNamespace('d', 'urn:DAV');
 
         $elements = [
@@ -128,8 +127,7 @@ class PluginTest extends DAV\AbstractServer
 
         $this->assertEquals(200, $this->response->status, 'Got an incorrect status back. Response body: '.$this->response->getBodyAsString());
 
-        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", 'xmlns\\1="urn:DAV"', $this->response->getBodyAsString());
-        $xml = simplexml_load_string($body);
+        $xml = $this->getSanitizedBodyAsXml();
         $xml->registerXPathNamespace('d', 'urn:DAV');
 
         $lockRoot = $xml->xpath('/d:prop/d:lockdiscovery/d:activelock/d:lockroot/d:href');

--- a/tests/Sabre/DAV/ServerPropsInfiniteDepthTest.php
+++ b/tests/Sabre/DAV/ServerPropsInfiniteDepthTest.php
@@ -120,8 +120,7 @@ class ServerPropsInfiniteDepthTest extends AbstractServer
 
         $this->sendRequest($xml);
 
-        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", 'xmlns\\1="urn:DAV"', $this->response->getBodyAsString());
-        $xml = simplexml_load_string($body);
+        $xml = $this->getSanitizedBodyAsXml();
         $xml->registerXPathNamespace('d', 'urn:DAV');
 
         $data = $xml->xpath('/d:multistatus/d:response/d:propstat/d:prop/d:lockdiscovery');
@@ -138,7 +137,7 @@ class ServerPropsInfiniteDepthTest extends AbstractServer
 </d:propfind>';
 
         $this->sendRequest($xml);
-        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", 'xmlns\\1="urn:DAV"', $this->response->getBodyAsString());
+        $body = $this->getSanitizedBody();
         $xml = simplexml_load_string($body);
         $xml->registerXPathNamespace('d', 'urn:DAV');
         $pathTests = [
@@ -168,7 +167,7 @@ class ServerPropsInfiniteDepthTest extends AbstractServer
 </d:propfind>';
 
         $this->sendRequest($xml);
-        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", 'xmlns\\1="urn:DAV"', $this->response->getBodyAsString());
+        $body = $this->getSanitizedBody();
         $xml = simplexml_load_string($body);
         $xml->registerXPathNamespace('d', 'urn:DAV');
         $pathTests = [

--- a/tests/Sabre/DAV/ServerPropsTest.php
+++ b/tests/Sabre/DAV/ServerPropsTest.php
@@ -55,8 +55,7 @@ class ServerPropsTest extends AbstractServer
             $this->response->getHeaders()
          );
 
-        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", 'xmlns\\1="urn:DAV"', $this->response->getBodyAsString());
-        $xml = simplexml_load_string($body);
+        $xml = $this->getSanitizedBodyAsXml();
         $xml->registerXPathNamespace('d', 'urn:DAV');
 
         list($data) = $xml->xpath('/d:multistatus/d:response/d:href');
@@ -85,8 +84,7 @@ class ServerPropsTest extends AbstractServer
             $this->response->getHeaders()
          );
 
-        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", 'xmlns\\1="urn:DAV"', $this->response->getBodyAsString());
-        $xml = simplexml_load_string($body);
+        $xml = $this->getSanitizedBodyAsXml();
         $xml->registerXPathNamespace('d', 'urn:DAV');
 
         $data = $xml->xpath('/d:multistatus/d:response/d:propstat/d:prop/d:ishidden');
@@ -111,8 +109,7 @@ class ServerPropsTest extends AbstractServer
             $this->response->getHeaders()
          );
 
-        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", 'xmlns\\1="urn:DAV"', $this->response->getBodyAsString());
-        $xml = simplexml_load_string($body);
+        $xml = $this->getSanitizedBodyAsXml();
         $xml->registerXPathNamespace('d', 'urn:DAV');
 
         list($data) = $xml->xpath('/d:multistatus/d:response/d:href');
@@ -133,8 +130,7 @@ class ServerPropsTest extends AbstractServer
 
         $this->sendRequest($xml);
 
-        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", 'xmlns\\1="urn:DAV"', $this->response->getBodyAsString());
-        $xml = simplexml_load_string($body);
+        $xml = $this->getSanitizedBodyAsXml();
         $xml->registerXPathNamespace('d', 'urn:DAV');
 
         $data = $xml->xpath('/d:multistatus/d:response/d:propstat/d:prop/d:supportedlock/d:lockentry');
@@ -167,8 +163,7 @@ class ServerPropsTest extends AbstractServer
 
         $this->sendRequest($xml);
 
-        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", 'xmlns\\1="urn:DAV"', $this->response->getBodyAsString());
-        $xml = simplexml_load_string($body);
+        $xml = $this->getSanitizedBodyAsXml();
         $xml->registerXPathNamespace('d', 'urn:DAV');
 
         $data = $xml->xpath('/d:multistatus/d:response/d:propstat/d:prop/d:lockdiscovery');
@@ -185,7 +180,7 @@ class ServerPropsTest extends AbstractServer
 </d:propfind>';
 
         $this->sendRequest($xml);
-        $body = preg_replace("/xmlns(:[A-Za-z0-9_])?=(\"|\')DAV:(\"|\')/", 'xmlns\\1="urn:DAV"', $this->response->getBodyAsString());
+        $body = $this->getSanitizedBody();
         $xml = simplexml_load_string($body);
         $xml->registerXPathNamespace('d', 'urn:DAV');
         $pathTests = [

--- a/tests/Sabre/DAV/ServerPropsTest.php
+++ b/tests/Sabre/DAV/ServerPropsTest.php
@@ -92,7 +92,6 @@ class ServerPropsTest extends AbstractServer
         $data = $xml->xpath('/d:multistatus/d:response/d:propstat/d:prop/d:ishidden');
         $this->assertEquals(5, count($data), 'Response should contain 5 elements');
 
-        $data = $xml->xpath('/d:multistatus/d:response/d:propstat/d:prop/d:ishidden');
         foreach ($data as $prop) {
             $this->assertEquals('1', $prop[0]);
         }


### PR DESCRIPTION
With properties manually added in a plugin using the `propFind` event like in this example: https://github.com/sabre-io/dav/issues/482 and with depth >= 1, the subnodes' propfind's type was incorrectly deduced.
This resulted in custom properties only being added to the first node and not on the subnodes.