### PR TITLE
Update browser plugin

### DIFF
--- a/lib/DAV/Browser/Plugin.php
+++ b/lib/DAV/Browser/Plugin.php
@@ -582,7 +582,6 @@ HTML;
         }
 
         $this->server->httpResponse->setHeader('Content-Type', $mime);
-        $this->server->httpResponse->setHeader('Content-Length', filesize($assetPath));
         $this->server->httpResponse->setHeader('Cache-Control', 'public, max-age=1209600');
         $this->server->httpResponse->setStatus(200);
         $this->server->httpResponse->setBody(fopen($assetPath, 'r'));


### PR DESCRIPTION
Deleting the line 585 $this->server->httpResponse->setHeader('Content-Length', filesize($assetPath)); to add compatibility with HTTP2 and SSL

With this line, the server works good, but in the browser, if the user uses SSL ans the server HTTP2, the page loading is very slow and the browser throws an error ERR_HTTP2_PROTOCOL_ERROR.