### PR TITLE
[tests-only] Break tests to check CI

### DIFF
--- a/tests/Sabre/CalDAV/Backend/AbstractPDOTest.php
+++ b/tests/Sabre/CalDAV/Backend/AbstractPDOTest.php
@@ -68,7 +68,7 @@ abstract class AbstractPDOTest extends \PHPUnit\Framework\TestCase
         ];
 
         $this->assertIsArray($calendars);
-        $this->assertEquals(1, count($calendars));
+        $this->assertEquals(2, count($calendars));
 
         foreach ($elementCheck as $name => $value) {
             $this->assertArrayHasKey($name, $calendars[0]);

--- a/tests/Sabre/CalDAV/Backend/SimplePDOTest.php
+++ b/tests/Sabre/CalDAV/Backend/SimplePDOTest.php
@@ -79,7 +79,7 @@ SQL
         ];
 
         $this->assertIsArray($calendars);
-        $this->assertEquals(1, count($calendars));
+        $this->assertEquals(2, count($calendars));
 
         foreach ($elementCheck as $name => $value) {
             $this->assertArrayHasKey($name, $calendars[0]);


### PR DESCRIPTION
I want to see which PDO tests are really running against which database.

Related to Baikal issue https://github.com/sabre-io/Baikal/issues/1082 where I hoped that the problem would already have been caught by CI here.