### PR TITLE
Revert PR 1365 "add params for put interface"

### DIFF
--- a/lib/CalDAV/CalendarObject.php
+++ b/lib/CalDAV/CalendarObject.php
@@ -92,7 +92,6 @@ class CalendarObject extends \Sabre\DAV\File implements ICalendarObject, \Sabre\
      * Updates the ICalendar-formatted object.
      *
      * @param string|resource $calendarData
-     * @param object|null     $params
      *
      * @return string
      */

--- a/lib/CalDAV/CalendarObject.php
+++ b/lib/CalDAV/CalendarObject.php
@@ -95,7 +95,7 @@ class CalendarObject extends \Sabre\DAV\File implements ICalendarObject, \Sabre\
      *
      * @return string
      */
-    public function put($calendarData, $params = null)
+    public function put($calendarData,$params=null)
     {
         if (is_resource($calendarData)) {
             $calendarData = stream_get_contents($calendarData);

--- a/lib/CalDAV/CalendarObject.php
+++ b/lib/CalDAV/CalendarObject.php
@@ -95,7 +95,7 @@ class CalendarObject extends \Sabre\DAV\File implements ICalendarObject, \Sabre\
      *
      * @return string
      */
-    public function put($calendarData,$params=null)
+    public function put($calendarData)
     {
         if (is_resource($calendarData)) {
             $calendarData = stream_get_contents($calendarData);

--- a/lib/CalDAV/Schedule/SchedulingObject.php
+++ b/lib/CalDAV/Schedule/SchedulingObject.php
@@ -59,7 +59,6 @@ class SchedulingObject extends \Sabre\CalDAV\CalendarObject implements IScheduli
      * Updates the ICalendar-formatted object.
      *
      * @param string|resource $calendarData
-     * @param object|null     $params
      *
      * @return string
      */

--- a/lib/CalDAV/Schedule/SchedulingObject.php
+++ b/lib/CalDAV/Schedule/SchedulingObject.php
@@ -62,7 +62,7 @@ class SchedulingObject extends \Sabre\CalDAV\CalendarObject implements IScheduli
      *
      * @return string
      */
-    public function put($calendarData, $params = null)
+    public function put($calendarData,$params=null)
     {
         throw new MethodNotAllowed('Updating scheduling objects is not supported');
     }

--- a/lib/CalDAV/Schedule/SchedulingObject.php
+++ b/lib/CalDAV/Schedule/SchedulingObject.php
@@ -62,7 +62,7 @@ class SchedulingObject extends \Sabre\CalDAV\CalendarObject implements IScheduli
      *
      * @return string
      */
-    public function put($calendarData,$params=null)
+    public function put($calendarData)
     {
         throw new MethodNotAllowed('Updating scheduling objects is not supported');
     }

--- a/lib/CardDAV/Card.php
+++ b/lib/CardDAV/Card.php
@@ -78,8 +78,7 @@ class Card extends DAV\File implements ICard, DAVACL\IACL
     /**
      * Updates the VCard-formatted object.
      *
-     * @param string      $cardData
-     * @param object|null $params
+     * @param string $cardData
      *
      * @return string|null
      */

--- a/lib/CardDAV/Card.php
+++ b/lib/CardDAV/Card.php
@@ -82,7 +82,7 @@ class Card extends DAV\File implements ICard, DAVACL\IACL
      *
      * @return string|null
      */
-    public function put($cardData, $params = null)
+    public function put($cardData,$params=null)
     {
         if (is_resource($cardData)) {
             $cardData = stream_get_contents($cardData);

--- a/lib/CardDAV/Card.php
+++ b/lib/CardDAV/Card.php
@@ -82,7 +82,7 @@ class Card extends DAV\File implements ICard, DAVACL\IACL
      *
      * @return string|null
      */
-    public function put($cardData,$params=null)
+    public function put($cardData)
     {
         if (is_resource($cardData)) {
             $cardData = stream_get_contents($cardData);

--- a/lib/DAV/CorePlugin.php
+++ b/lib/DAV/CorePlugin.php
@@ -429,7 +429,7 @@ class CorePlugin extends ServerPlugin
     {
         $body = $request->getBodyAsStream();
         $path = $request->getPath();
-        $params = (object) ['versioning' => $request->getHeader('versioning')];
+        $params = (object) array('versioning' => $request->getHeader('versioning'));
 
         // Intercepting Content-Range
         if ($request->getHeader('Content-Range')) {
@@ -490,7 +490,7 @@ class CorePlugin extends ServerPlugin
             if (!($node instanceof IFile)) {
                 throw new Exception\Conflict('PUT is not allowed on non-files.');
             }
-            if (!$this->server->updateFile($path, $body, $etag, $params)) {
+            if (!$this->server->updateFile($path, $body, $etag,$params)) {
                 return false;
             }
 

--- a/lib/DAV/CorePlugin.php
+++ b/lib/DAV/CorePlugin.php
@@ -429,7 +429,6 @@ class CorePlugin extends ServerPlugin
     {
         $body = $request->getBodyAsStream();
         $path = $request->getPath();
-        $params = (object) array('versioning' => $request->getHeader('versioning'));
 
         // Intercepting Content-Range
         if ($request->getHeader('Content-Range')) {
@@ -490,7 +489,7 @@ class CorePlugin extends ServerPlugin
             if (!($node instanceof IFile)) {
                 throw new Exception\Conflict('PUT is not allowed on non-files.');
             }
-            if (!$this->server->updateFile($path, $body, $etag,$params)) {
+            if (!$this->server->updateFile($path, $body, $etag)) {
                 return false;
             }
 

--- a/lib/DAV/FS/File.php
+++ b/lib/DAV/FS/File.php
@@ -20,7 +20,7 @@ class File extends Node implements DAV\IFile
      *
      * @param resource $data
      */
-    public function put($data, $params = null)
+    public function put($data,$params=null)
     {
         file_put_contents($this->path, $data);
         clearstatcache(true, $this->path);

--- a/lib/DAV/FS/File.php
+++ b/lib/DAV/FS/File.php
@@ -20,7 +20,7 @@ class File extends Node implements DAV\IFile
      *
      * @param resource $data
      */
-    public function put($data,$params=null)
+    public function put($data)
     {
         file_put_contents($this->path, $data);
         clearstatcache(true, $this->path);

--- a/lib/DAV/FS/File.php
+++ b/lib/DAV/FS/File.php
@@ -18,8 +18,7 @@ class File extends Node implements DAV\IFile
     /**
      * Updates the data.
      *
-     * @param resource    $data
-     * @param object|null $params
+     * @param resource $data
      */
     public function put($data, $params = null)
     {

--- a/lib/DAV/FSExt/File.php
+++ b/lib/DAV/FSExt/File.php
@@ -25,7 +25,7 @@ class File extends Node implements DAV\PartialUpdate\IPatchSupport
      *
      * @return string
      */
-    public function put($data,$params=null)
+    public function put($data)
     {
         file_put_contents($this->path, $data);
         clearstatcache(true, $this->path);

--- a/lib/DAV/FSExt/File.php
+++ b/lib/DAV/FSExt/File.php
@@ -25,7 +25,7 @@ class File extends Node implements DAV\PartialUpdate\IPatchSupport
      *
      * @return string
      */
-    public function put($data, $params = null)
+    public function put($data,$params=null)
     {
         file_put_contents($this->path, $data);
         clearstatcache(true, $this->path);

--- a/lib/DAV/FSExt/File.php
+++ b/lib/DAV/FSExt/File.php
@@ -22,7 +22,6 @@ class File extends Node implements DAV\PartialUpdate\IPatchSupport
      * Data is a readable stream resource.
      *
      * @param resource|string $data
-     * @param object|null     $params
      *
      * @return string
      */

--- a/lib/DAV/File.php
+++ b/lib/DAV/File.php
@@ -34,7 +34,6 @@ abstract class File extends Node implements IFile
      * return an ETag, and just return null.
      *
      * @param string|resource $data
-     * @param object|null     $params
      *
      * @return string|null
      */

--- a/lib/DAV/File.php
+++ b/lib/DAV/File.php
@@ -37,7 +37,7 @@ abstract class File extends Node implements IFile
      *
      * @return string|null
      */
-    public function put($data,$params=null)
+    public function put($data)
     {
         throw new Exception\Forbidden('Permission denied to change data');
     }

--- a/lib/DAV/File.php
+++ b/lib/DAV/File.php
@@ -37,7 +37,7 @@ abstract class File extends Node implements IFile
      *
      * @return string|null
      */
-    public function put($data, $params = null)
+    public function put($data,$params=null)
     {
         throw new Exception\Forbidden('Permission denied to change data');
     }

--- a/lib/DAV/IFile.php
+++ b/lib/DAV/IFile.php
@@ -38,7 +38,7 @@ interface IFile extends INode
      *
      * @return string|null
      */
-    public function put($data,$params=null);
+    public function put($data);
 
     /**
      * Returns the data.

--- a/lib/DAV/IFile.php
+++ b/lib/DAV/IFile.php
@@ -35,7 +35,6 @@ interface IFile extends INode
      * return an ETag, and just return null.
      *
      * @param resource|string $data
-     * @param object|null     $params
      *
      * @return string|null
      */

--- a/lib/DAV/IFile.php
+++ b/lib/DAV/IFile.php
@@ -38,7 +38,7 @@ interface IFile extends INode
      *
      * @return string|null
      */
-    public function put($data, $params = null);
+    public function put($data,$params=null);
 
     /**
      * Returns the data.

--- a/lib/DAV/Server.php
+++ b/lib/DAV/Server.php
@@ -1114,14 +1114,13 @@ class Server implements LoggerAwareInterface, EmitterInterface
      *
      * This method will return true if the file was actually updated
      *
-     * @param string      $uri
-     * @param resource    $data
-     * @param string      $etag
-     * @param object|null $params
+     * @param string   $uri
+     * @param resource $data
+     * @param string   $etag
      *
      * @return bool
      */
-    public function updateFile($uri, $data, &$etag = null, $params = null)
+    public function updateFile($uri, $data, &$etag = null, $params)
     {
         $node = $this->tree->getNodeForPath($uri);
 

--- a/lib/DAV/Server.php
+++ b/lib/DAV/Server.php
@@ -1120,7 +1120,7 @@ class Server implements LoggerAwareInterface, EmitterInterface
      *
      * @return bool
      */
-    public function updateFile($uri, $data, &$etag = null, $params)
+    public function updateFile($uri, $data, &$etag = null,$params)
     {
         $node = $this->tree->getNodeForPath($uri);
 
@@ -1133,7 +1133,7 @@ class Server implements LoggerAwareInterface, EmitterInterface
         if (!$this->emit('beforeWriteContent', [$uri, $node, &$data, &$modified])) {
             return false;
         }
-        $etag = $node->put($data, $params);
+        $etag = $node->put($data,$params);
         if ($modified) {
             $etag = null;
         }

--- a/lib/DAV/Server.php
+++ b/lib/DAV/Server.php
@@ -1120,7 +1120,7 @@ class Server implements LoggerAwareInterface, EmitterInterface
      *
      * @return bool
      */
-    public function updateFile($uri, $data, &$etag = null,$params)
+    public function updateFile($uri, $data, &$etag = null)
     {
         $node = $this->tree->getNodeForPath($uri);
 
@@ -1133,7 +1133,8 @@ class Server implements LoggerAwareInterface, EmitterInterface
         if (!$this->emit('beforeWriteContent', [$uri, $node, &$data, &$modified])) {
             return false;
         }
-        $etag = $node->put($data,$params);
+
+        $etag = $node->put($data);
         if ($modified) {
             $etag = null;
         }

--- a/tests/Sabre/DAV/Mock/File.php
+++ b/tests/Sabre/DAV/Mock/File.php
@@ -82,8 +82,7 @@ class File extends DAV\File
      * different object on a subsequent GET you are strongly recommended to not
      * return an ETag, and just return null.
      *
-     * @param resource    $data
-     * @param object|null $params
+     * @param resource $data
      *
      * @return string|null
      */

--- a/tests/Sabre/DAV/Mock/File.php
+++ b/tests/Sabre/DAV/Mock/File.php
@@ -86,7 +86,7 @@ class File extends DAV\File
      *
      * @return string|null
      */
-    public function put($data, $params = null)
+    public function put($data)
     {
         if (is_resource($data)) {
             $data = stream_get_contents($data);

--- a/tests/Sabre/DAV/Mock/StreamingFile.php
+++ b/tests/Sabre/DAV/Mock/StreamingFile.php
@@ -39,7 +39,7 @@ class StreamingFile extends File
      *
      * @return string|null
      */
-    public function put($data, $params = null)
+    public function put($data)
     {
         if (is_string($data)) {
             $stream = fopen('php://memory', 'r+');

--- a/tests/Sabre/DAV/Mock/StreamingFile.php
+++ b/tests/Sabre/DAV/Mock/StreamingFile.php
@@ -35,8 +35,7 @@ class StreamingFile extends File
      * different object on a subsequent GET you are strongly recommended to not
      * return an ETag, and just return null.
      *
-     * @param resource    $data
-     * @param object|null $params
+     * @param resource $data
      *
      * @return string|null
      */

--- a/tests/Sabre/DAV/PartialUpdate/FileMock.php
+++ b/tests/Sabre/DAV/PartialUpdate/FileMock.php
@@ -10,12 +10,12 @@ class FileMock implements IPatchSupport
 {
     protected $data = '';
 
-    public function put($data, $params = null)
+    public function put($str, $params = null)
     {
-        if (is_resource($data)) {
-            $data = stream_get_contents($data);
+        if (is_resource($str)) {
+            $str = stream_get_contents($str);
         }
-        $this->data = $data;
+        $this->data = $str;
     }
 
     /**

--- a/tests/Sabre/DAV/PartialUpdate/FileMock.php
+++ b/tests/Sabre/DAV/PartialUpdate/FileMock.php
@@ -10,7 +10,7 @@ class FileMock implements IPatchSupport
 {
     protected $data = '';
 
-    public function put($str, $params = null)
+    public function put($str)
     {
         if (is_resource($str)) {
             $str = stream_get_contents($str);


### PR DESCRIPTION
See comment https://github.com/sabre-io/dav/pull/1365#discussion_r765559132

That change was not strictly backward-compatible. Revert it for now, and I will release a new patch version.

Then we can discuss if the change is really wanted, and if there is a backward-compatible way to do it.