### PR TITLE
Allow float sizes for 32bit support

### DIFF
--- a/lib/DAV/IFile.php
+++ b/lib/DAV/IFile.php
@@ -77,7 +77,7 @@ interface IFile extends INode
     /**
      * Returns the size of the node, in bytes.
      *
-     * @return int
+     * @return int|float
      */
     public function getSize();
 }


### PR DESCRIPTION
For 32bit support in Nextcloud we are typing sizes as int|float as PHP uses float for bigint.

Would you consider merging this change?