### PR TITLE
feat: change scheduleReply's visibility to use it in child classes

### DIFF
--- a/lib/CalDAV/Schedule/Plugin.php
+++ b/lib/CalDAV/Schedule/Plugin.php
@@ -969,7 +969,7 @@ class Plugin extends ServerPlugin
      *
      * @return bool
      */
-    private function scheduleReply(RequestInterface $request)
+    protected function scheduleReply(RequestInterface $request)
     {
         $scheduleReply = $request->getHeader('Schedule-Reply');
 


### PR DESCRIPTION
We extended the default implementation. 

It would be nice to use the method without copying in the child class.