### PR TITLE
feat: introduce IFile::getRange()

### DIFF
--- a/lib/DAV/FS/File.php
+++ b/lib/DAV/FS/File.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Sabre\DAV\FS;
 
 use Sabre\DAV;
+use Sabre\DAV\CorePlugin;
+use Sabre\DAV\Exception\RequestedRangeNotSatisfiable;
 
 /**
  * File class.
@@ -34,6 +36,14 @@ class File extends Node implements DAV\IFile
     public function get()
     {
         return fopen($this->path, 'r');
+    }
+
+    /**
+     * @throws RequestedRangeNotSatisfiable
+     */
+    public function getRange(int $start, int $end)
+    {
+        return CorePlugin::getRangeFromFile($this, $start);
     }
 
     /**

--- a/lib/DAV/FSExt/File.php
+++ b/lib/DAV/FSExt/File.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Sabre\DAV\FSExt;
 
 use Sabre\DAV;
+use Sabre\DAV\CorePlugin;
+use Sabre\DAV\Exception\RequestedRangeNotSatisfiable;
 use Sabre\DAV\FS\Node;
 
 /**
@@ -65,18 +67,18 @@ class File extends Node implements DAV\PartialUpdate\IPatchSupport
     {
         switch ($rangeType) {
             case 1:
-                $f = fopen($this->path, 'a');
+                $f = fopen($this->path, 'ab');
                 break;
             case 2:
-                $f = fopen($this->path, 'c');
+                $f = fopen($this->path, 'cb');
                 fseek($f, $offset);
                 break;
             case 3:
-                $f = fopen($this->path, 'c');
+                $f = fopen($this->path, 'cb');
                 fseek($f, $offset, SEEK_END);
                 break;
             default:
-                $f = fopen($this->path, 'a');
+                $f = fopen($this->path, 'ab');
                 break;
         }
         if (is_string($data)) {
@@ -97,7 +99,15 @@ class File extends Node implements DAV\PartialUpdate\IPatchSupport
      */
     public function get()
     {
-        return fopen($this->path, 'r');
+        return fopen($this->path, 'rb');
+    }
+
+    /**
+     * @throws RequestedRangeNotSatisfiable
+     */
+    public function getRange(int $start, int $end)
+    {
+        return CorePlugin::getRangeFromFile($this, $start);
     }
 
     /**

--- a/lib/DAV/File.php
+++ b/lib/DAV/File.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Sabre\DAV;
 
+use Sabre\DAV\Exception\RequestedRangeNotSatisfiable;
+
 /**
  * File class.
  *
@@ -52,6 +54,14 @@ abstract class File extends Node implements IFile
     public function get()
     {
         throw new Exception\Forbidden('Permission denied to read this file');
+    }
+
+    /**
+     * @throws RequestedRangeNotSatisfiable
+     */
+    public function getRange(int $start, int $end)
+    {
+        return CorePlugin::getRangeFromFile($this, $start);
     }
 
     /**

--- a/lib/DAV/IFile.php
+++ b/lib/DAV/IFile.php
@@ -50,6 +50,13 @@ interface IFile extends INode
     public function get();
 
     /**
+     * Returns a range of bytes withing the data.
+     *
+     * @return mixed
+     */
+    public function getRange(int $start, int $end);
+
+    /**
      * Returns the mime-type for a file.
      *
      * If null is returned, we'll assume application/octet-stream

--- a/tests/Sabre/DAV/PartialUpdate/FileMock.php
+++ b/tests/Sabre/DAV/PartialUpdate/FileMock.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Sabre\DAV\PartialUpdate;
 
 use Sabre\DAV;
+use Sabre\DAV\CorePlugin;
+use Sabre\DAV\Exception\RequestedRangeNotSatisfiable;
 
 class FileMock implements IPatchSupport
 {
@@ -72,6 +74,14 @@ class FileMock implements IPatchSupport
     public function get()
     {
         return $this->data;
+    }
+
+    /**
+     * @throws RequestedRangeNotSatisfiable
+     */
+    public function getRange(int $start, int $end)
+    {
+        return CorePlugin::getRangeFromFile($this, $start);
     }
 
     public function getContentType()


### PR DESCRIPTION
depending on the implementation of IFile it can be reasonable to know the range already within the IFile::get(). To not break the api an additional method IFile:getRange() has been added together with a default implementation which is accessible via CorePlugin::getRangeFromFile

Specifically when having some storage which is using an http based protocol (like S3) it is necessary to know the range when opening the stream.