### PR TITLE
Sabre/Xml tests are no longer published

### DIFF
--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -10,9 +10,6 @@
 >
 
   <testsuites>
-      <testsuite name="sabre-xml">
-        <directory>../vendor/sabre/xml/tests/Sabre/Xml/</directory>
-      </testsuite>
       <testsuite name="sabre-http">
           <directory>../vendor/sabre/http/tests/HTTP</directory>
       </testsuite>


### PR DESCRIPTION
https://github.com/sabre-io/xml/pull/195 added `.gitattributes` that specified:
```
/tests export-ignore
```

So `vendor/sabre/xml` no longer contains the `tests` folder.

Remove it from `phpunit.xml` - we can't run those tests here in `dav`

CI is currently red in `master` because of this.