### PR TITLE
PHP 8.2 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: [ '7.1', '7.2', '7.3', '7.4', '8.0' ]
+        php-versions: [ '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2' ]
         coverage: [ 'xdebug' ]
         streaming: [ false ]
         include:


### PR DESCRIPTION
- add PHP 8.2 to CI
- also run the standard CI (non-streaming) with PHP 8.1 (which already runs with the streaming option)