### PR TITLE
Prepare 4.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 ChangeLog
 =========
 
+4.4.0 (2022-06-27)
+-------------------------
+* #1396: Include "before" and "after" copy events (@jvillafanez)
+* #1404: Fix encoding detection on PHP 8.1 (@come-nc)
+
 4.3.1 (2022-01-20)
 -------------------------
 * #1385: fix: ensure first argument on strpos is a string (@DeepDiver1975)

--- a/README.md
+++ b/README.md
@@ -14,16 +14,17 @@ http://sabre.io/
 Build status
 ------------
 
-| branch       | status | minimum PHP version |
-| ------------ | ------ | ------------------- |
-| master       | [![Build Status](https://travis-ci.org/sabre-io/dav.svg?branch=master)](https://travis-ci.org/sabre-io/dav) | PHP 7.1 |
-| 3.1          | [![Build Status](https://travis-ci.org/sabre-io/dav.svg?branch=3.0)](https://travis-ci.org/sabre-io/dav) | PHP 5.5 |
-| 3.0          | [![Build Status](https://travis-ci.org/sabre-io/dav.svg?branch=3.0)](https://travis-ci.org/sabre-io/dav) | PHP 5.4 |
-| 2.1          | [![Build Status](https://travis-ci.org/sabre-io/dav.svg?branch=2.1)](https://travis-ci.org/sabre-io/dav) | PHP 5.4 |
-| 2.0          | [![Build Status](https://travis-ci.org/sabre-io/dav.svg?branch=2.0)](https://travis-ci.org/sabre-io/dav) | PHP 5.4 |
-| 1.8          | [![Build Status](https://travis-ci.org/sabre-io/dav.svg?branch=1.8)](https://travis-ci.org/sabre-io/dav) | PHP 5.3 |
-| 1.7          | [![Build Status](https://travis-ci.org/sabre-io/dav.svg?branch=1.7)](https://travis-ci.org/sabre-io/dav) | PHP 5.3 |
-| 1.6          | [![Build Status](https://travis-ci.org/sabre-io/dav.svg?branch=1.6)](https://travis-ci.org/sabre-io/dav) | PHP 5.3 |
+| branch     | status                                                                    | PHP version        |
+|------------|---------------------------------------------------------------------------|--------------------|
+| master 4.* | ![CI](https://github.com/sabre-io/dav/actions/workflows/ci.yml/badge.svg) | PHP 7.1 up, 8.0 up |
+| 3.2        | unmaintained                                                              | PHP 5.5 to 7.1     |
+| 3.1        | unmaintained                                                              | PHP 5.5            |
+| 3.0        | unmaintained                                                              | PHP 5.4            |
+| 2.1        | unmaintained                                                              | PHP 5.4            |
+| 2.0        | unmaintained                                                              | PHP 5.4            |
+| 1.8        | unmaintained                                                              | PHP 5.3            |
+| 1.7        | unmaintained                                                              | PHP 5.3            |
+| 1.6        | unmaintained                                                              | PHP 5.3            |
 
 Documentation
 -------------

--- a/lib/DAV/Version.php
+++ b/lib/DAV/Version.php
@@ -16,5 +16,5 @@ class Version
     /**
      * Full version number.
      */
-    public const VERSION = '4.3.1';
+    public const VERSION = '4.4.0';
 }


### PR DESCRIPTION
PR #1396 Include "before" and "after" copy events - that adds new events (even though they are very similar to existing events that happen for "move"). Adding these events could be considered a "bugfix" (= patch release), but they do introduce something new. So I have bumped the minor version, to be sure to meet SemVer rules/conventions.

I updated the release versions table in README. The old CI badges for Travis are completely out-of-date.