### PR TITLE
Include "before" and "after" copy events as with move events

### DIFF
--- a/lib/DAV/CorePlugin.php
+++ b/lib/DAV/CorePlugin.php
@@ -645,6 +645,10 @@ class CorePlugin extends ServerPlugin
         if (!$this->server->emit('beforeBind', [$copyInfo['destination']])) {
             return false;
         }
+        if (!$this->server->emit('beforeCopy', [$path, $copyInfo['destination']])) {
+            return false;
+        }
+
         if ($copyInfo['destinationExists']) {
             if (!$this->server->emit('beforeUnbind', [$copyInfo['destination']])) {
                 return false;
@@ -653,6 +657,7 @@ class CorePlugin extends ServerPlugin
         }
 
         $this->server->tree->copy($path, $copyInfo['destination']);
+        $this->server->emit('afterCopy', [$path, $copyInfo['destination']]);
         $this->server->emit('afterBind', [$copyInfo['destination']]);
 
         // If a resource was overwritten we should send a 204, otherwise a 201


### PR DESCRIPTION
The same way "beforeMove" and "afterMove" events are triggered, the new "beforeCopy" and "afterCopy" events will be triggered during a COPY request.