### PR TITLE
fix: The WebDAV response element must only contain `propstat` OR `status` element(s)

### DIFF
--- a/tests/Sabre/DAVACL/PrincipalMatchTest.php
+++ b/tests/Sabre/DAVACL/PrincipalMatchTest.php
@@ -28,12 +28,8 @@ XML;
         $expected = <<<XML
 <?xml version="1.0"?>
 <d:multistatus xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns">
-    <d:status>HTTP/1.1 200 OK</d:status>
     <d:href>/principals/user1</d:href>
-    <d:propstat>
-        <d:prop/>
-        <d:status>HTTP/1.1 418 I'm a teapot</d:status>
-    </d:propstat>
+    <d:status>HTTP/1.1 200 OK</d:status>
 </d:multistatus>
 XML;
 
@@ -63,7 +59,6 @@ XML;
         $expected = <<<XML
 <?xml version="1.0"?>
 <d:multistatus xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns">
-    <d:status>HTTP/1.1 200 OK</d:status>
     <d:href>/principals/user1/</d:href>
     <d:propstat>
         <d:prop>
@@ -102,7 +97,6 @@ XML;
         $expected = <<<XML
 <?xml version="1.0"?>
 <d:multistatus xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns">
-    <d:status>HTTP/1.1 200 OK</d:status>
     <d:href>/principals/user1/</d:href>
     <d:propstat>
         <d:prop>


### PR DESCRIPTION
* Resolves https://github.com/sabre-io/dav/issues/1487

The response element should look like, see [section-14.24](https://datatracker.ietf.org/doc/html/rfc4918#section-14.24) :
`<!ELEMENT response (href, ((href*, status)|(propstat+)), error?, responsedescription? , location?) >`

Meaning it
* Must contain a `href` :heavy_check_mark: 
* Might contain `error`, `responsedescription` and `location` (not implemented by us) :white_check_mark: 
* Must **EITHER** contain a status **OR** one or more `propstat` elements

So we have to ensure the status is only set if there is no `propstat`.