### PR TITLE
feat: add propFindUnfiltered public method to Client

### DIFF
--- a/lib/DAV/Client.php
+++ b/lib/DAV/Client.php
@@ -174,7 +174,7 @@ class Client extends HTTP\Client
     }
 
     /**
-     * Does a PROPFIND request.
+     * Does a PROPFIND request with filtered response.
      *
      * The list of requested properties must be specified as an array, in clark
      * notation.
@@ -209,6 +209,50 @@ class Client extends HTTP\Client
         $newResult = [];
         foreach ($result as $href => $statusList) {
             $newResult[$href] = isset($statusList[200]) ? $statusList[200] : [];
+        }
+
+        return $newResult;
+    }
+
+    /**
+     * Does a PROPFIND request with unfiltered response.
+     *
+     * The list of requested properties must be specified as an array, in clark
+     * notation.
+     *
+     * The returned array will contain a list of filenames as keys, and
+     * properties as values.
+     *
+     * The properties array will contain the list of properties. All properties
+     * that are actually returned from the server are returned by this method.
+     *
+     * Depth should be either 0 or 1. A depth of 1 will cause a request to be
+     * made to the server to also return all child resources.
+     *
+     * @param string $url
+     * @param int    $depth
+     *
+     * @return array
+     */
+    public function propFindUnfiltered($url, array $properties, $depth = 0)
+    {
+        $result = $this->doPropFind($url, $properties, $depth);
+
+        // If depth was 0, we only return the top item
+        if (0 === $depth) {
+            reset($result);
+            $resourceStatusList = current($result);
+            reset($resourceStatusList);
+            // $resourceStatus = key($resourceStatusList);
+            return current($resourceStatusList);
+        }
+
+        $newResult = [];
+        foreach ($result as $href => $statusList) {
+            reset($statusList);
+            // $resourceStatus = key($statusList);
+            $resourceProperties = current($statusList);
+            $newResult[$href] = $resourceProperties;
         }
 
         return $newResult;

--- a/lib/DAV/Client.php
+++ b/lib/DAV/Client.php
@@ -243,16 +243,14 @@ class Client extends HTTP\Client
             reset($result);
             $resourceStatusList = current($result);
             reset($resourceStatusList);
-            // $resourceStatus = key($resourceStatusList);
-            return current($resourceStatusList);
+
+            return ['properties' => current($resourceStatusList), 'status' => key($resourceStatusList)];
         }
 
         $newResult = [];
         foreach ($result as $href => $statusList) {
             reset($statusList);
-            // $resourceStatus = key($statusList);
-            $resourceProperties = current($statusList);
-            $newResult[$href] = $resourceProperties;
+            $newResult[$href] = ['properties' => current($statusList), 'status' => key($statusList)];
         }
 
         return $newResult;

