### PR TITLE
hack to allow mounting C:\ on Windows 10

### DIFF
--- a/lib/DAV/FS/Directory.php
+++ b/lib/DAV/FS/Directory.php
@@ -100,17 +100,17 @@ class Directory extends Node implements DAV\ICollection, DAV\IQuota {
             \FilesystemIterator::CURRENT_AS_SELF
           | \FilesystemIterator::SKIP_DOTS
         );
-        $isWindows = (PHP_OS === 'WINNT');
+        $enableCMountHack = (PHP_OS === 'WINNT' && $this->path === 'C:');
         foreach ($iterator as $entry) {
-            if ($isWindows) {
+            if ($enableCMountHack) {
                 // Hack to allow mounting C:\ on Windows 10
                 // These files exist, but fails file_exists() for some reason, which causes
                 // an exception in $this->getChild().
-                if (in_array($entry->getPathname(), [
-                    'C:\\DumpStack.log.tmp',
-                    'C:\\hiberfil.sys',
-                    'C:\\pagefile.sys',
-                    'C:\\swapfile.sys',
+                if (in_array($entry->getFilename(), [
+                    'DumpStack.log.tmp',
+                    'hiberfil.sys',
+                    'pagefile.sys',
+                    'swapfile.sys',
                 ], true)) {
                     continue;
                 }

--- a/lib/DAV/FS/Directory.php
+++ b/lib/DAV/FS/Directory.php
@@ -111,6 +111,8 @@ class Directory extends Node implements DAV\ICollection, DAV\IQuota {
                     'hiberfil.sys',
                     'pagefile.sys',
                     'swapfile.sys',
+                    'PerfLogs',
+                    'System Volume Information',
                 ], true)) {
                     continue;
                 }

--- a/lib/DAV/FS/Directory.php
+++ b/lib/DAV/FS/Directory.php
@@ -100,8 +100,22 @@ class Directory extends Node implements DAV\ICollection, DAV\IQuota {
             \FilesystemIterator::CURRENT_AS_SELF
           | \FilesystemIterator::SKIP_DOTS
         );
+        $isWindows = (PHP_OS === 'WINNT');
         foreach ($iterator as $entry) {
-
+            if ($isWindows) {
+                // Hack to allow mounting C:\ on Windows 10
+                // These files exist, but fails file_exists() for some reason, which causes
+                // an exception in $this->getChild().
+                $pathname = $entry->getPathname();
+                if (in_array($pathname, [
+                    'C:\\DumpStack.log.tmp',
+                    'C:\\hiberfil.sys',
+                    'C:\\pagefile.sys',
+                    'C:\\swapfile.sys',
+                ], true)) {
+                    continue;
+                }
+            }            
             $nodes[] = $this->getChild($entry->getFilename());
 
         }

--- a/lib/DAV/FS/Directory.php
+++ b/lib/DAV/FS/Directory.php
@@ -106,8 +106,7 @@ class Directory extends Node implements DAV\ICollection, DAV\IQuota {
                 // Hack to allow mounting C:\ on Windows 10
                 // These files exist, but fails file_exists() for some reason, which causes
                 // an exception in $this->getChild().
-                $pathname = $entry->getPathname();
-                if (in_array($pathname, [
+                if (in_array($entry->getPathname(), [
                     'C:\\DumpStack.log.tmp',
                     'C:\\hiberfil.sys',
                     'C:\\pagefile.sys',


### PR DESCRIPTION
for some reason these files exist but fails file_exists("C:\\hiberfile.sys"); which then causes an exception in getChild(), i think it's a bug in PHP's file_exists(), where file_exists() return false if a file "exists but is not readable", and IIRC someone raised the issue on the php bugtracker, but the php core devs refused to fix it for "backwards compatibility reasons" ... don't remember the bug report number though.

anyway, this hack allows mounting C:\ on windows 10. Related issue: https://github.com/sabre-io/dav/issues/1458