### PR TITLE
Prepare 4.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ChangeLog
 =========
 
+4.2.3 (2021-12-09)
+-------------------------
+* #1375: revert 1365 'add params for put interface' (@phil-davis)
+
 4.2.2 (2021-12-09)
 -------------------------
 * #1248: CalDAV to sync properly when limit is set in PDO backend (@nhirokinet)

--- a/lib/DAV/Version.php
+++ b/lib/DAV/Version.php
@@ -16,5 +16,5 @@ class Version
     /**
      * Full version number.
      */
-    public const VERSION = '4.2.2';
+    public const VERSION = '4.2.3';
 }


### PR DESCRIPTION
PR #1365 is reverted by PR #1375

See comment https://github.com/sabre-io/dav/pull/1365#discussion_r765559132

That change was not strictly backward-compatible. So it should not be included in a patch release. I will release 4.2.3 so that 4.2.2 gets quickly superceded.