### PR TITLE
Bump require-dev dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,10 +33,10 @@
         "ext-json": "*"
     },
     "require-dev" : {
-        "friendsofphp/php-cs-fixer": "^2.17.1",
+        "friendsofphp/php-cs-fixer": "^2.19",
         "phpstan/phpstan": "^0.12",
-        "phpunit/phpunit" : "^7.5 || ^8.5 || ^9.0",
-        "monolog/monolog": "^1.18"
+        "phpunit/phpunit" : "^7.5 || ^8.5 || ^9.6",
+        "monolog/monolog": "^1.27"
     },
     "suggest" : {
         "ext-curl" : "*",


### PR DESCRIPTION
I really just want to check that all of CI still passes (there have been minor version releases of the CI tools phpunit, phpstan and php-cs-fixer recently).

This PR updates the minor versions recorded in `composer.json`. That does not do anything exciting, but maybe it helps in the future that we know what minor version of each tool was known to work.