### PR TITLE
docs: fix type definition for oldObject

### DIFF
--- a/lib/CalDAV/Schedule/Plugin.php
+++ b/lib/CalDAV/Schedule/Plugin.php
@@ -605,10 +605,9 @@ class Plugin extends ServerPlugin
      *
      * This method may update $newObject to add any status changes.
      *
-     * @param VCalendar|string $oldObject
-     * @param array            $ignore    any addresses to not send messages to
-     * @param bool             $modified  a marker to indicate that the original object
-     *                                    modified by this process
+     * @param VCalendar|string|null $oldObject
+     * @param array                 $ignore    any addresses to not send messages to
+     * @param bool                  $modified  a marker to indicate that the original object modified by this process
      */
     protected function processICalendarChange($oldObject, VCalendar $newObject, array $addresses, array $ignore = [], &$modified = false)
     {


### PR DESCRIPTION
Broker.parseEvents accepts null for oldObject and therefore processICalendarChange as well.