### PR TITLE
Make sure a {DAV:}prop is not empty

### DIFF
--- a/lib/DAV/Xml/Element/Response.php
+++ b/lib/DAV/Xml/Element/Response.php
@@ -186,8 +186,21 @@ class Response implements Element
 
                 return [];
             }
+
+            if (!$reader->read()) {
+                $reader->next();
+
+                return [];
+            }
+
+            if (Reader::END_ELEMENT === $reader->nodeType) {
+                $reader->next();
+
+                return [];
+            }
+
             $values = [];
-            $reader->read();
+
             do {
                 if (Reader::ELEMENT === $reader->nodeType) {
                     $clark = $reader->getClark();
@@ -199,9 +212,12 @@ class Response implements Element
                         $values[$clark] = $reader->parseCurrentElement()['value'];
                     }
                 } else {
-                    $reader->read();
+                    if (!$reader->read()) {
+                        break;
+                    }
                 }
             } while (Reader::END_ELEMENT !== $reader->nodeType);
+
             $reader->read();
 
             return $values;

--- a/tests/Sabre/DAV/Xml/Element/ResponseTest.php
+++ b/tests/Sabre/DAV/Xml/Element/ResponseTest.php
@@ -301,4 +301,35 @@ class ResponseTest extends DAV\Xml\XmlTest
             $result['value']
         );
     }
+
+    public function testDeserializeNoProperties()
+    {
+        $xml = '<?xml version="1.0"?>
+<d:response xmlns:d="DAV:">
+  <d:href>/uri</d:href>
+  <d:propstat>
+    <d:prop></d:prop>
+    <d:status>HTTP/1.1 200 OK</d:status>
+  </d:propstat>  
+  <d:propstat>
+    <d:prop>
+        <d:foo />
+    </d:prop>
+    <d:status>HTTP/1.1 404 OK</d:status>
+  </d:propstat>
+</d:response>
+';
+
+        $result = $this->parse($xml, [
+            '{DAV:}response' => Response::class,
+        ]);
+        $this->assertEquals(
+            new Response('/uri', [
+                '404' => [
+                    '{DAV:}foo' => null,
+                ],
+            ]),
+            $result['value']
+        );
+    }
 }


### PR DESCRIPTION
Port https://github.com/sabre-io/xml/pull/158 to sabre/dav prop parser. 

```
<?xml version="1.0" encoding="UTF-8"?>
<D:multistatus xmlns:D="DAV:">
  <D:response>
    <D:href>/alfresco/webdav/Webdav/</D:href>
    <D:propstat>
      <D:prop></D:prop>
      <D:status>HTTP/1.1 200 OK</D:status>
    </D:propstat>
    <D:propstat>
      <D:prop>
        <quota-available-bytes/></D:prop>
      <D:status>HTTP/1.1 404 Not Found</D:status>
    </D:propstat>
  </D:response>
</D:multistatus>
```

Is a multistatus propfind response by Alfresco. XMLReader or Sabre/XML is having troubles to parse the empty <prop></prop> element. 

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/3902676/61731726-5e3b3800-ad7c-11e9-83d8-f0e21d9885d6.png)  | ![image](https://user-images.githubusercontent.com/3902676/61731665-3fd53c80-ad7c-11e9-8627-623a21f4bbb5.png) |
|  Faulty response (with no elements in propstat) | Correct response (with 1+ elements in propstat) |










Report: https://github.com/nextcloud/server/issues/16471