### PR TITLE
fix(sync): Fix PHPDoc to allow getChanges for sync to return null

### DIFF
--- a/lib/CalDAV/Backend/PDO.php
+++ b/lib/CalDAV/Backend/PDO.php
@@ -939,7 +939,7 @@ SQL;
      * @param int    $syncLevel
      * @param int    $limit
      *
-     * @return array
+     * @return array|null
      */
     public function getChangesForCalendar($calendarId, $syncToken, $syncLevel, $limit = null)
     {

--- a/lib/CalDAV/Backend/SyncSupport.php
+++ b/lib/CalDAV/Backend/SyncSupport.php
@@ -77,7 +77,7 @@ interface SyncSupport extends BackendInterface
      * @param int    $syncLevel
      * @param int    $limit
      *
-     * @return array
+     * @return array|null
      */
     public function getChangesForCalendar($calendarId, $syncToken, $syncLevel, $limit = null);
 }

--- a/lib/CalDAV/Calendar.php
+++ b/lib/CalDAV/Calendar.php
@@ -442,7 +442,7 @@ class Calendar implements ICalendar, DAV\IProperties, DAV\Sync\ISyncCollection, 
      * @param int    $syncLevel
      * @param int    $limit
      *
-     * @return array
+     * @return array|null
      */
     public function getChanges($syncToken, $syncLevel, $limit = null)
     {

--- a/lib/CardDAV/AddressBook.php
+++ b/lib/CardDAV/AddressBook.php
@@ -317,7 +317,7 @@ class AddressBook extends DAV\Collection implements IAddressBook, DAV\IPropertie
      * @param int    $syncLevel
      * @param int    $limit
      *
-     * @return array
+     * @return array|null
      */
     public function getChanges($syncToken, $syncLevel, $limit = null)
     {

--- a/lib/CardDAV/Backend/PDO.php
+++ b/lib/CardDAV/Backend/PDO.php
@@ -452,7 +452,7 @@ class PDO extends AbstractBackend implements SyncSupport
      * @param int    $syncLevel
      * @param int    $limit
      *
-     * @return array
+     * @return array|null
      */
     public function getChangesForAddressBook($addressBookId, $syncToken, $syncLevel, $limit = null)
     {

--- a/lib/CardDAV/Backend/SyncSupport.php
+++ b/lib/CardDAV/Backend/SyncSupport.php
@@ -77,7 +77,7 @@ interface SyncSupport extends BackendInterface
      * @param int    $syncLevel
      * @param int    $limit
      *
-     * @return array
+     * @return array|null
      */
     public function getChangesForAddressBook($addressBookId, $syncToken, $syncLevel, $limit = null);
 }

--- a/lib/DAV/Sync/ISyncCollection.php
+++ b/lib/DAV/Sync/ISyncCollection.php
@@ -84,7 +84,7 @@ interface ISyncCollection extends DAV\ICollection
      * @param int    $syncLevel
      * @param int    $limit
      *
-     * @return array
+     * @return array|null
      */
     public function getChanges($syncToken, $syncLevel, $limit = null);
 }

--- a/tests/Sabre/DAV/Sync/MockSyncCollection.php
+++ b/tests/Sabre/DAV/Sync/MockSyncCollection.php
@@ -98,7 +98,7 @@ class MockSyncCollection extends DAV\SimpleCollection implements ISyncCollection
      * @param int    $syncLevel
      * @param int    $limit
      *
-     * @return array
+     * @return array|null
      */
     public function getChanges($syncToken, $syncLevel, $limit = null)
     {


### PR DESCRIPTION
As per the comments: "If the syncToken is expired (due to data cleanup) or unknown, you must return null."

Helps with static analysis issues.