### PR TITLE
declare addressDataProperties to avoid PHP 8.2 deprecation notice

### DIFF
--- a/lib/CardDAV/Xml/Request/AddressBookMultiGetReport.php
+++ b/lib/CardDAV/Xml/Request/AddressBookMultiGetReport.php
@@ -38,7 +38,7 @@ class AddressBookMultiGetReport implements XmlDeserializable
     public $hrefs;
 
     /**
-     * The mimetype of the content that should be returend. Usually
+     * The mimetype of the content that should be returned. Usually
      * text/vcard.
      *
      * @var string
@@ -52,6 +52,13 @@ class AddressBookMultiGetReport implements XmlDeserializable
      * @var string
      */
     public $version = null;
+
+    /**
+     * An array with requested vcard properties.
+     *
+     * @var array
+     */
+    public $addressDataProperties;
 
     /**
      * The deserialize method is called during xml parsing.

--- a/tests/Sabre/CardDAV/Xml/Request/AddressBookMultiGetReportTest.php
+++ b/tests/Sabre/CardDAV/Xml/Request/AddressBookMultiGetReportTest.php
@@ -4,7 +4,7 @@ namespace Sabre\CardDAV\Xml\Request;
 
 use Sabre\DAV\Xml\XmlTest;
 
-class AddressBookMultiGetTest extends XmlTest
+class AddressBookMultiGetReportTest extends XmlTest
 {
     protected $elementMap = [
         '{urn:ietf:params:xml:ns:carddav}addressbook-multiget' => 'Sabre\\CardDAV\\Xml\\Request\AddressBookMultiGetReport',
@@ -36,7 +36,7 @@ class AddressBookMultiGetTest extends XmlTest
         );
     }
 
-    public function providesAddressDataXml()
+    public function providesAddressDataXml(): array
     {
         $simpleXml = <<<XML
 <?xml version='1.0' encoding='UTF-8' ?>
@@ -83,7 +83,7 @@ XML;
         return [
             'address data with version' => [$simpleXml, [], '4.0'],
             'address data with inner all props' => [$allPropsXml, []],
-            'address data with mutliple props' => [$multiplePropsXml, ['VERSION', 'UID', 'NICKNAME', 'EMAIL', 'FN']],
+            'address data with multiple props' => [$multiplePropsXml, ['VERSION', 'UID', 'NICKNAME', 'EMAIL', 'FN']],
         ];
     }
 }


### PR DESCRIPTION
Issue #1445 

declare addressDataProperties to avoid PHP 8.2 deprecation notice

This is the easy fix that I can see for one of the things mentioned in the issue.