--- a/lib/DAV/Client.php
+++ b/lib/DAV/Client.php
@@ -237,20 +237,21 @@ class Client extends HTTP\Client
     public function propFindUnfiltered($url, array $properties, $depth = 0)
     {
         $result = $this->doPropFind($url, $properties, $depth);
+        $newResult = [];
 
         // If depth was 0, we only return the top item
         if (0 === $depth) {
             reset($result);
-            $resourceStatusList = current($result);
-            reset($resourceStatusList);
-
-            return ['properties' => current($resourceStatusList), 'status' => key($resourceStatusList)];
-        }
-
-        $newResult = [];
-        foreach ($result as $href => $statusList) {
-            reset($statusList);
-            $newResult[$href] = ['properties' => current($statusList), 'status' => key($statusList)];
+            $statusList = current($result);
+            foreach ($statusList as $statusCode => $associatedProperties) {
+                $newResult[] = ['properties' => $associatedProperties, 'status' => $statusCode];
+            }
+        } else {
+            foreach ($result as $href => $statusList) {
+                foreach ($statusList as $statusCode => $associatedProperties) {
+                    $newResult[$href][] = ['properties' => $associatedProperties, 'status' => $statusCode];
+                }
+            }
         }
 
         return $newResult;

--- a/lib/DAV/Client.php
+++ b/lib/DAV/Client.php
@@ -196,6 +196,45 @@ class Client extends HTTP\Client
      */
     public function propFind($url, array $properties, $depth = 0)
     {
+        $result = $this->doPropFind($url, $properties, $depth);
+
+        // If depth was 0, we only return the top item
+        if (0 === $depth) {
+            reset($result);
+            $result = current($result);
+
+            return isset($result[200]) ? $result[200] : [];
+        }
+
+        $newResult = [];
+        foreach ($result as $href => $statusList) {
+            $newResult[$href] = isset($statusList[200]) ? $statusList[200] : [];
+        }
+
+        return $newResult;
+    }
+
+    /**
+     * Does a PROPFIND request.
+     *
+     * The list of requested properties must be specified as an array, in clark
+     * notation.
+     *
+     * The returned array will contain a list of filenames as keys, and
+     * properties as values.
+     *
+     * The properties array will contain the list of properties.
+     *
+     * Depth should be either 0 or 1. A depth of 1 will cause a request to be
+     * made to the server to also return all child resources.
+     *
+     * @param string $url
+     * @param int    $depth
+     *
+     * @return array
+     */
+    private function doPropFind($url, array $properties, $depth = 0)
+    {
         $dom = new \DOMDocument('1.0', 'UTF-8');
         $dom->formatOutput = true;
         $root = $dom->createElementNS('DAV:', 'd:propfind');
@@ -234,20 +273,7 @@ class Client extends HTTP\Client
 
         $result = $this->parseMultiStatus($response->getBodyAsString());
 
-        // If depth was 0, we only return the top item
-        if (0 === $depth) {
-            reset($result);
-            $result = current($result);
-
-            return isset($result[200]) ? $result[200] : [];
-        }
-
-        $newResult = [];
-        foreach ($result as $href => $statusList) {
-            $newResult[$href] = isset($statusList[200]) ? $statusList[200] : [];
-        }
-
-        return $newResult;
+        return $result;
     }
 
     /**

--- a/tests/Sabre/DAV/ClientTest.php
+++ b/tests/Sabre/DAV/ClientTest.php
@@ -304,8 +304,11 @@ XML;
         $result = $client->propFindUnfiltered('folder1', ['{DAV:}resourcetype', '{DAV:}displayname', '{urn:zim}gir']);
 
         self::assertEquals([
-            '{DAV:}resourcetype' => new Xml\Property\ResourceType('{DAV:}collection'),
-            '{DAV:}displayname' => 'Folder1',
+            'properties' => [
+                '{DAV:}resourcetype' => new Xml\Property\ResourceType('{DAV:}collection'),
+                '{DAV:}displayname' => 'Folder1',
+            ],
+            'status' => 200,
         ], $result);
 
         $request = $client->request;
@@ -382,20 +385,32 @@ XML;
 
         self::assertEquals([
             '/folder1' => [
-                '{DAV:}resourcetype' => new Xml\Property\ResourceType('{DAV:}collection'),
-                '{DAV:}displayname' => 'Folder1',
+                'properties' => [
+                    '{DAV:}resourcetype' => new Xml\Property\ResourceType('{DAV:}collection'),
+                    '{DAV:}displayname' => 'Folder1',
+                ],
+                'status' => 200,
             ],
             '/folder1/file1.txt' => [
-                '{DAV:}resourcetype' => null,
-                '{DAV:}displayname' => 'File1',
+                'properties' => [
+                    '{DAV:}resourcetype' => null,
+                    '{DAV:}displayname' => 'File1',
+                ],
+                'status' => 200,
             ],
             '/folder1/file2.txt' => [
-                '{DAV:}resourcetype' => null,
-                '{DAV:}displayname' => 'File2',
+                'properties' => [
+                    '{DAV:}resourcetype' => null,
+                    '{DAV:}displayname' => 'File2',
+                ],
+                'status' => 403,
             ],
             '/folder1/file3.txt' => [
-                '{DAV:}resourcetype' => null,
-                '{DAV:}displayname' => 'File3',
+                'properties' => [
+                    '{DAV:}resourcetype' => null,
+                    '{DAV:}displayname' => 'File3',
+                ],
+                'status' => 425,
             ],
         ], $result);
 

--- a/tests/Sabre/DAV/ClientTest.php
+++ b/tests/Sabre/DAV/ClientTest.php
@@ -270,6 +270,144 @@ XML;
         ], $request->getHeaders());
     }
 
+    /**
+     * An "unfiltered" PROPFIND on a folder containing resources will include the
+     * meta-data for resources that have a status that is not 200.
+     * For example, resources that are "403" (access is forbidden to the user)
+     * or "425" (too early), the resource may have been recently uploaded and
+     * still has some processing happening in the server before being made
+     * available for regular access.
+     */
+    public function testPropFindUnfilteredDepth0()
+    {
+        $client = new ClientMock([
+            'baseUri' => '/',
+        ]);
+
+        $responseBody = <<<XML
+<?xml version="1.0"?>
+<d:multistatus xmlns:d="DAV:">
+  <d:response>
+    <d:href>/folder1</d:href>
+    <d:propstat>
+      <d:prop>
+        <d:resourcetype><d:collection/></d:resourcetype>
+        <d:displayname>Folder1</d:displayname>
+      </d:prop>
+      <d:status>HTTP/1.1 200 OK</d:status>
+    </d:propstat>
+  </d:response>
+</d:multistatus>
+XML;
+
+        $client->response = new Response(207, [], $responseBody);
+        $result = $client->propFindUnfiltered('folder1', ['{DAV:}resourcetype', '{DAV:}displayname', '{urn:zim}gir']);
+
+        self::assertEquals([
+            '{DAV:}resourcetype' => new Xml\Property\ResourceType('{DAV:}collection'),
+            '{DAV:}displayname' => 'Folder1',
+        ], $result);
+
+        $request = $client->request;
+        self::assertEquals('PROPFIND', $request->getMethod());
+        self::assertEquals('/folder1', $request->getUrl());
+        self::assertEquals([
+            'Depth' => ['0'],
+            'Content-Type' => ['application/xml'],
+        ], $request->getHeaders());
+    }
+
+    /**
+     * An "unfiltered" PROPFIND on a folder containing resources will include the
+     * meta-data for resources that have a status that is not 200.
+     * For example, resources that are "403" (access is forbidden to the user)
+     * or "425" (too early), the resource may have been recently uploaded and
+     * still has some processing happening in the server before being made
+     * available for regular access.
+     */
+    public function testPropFindUnfiltered()
+    {
+        $client = new ClientMock([
+            'baseUri' => '/',
+        ]);
+
+        $responseBody = <<<XML
+<?xml version="1.0"?>
+<d:multistatus xmlns:d="DAV:">
+  <d:response>
+    <d:href>/folder1</d:href>
+    <d:propstat>
+      <d:prop>
+        <d:resourcetype><d:collection/></d:resourcetype>
+        <d:displayname>Folder1</d:displayname>
+      </d:prop>
+      <d:status>HTTP/1.1 200 OK</d:status>
+    </d:propstat>
+  </d:response>
+  <d:response>
+    <d:href>/folder1/file1.txt</d:href>
+    <d:propstat>
+      <d:prop>
+        <d:resourcetype/>
+        <d:displayname>File1</d:displayname>
+      </d:prop>
+      <d:status>HTTP/1.1 200 OK</d:status>
+    </d:propstat>
+  </d:response>
+  <d:response>
+    <d:href>/folder1/file2.txt</d:href>
+    <d:propstat>
+      <d:prop>
+        <d:resourcetype/>
+        <d:displayname>File2</d:displayname>
+      </d:prop>
+      <d:status>HTTP/1.1 403 Forbidden</d:status>
+    </d:propstat>
+  </d:response>
+  <d:response>
+    <d:href>/folder1/file3.txt</d:href>
+    <d:propstat>
+      <d:prop>
+        <d:resourcetype/>
+        <d:displayname>File3</d:displayname>
+      </d:prop>
+      <d:status>HTTP/1.1 425 Too Early</d:status>
+    </d:propstat>
+  </d:response>
+</d:multistatus>
+XML;
+
+        $client->response = new Response(207, [], $responseBody);
+        $result = $client->propFindUnfiltered('folder1', ['{DAV:}resourcetype', '{DAV:}displayname', '{urn:zim}gir'], 1);
+
+        self::assertEquals([
+            '/folder1' => [
+                '{DAV:}resourcetype' => new Xml\Property\ResourceType('{DAV:}collection'),
+                '{DAV:}displayname' => 'Folder1',
+            ],
+            '/folder1/file1.txt' => [
+                '{DAV:}resourcetype' => null,
+                '{DAV:}displayname' => 'File1',
+            ],
+            '/folder1/file2.txt' => [
+                '{DAV:}resourcetype' => null,
+                '{DAV:}displayname' => 'File2',
+            ],
+            '/folder1/file3.txt' => [
+                '{DAV:}resourcetype' => null,
+                '{DAV:}displayname' => 'File3',
+            ],
+        ], $result);
+
+        $request = $client->request;
+        self::assertEquals('PROPFIND', $request->getMethod());
+        self::assertEquals('/folder1', $request->getUrl());
+        self::assertEquals([
+            'Depth' => ['1'],
+            'Content-Type' => ['application/xml'],
+        ], $request->getHeaders());
+    }
+
     public function testPropPatch()
     {
         $client = new ClientMock([

--- a/tests/Sabre/DAV/ClientTest.php
+++ b/tests/Sabre/DAV/ClientTest.php
@@ -185,6 +185,91 @@ XML;
         ], $request->getHeaders());
     }
 
+    /**
+     * A PROPFIND on a folder containing resources will filter out the meta-data
+     * for resources that have a status that is not 200.
+     * For example, resources that are "403" (access is forbidden to the user)
+     * or "425" (too early), the resource may have been recently uploaded and
+     * still has some processing happening in the server before being made
+     * available for regular access.
+     */
+    public function testPropFindMixedErrors()
+    {
+        $client = new ClientMock([
+            'baseUri' => '/',
+        ]);
+
+        $responseBody = <<<XML
+<?xml version="1.0"?>
+<d:multistatus xmlns:d="DAV:">
+  <d:response>
+    <d:href>/folder1</d:href>
+    <d:propstat>
+      <d:prop>
+        <d:resourcetype><d:collection/></d:resourcetype>
+        <d:displayname>Folder1</d:displayname>
+      </d:prop>
+      <d:status>HTTP/1.1 200 OK</d:status>
+    </d:propstat>
+  </d:response>
+  <d:response>
+    <d:href>/folder1/file1.txt</d:href>
+    <d:propstat>
+      <d:prop>
+        <d:resourcetype/>
+        <d:displayname>File1</d:displayname>
+      </d:prop>
+      <d:status>HTTP/1.1 200 OK</d:status>
+    </d:propstat>
+  </d:response>
+  <d:response>
+    <d:href>/folder1/file2.txt</d:href>
+    <d:propstat>
+      <d:prop>
+        <d:resourcetype/>
+        <d:displayname>File2</d:displayname>
+      </d:prop>
+      <d:status>HTTP/1.1 403 Forbidden</d:status>
+    </d:propstat>
+  </d:response>
+  <d:response>
+    <d:href>/folder1/file3.txt</d:href>
+    <d:propstat>
+      <d:prop>
+        <d:resourcetype/>
+        <d:displayname>File3</d:displayname>
+      </d:prop>
+      <d:status>HTTP/1.1 425 Too Early</d:status>
+    </d:propstat>
+  </d:response>
+</d:multistatus>
+XML;
+
+        $client->response = new Response(207, [], $responseBody);
+        $result = $client->propFind('folder1', ['{DAV:}resourcetype', '{DAV:}displayname', '{urn:zim}gir'], 1);
+
+        self::assertEquals([
+            '/folder1' => [
+            '{DAV:}resourcetype' => new Xml\Property\ResourceType('{DAV:}collection'),
+            '{DAV:}displayname' => 'Folder1',
+            ],
+            '/folder1/file1.txt' => [
+                '{DAV:}resourcetype' => null,
+                '{DAV:}displayname' => 'File1',
+            ],
+            '/folder1/file2.txt' => [],
+            '/folder1/file3.txt' => [],
+        ], $result);
+
+        $request = $client->request;
+        self::assertEquals('PROPFIND', $request->getMethod());
+        self::assertEquals('/folder1', $request->getUrl());
+        self::assertEquals([
+            'Depth' => ['1'],
+            'Content-Type' => ['application/xml'],
+        ], $request->getHeaders());
+    }
+
     public function testPropPatch()
     {
         $client = new ClientMock([

--- a/tests/Sabre/DAV/ClientTest.php
+++ b/tests/Sabre/DAV/ClientTest.php
@@ -296,19 +296,33 @@ XML;
       </d:prop>
       <d:status>HTTP/1.1 200 OK</d:status>
     </d:propstat>
+    <d:propstat>
+      <d:prop>
+        <d:contentlength></d:contentlength>
+      </d:prop>
+      <d:status>HTTP/1.1 404 Not Found</d:status>
+    </d:propstat>
   </d:response>
 </d:multistatus>
 XML;
 
         $client->response = new Response(207, [], $responseBody);
-        $result = $client->propFindUnfiltered('folder1', ['{DAV:}resourcetype', '{DAV:}displayname', '{urn:zim}gir']);
+        $result = $client->propFindUnfiltered('folder1', ['{DAV:}resourcetype', '{DAV:}displayname', '{DAV:}contentlength', '{urn:zim}gir']);
 
         self::assertEquals([
-            'properties' => [
-                '{DAV:}resourcetype' => new Xml\Property\ResourceType('{DAV:}collection'),
-                '{DAV:}displayname' => 'Folder1',
+            [
+                'properties' => [
+                    '{DAV:}resourcetype' => new Xml\Property\ResourceType('{DAV:}collection'),
+                    '{DAV:}displayname' => 'Folder1',
+                ],
+                'status' => 200,
             ],
-            'status' => 200,
+            [
+                'properties' => [
+                    '{DAV:}contentlength' => null,
+                ],
+                'status' => 404,
+            ],
         ], $result);
 
         $request = $client->request;
@@ -410,42 +424,64 @@ XML;
 
         self::assertEquals([
             '/folder1' => [
-                'properties' => [
-                    '{DAV:}resourcetype' => new Xml\Property\ResourceType('{DAV:}collection'),
-                    '{DAV:}displayname' => 'Folder1',
+                [
+                    'properties' => [
+                        '{DAV:}resourcetype' => new Xml\Property\ResourceType('{DAV:}collection'),
+                        '{DAV:}displayname' => 'Folder1',
+                    ],
+                    'status' => 200,
                 ],
-                'status' => 200,
+                 [
+                    'properties' => [
+                        '{DAV:}contentlength' => null,
+                    ],
+                    'status' => 404,
+                ],
             ],
             '/folder1/file1.txt' => [
-                'properties' => [
-                    '{DAV:}resourcetype' => null,
-                    '{DAV:}displayname' => 'File1',
-                    '{DAV:}contentlength' => 12,
+                [
+                    'properties' => [
+                        '{DAV:}resourcetype' => null,
+                        '{DAV:}displayname' => 'File1',
+                        '{DAV:}contentlength' => 12,
+                    ],
+                    'status' => 200,
                 ],
-                'status' => 200,
             ],
             '/folder1/file2.txt' => [
-                'properties' => [
-                    '{DAV:}resourcetype' => null,
-                    '{DAV:}displayname' => 'File2',
-                    '{DAV:}contentlength' => 27,
+                [
+                    'properties' => [
+                        '{DAV:}resourcetype' => null,
+                        '{DAV:}displayname' => 'File2',
+                        '{DAV:}contentlength' => 27,
+                    ],
+                    'status' => 403,
                 ],
-                'status' => 403,
             ],
             '/folder1/file3.txt' => [
-                'properties' => [
-                    '{DAV:}resourcetype' => null,
-                    '{DAV:}displayname' => 'File3',
-                    '{DAV:}contentlength' => 42,
+                [
+                    'properties' => [
+                        '{DAV:}resourcetype' => null,
+                        '{DAV:}displayname' => 'File3',
+                        '{DAV:}contentlength' => 42,
+                    ],
+                    'status' => 425,
                 ],
-                'status' => 425,
             ],
             '/folder1/subfolder' => [
-                'properties' => [
-                    '{DAV:}resourcetype' => new Xml\Property\ResourceType('{DAV:}collection'),
-                    '{DAV:}displayname' => 'SubFolder',
+                [
+                    'properties' => [
+                        '{DAV:}resourcetype' => new Xml\Property\ResourceType('{DAV:}collection'),
+                        '{DAV:}displayname' => 'SubFolder',
+                    ],
+                    'status' => 200,
                 ],
-                'status' => 200,
+                [
+                    'properties' => [
+                        '{DAV:}contentlength' => null,
+                    ],
+                    'status' => 404,
+                ],
             ],
         ], $result);
 

--- a/tests/Sabre/DAV/ClientTest.php
+++ b/tests/Sabre/DAV/ClientTest.php
@@ -346,6 +346,12 @@ XML;
       </d:prop>
       <d:status>HTTP/1.1 200 OK</d:status>
     </d:propstat>
+    <d:propstat>
+      <d:prop>
+        <d:contentlength></d:contentlength>
+      </d:prop>
+      <d:status>HTTP/1.1 404 Not Found</d:status>
+    </d:propstat>
   </d:response>
   <d:response>
     <d:href>/folder1/file1.txt</d:href>
@@ -353,6 +359,7 @@ XML;
       <d:prop>
         <d:resourcetype/>
         <d:displayname>File1</d:displayname>
+        <d:contentlength>12</d:contentlength>
       </d:prop>
       <d:status>HTTP/1.1 200 OK</d:status>
     </d:propstat>
@@ -363,6 +370,7 @@ XML;
       <d:prop>
         <d:resourcetype/>
         <d:displayname>File2</d:displayname>
+        <d:contentlength>27</d:contentlength>
       </d:prop>
       <d:status>HTTP/1.1 403 Forbidden</d:status>
     </d:propstat>
@@ -373,15 +381,32 @@ XML;
       <d:prop>
         <d:resourcetype/>
         <d:displayname>File3</d:displayname>
+        <d:contentlength>42</d:contentlength>
       </d:prop>
       <d:status>HTTP/1.1 425 Too Early</d:status>
+    </d:propstat>
+  </d:response>
+  <d:response>
+    <d:href>/folder1/subfolder</d:href>
+    <d:propstat>
+      <d:prop>
+        <d:resourcetype><d:collection/></d:resourcetype>
+        <d:displayname>SubFolder</d:displayname>
+      </d:prop>
+      <d:status>HTTP/1.1 200 OK</d:status>
+    </d:propstat>
+    <d:propstat>
+      <d:prop>
+        <d:contentlength></d:contentlength>
+      </d:prop>
+      <d:status>HTTP/1.1 404 Not Found</d:status>
     </d:propstat>
   </d:response>
 </d:multistatus>
 XML;
 
         $client->response = new Response(207, [], $responseBody);
-        $result = $client->propFindUnfiltered('folder1', ['{DAV:}resourcetype', '{DAV:}displayname', '{urn:zim}gir'], 1);
+        $result = $client->propFindUnfiltered('folder1', ['{DAV:}resourcetype', '{DAV:}displayname', '{DAV:}contentlength', '{urn:zim}gir'], 1);
 
         self::assertEquals([
             '/folder1' => [
@@ -395,6 +420,7 @@ XML;
                 'properties' => [
                     '{DAV:}resourcetype' => null,
                     '{DAV:}displayname' => 'File1',
+                    '{DAV:}contentlength' => 12,
                 ],
                 'status' => 200,
             ],
@@ -402,6 +428,7 @@ XML;
                 'properties' => [
                     '{DAV:}resourcetype' => null,
                     '{DAV:}displayname' => 'File2',
+                    '{DAV:}contentlength' => 27,
                 ],
                 'status' => 403,
             ],
@@ -409,8 +436,16 @@ XML;
                 'properties' => [
                     '{DAV:}resourcetype' => null,
                     '{DAV:}displayname' => 'File3',
+                    '{DAV:}contentlength' => 42,
                 ],
                 'status' => 425,
+            ],
+            '/folder1/subfolder' => [
+                'properties' => [
+                    '{DAV:}resourcetype' => new Xml\Property\ResourceType('{DAV:}collection'),
+                    '{DAV:}displayname' => 'SubFolder',
+                ],
+                'status' => 200,
             ],
         ], $result);
 


### PR DESCRIPTION
1) add an extra unit test to cover the existing behaviour of `propFind` when the response has multiple resources listed, and the resources have different status.

2) refactor out the common code that we want to keep using into `doPropFind`

3) add `propFindUnfiltered` method that returns all the propfind data, including for resources that had a non-200 status, and a unit test to cover it.

4) return both properties and status in propFindUnfiltered
The propfind data was returned (key-value array of properties and their values). But the individual statuses were not anywhere in the returned data. The caller is going to want to be able to find out the status of the propfind of each resource. Where to put that in the returned data, without polluting the key-values of the properties themselves? I have made the returned array have:
- array of resources keyed by the resource name
- inside that, and array with keys 'properties' and 'status'
- 'properties' has the key-value array of properties and their values
- 'status' has the status returned for that resource

Question: I have currently assumed that there is just one status value for each resource - for example "file1.txt" might have got a 418 "I'm a teapot" status, and there are a list of properties that were returned. But is it possible that each property might have a different status? 
(some properties were "easy" for the server to get, and have 200 status, other properties were "secure" and had a 403 "forbidden" status for the requesting user, other properties got 404 "not found" because that file in the folder did not have that meta-data...)