### PR TITLE
Fix deprecated usages on PHP 8.1

### DIFF
--- a/lib/DAV/Xml/Element/Response.php
+++ b/lib/DAV/Xml/Element/Response.php
@@ -121,7 +121,7 @@ class Response implements Element
 
         foreach ($this->getResponseProperties() as $status => $properties) {
             // Skipping empty lists
-            if (!$properties || (!ctype_digit($status) && !is_int($status))) {
+            if (!$properties || (!is_int($status) && !ctype_digit($status))) {
                 continue;
             }
             $empty = false;


### PR DESCRIPTION
Fixes following errors encountered on a PHP 8.1 RC environment.

```
==> Error E_DEPRECATED in ... generated by file /var/glpi/vendor/sabre/dav/lib/DAV/Xml/Element/Response.php on line 124:
ctype_digit(): Argument of type int will be interpreted as string in the future
```