### PR TITLE
[4.5] fix: restore autoPrefix property of Href

### DIFF
--- a/lib/DAV/Xml/Property/Href.php
+++ b/lib/DAV/Xml/Property/Href.php
@@ -35,6 +35,19 @@ class Href implements Element, HtmlOutput
     protected $hrefs;
 
     /**
+     * Automatically prefix the url with the server base directory.
+     * Note: use of this property in code was removed in PR:
+     * https://github.com/sabre-io/dav/pull/801
+     * But the property is left here because old data may still exist
+     * that has this property saved.
+     * See discussion in issue:
+     * https://github.com/sabre-io/Baikal/issues/1154.
+     *
+     * @var bool
+     */
+    protected $autoPrefix = true;
+
+    /**
      * Constructor.
      *
      * You must either pass a string for a single href, or an array of hrefs.


### PR DESCRIPTION
use of this property in code was removed in PR
https://github.com/sabre-io/dav/pull/801
But the property is left here because old data may still exist that has this property saved.

See discussion in https://github.com/sabre-io/Baikal/issues/1154

Backport of PR #1514
