### PR TITLE
Remove unused itipMessage property

### DIFF
--- a/lib/CalDAV/Schedule/IMipPlugin.php
+++ b/lib/CalDAV/Schedule/IMipPlugin.php
@@ -31,13 +31,6 @@ class IMipPlugin extends DAV\ServerPlugin
     protected $senderEmail;
 
     /**
-     * ITipMessage.
-     *
-     * @var ITip\Message
-     */
-    protected $itipMessage;
-
-    /**
      * Creates the email handler.
      *
      * @param string $senderEmail. The 'senderEmail' is the email that shows up


### PR DESCRIPTION
Unless I missed something this property is never set or get?
Spotted by psalm.