### PR TITLE
Fix encoding detection on PHP 8.1

### DIFF
--- a/lib/DAV/StringUtil.php
+++ b/lib/DAV/StringUtil.php
@@ -77,10 +77,8 @@ class StringUtil
      */
     public static function ensureUTF8($input)
     {
-        $encoding = mb_detect_encoding($input, ['UTF-8', 'ISO-8859-1'], true);
-
-        if ('ISO-8859-1' === $encoding) {
-            return utf8_encode($input);
+        if (!mb_check_encoding($input, 'UTF-8') && mb_check_encoding($input, 'ISO-8859-1')) {
+            return mb_convert_encoding($input, 'UTF-8', 'ISO-8859-1');
         } else {
             return $input;
         }


### PR DESCRIPTION
Also get rid of deprecated utf8_encode

Spin-off of https://github.com/sabre-io/http/pull/182