### PR TITLE
Drop evert/phpdoc-md dev dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,6 @@
         "friendsofphp/php-cs-fixer": "^2.17.1",
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit" : "^7.5 || ^8.5 || ^9.0",
-        "evert/phpdoc-md" : "~0.1.0",
         "monolog/monolog": "^1.18"
     },
     "suggest" : {


### PR DESCRIPTION
Maybe I miss something, but this dependency does not seems to be used anymore.