### PR TITLE
feat: return PROPFIND properties indexed by status

### DIFF
--- a/lib/DAV/Client.php
+++ b/lib/DAV/Client.php
@@ -174,7 +174,7 @@ class Client extends HTTP\Client
     }
 
     /**
-     * Does a PROPFIND request.
+     * Does a PROPFIND request with filtered response.
      *
      * The list of requested properties must be specified as an array, in clark
      * notation.
@@ -209,6 +209,50 @@ class Client extends HTTP\Client
         $newResult = [];
         foreach ($result as $href => $statusList) {
             $newResult[$href] = isset($statusList[200]) ? $statusList[200] : [];
+        }
+
+        return $newResult;
+    }
+
+    /**
+     * Does a PROPFIND request with unfiltered response.
+     *
+     * The list of requested properties must be specified as an array, in clark
+     * notation.
+     *
+     * The returned array will contain a list of filenames as keys, and
+     * properties as values.
+     *
+     * The properties array will contain the list of properties. All properties
+     * that are actually returned from the server are returned by this method.
+     *
+     * Depth should be either 0 or 1. A depth of 1 will cause a request to be
+     * made to the server to also return all child resources.
+     *
+     * @param string $url
+     * @param int    $depth
+     *
+     * @return array
+     */
+    public function propFindUnfiltered($url, array $properties, $depth = 0)
+    {
+        $result = $this->doPropFind($url, $properties, $depth);
+
+        // If depth was 0, we only return the top item
+        if (0 === $depth) {
+            reset($result);
+            $resourceStatusList = current($result);
+            reset($resourceStatusList);
+            // $resourceStatus = key($resourceStatusList);
+            return current($resourceStatusList);
+        }
+
+        $newResult = [];
+        foreach ($result as $href => $statusList) {
+            reset($statusList);
+            // $resourceStatus = key($statusList);
+            $resourceProperties = current($statusList);
+            $newResult[$href] = $resourceProperties;
         }
 
         return $newResult;

--- a/lib/DAV/Client.php
+++ b/lib/DAV/Client.php
@@ -243,16 +243,14 @@ class Client extends HTTP\Client
             reset($result);
             $resourceStatusList = current($result);
             reset($resourceStatusList);
-            // $resourceStatus = key($resourceStatusList);
-            return current($resourceStatusList);
+
+            return ['properties' => current($resourceStatusList), 'status' => key($resourceStatusList)];
         }
 
         $newResult = [];
         foreach ($result as $href => $statusList) {
             reset($statusList);
-            // $resourceStatus = key($statusList);
-            $resourceProperties = current($statusList);
-            $newResult[$href] = $resourceProperties;
+            $newResult[$href] = ['properties' => current($statusList), 'status' => key($statusList)];
         }
 
         return $newResult;

--- a/lib/DAV/Client.php
+++ b/lib/DAV/Client.php
@@ -242,19 +242,11 @@ class Client extends HTTP\Client
         // If depth was 0, we only return the top item
         if (0 === $depth) {
             reset($result);
-            $statusList = current($result);
-            foreach ($statusList as $statusCode => $associatedProperties) {
-                $newResult[] = ['properties' => $associatedProperties, 'status' => $statusCode];
-            }
-        } else {
-            foreach ($result as $href => $statusList) {
-                foreach ($statusList as $statusCode => $associatedProperties) {
-                    $newResult[$href][] = ['properties' => $associatedProperties, 'status' => $statusCode];
-                }
-            }
-        }
 
-        return $newResult;
+            return current($result);
+        } else {
+            return $result;
+        }
     }
 
     /**

--- a/lib/DAV/Client.php
+++ b/lib/DAV/Client.php
@@ -179,15 +179,17 @@ class Client extends HTTP\Client
      * The list of requested properties must be specified as an array, in clark
      * notation.
      *
-     * The returned array will contain a list of filenames as keys, and
-     * properties as values.
-     *
-     * The properties array will contain the list of properties. Only properties
-     * that are actually returned from the server (without error) will be
-     * returned, anything else is discarded.
-     *
      * Depth should be either 0 or 1. A depth of 1 will cause a request to be
      * made to the server to also return all child resources.
+     *
+     * For depth 0, just the array of properties for the resource is returned.
+     *
+     * For depth 1, the returned array will contain a list of resource names as keys,
+     * and an array of properties as values.
+     *
+     * The array of properties will contain the properties as keys with their values as the value.
+     * Only properties that are actually returned from the server without error will be
+     * returned, anything else is discarded.
      *
      * @param string $url
      * @param int    $depth
@@ -220,14 +222,18 @@ class Client extends HTTP\Client
      * The list of requested properties must be specified as an array, in clark
      * notation.
      *
-     * The returned array will contain a list of filenames as keys, and
-     * properties as values.
-     *
-     * The properties array will contain the list of properties. All properties
-     * that are actually returned from the server are returned by this method.
-     *
      * Depth should be either 0 or 1. A depth of 1 will cause a request to be
      * made to the server to also return all child resources.
+     *
+     * For depth 0, just the multi-level array of status and properties for the resource is returned.
+     *
+     * For depth 1, the returned array will contain a list of resources as keys and
+     * a multi-level array containing status and properties as value.
+     *
+     * The multi-level array of status and properties is formatted the same as what is
+     * documented for parseMultiStatus.
+     *
+     * All properties that are actually returned from the server are returned by this method.
      *
      * @param string $url
      * @param int    $depth
@@ -237,7 +243,6 @@ class Client extends HTTP\Client
     public function propFindUnfiltered($url, array $properties, $depth = 0)
     {
         $result = $this->doPropFind($url, $properties, $depth);
-        $newResult = [];
 
         // If depth was 0, we only return the top item
         if (0 === $depth) {
@@ -255,13 +260,14 @@ class Client extends HTTP\Client
      * The list of requested properties must be specified as an array, in clark
      * notation.
      *
-     * The returned array will contain a list of filenames as keys, and
-     * properties as values.
-     *
-     * The properties array will contain the list of properties.
-     *
      * Depth should be either 0 or 1. A depth of 1 will cause a request to be
      * made to the server to also return all child resources.
+     *
+     * The returned array will contain a list of resources as keys and
+     * a multi-level array containing status and properties as value.
+     *
+     * The multi-level array of status and properties is formatted the same as what is
+     * documented for parseMultiStatus.
      *
      * @param string $url
      * @param int    $depth
@@ -306,9 +312,7 @@ class Client extends HTTP\Client
             throw new HTTP\ClientHttpException($response);
         }
 
-        $result = $this->parseMultiStatus($response->getBodyAsString());
-
-        return $result;
+        return $this->parseMultiStatus($response->getBodyAsString());
     }
 
     /**

--- a/lib/DAV/Client.php
+++ b/lib/DAV/Client.php
@@ -237,20 +237,21 @@ class Client extends HTTP\Client
     public function propFindUnfiltered($url, array $properties, $depth = 0)
     {
         $result = $this->doPropFind($url, $properties, $depth);
+        $newResult = [];
 
         // If depth was 0, we only return the top item
         if (0 === $depth) {
             reset($result);
-            $resourceStatusList = current($result);
-            reset($resourceStatusList);
-
-            return ['properties' => current($resourceStatusList), 'status' => key($resourceStatusList)];
-        }
-
-        $newResult = [];
-        foreach ($result as $href => $statusList) {
-            reset($statusList);
-            $newResult[$href] = ['properties' => current($statusList), 'status' => key($statusList)];
+            $statusList = current($result);
+            foreach ($statusList as $statusCode => $associatedProperties) {
+                $newResult[] = ['properties' => $associatedProperties, 'status' => $statusCode];
+            }
+        } else {
+            foreach ($result as $href => $statusList) {
+                foreach ($statusList as $statusCode => $associatedProperties) {
+                    $newResult[$href][] = ['properties' => $associatedProperties, 'status' => $statusCode];
+                }
+            }
         }
 
         return $newResult;

--- a/lib/DAV/Client.php
+++ b/lib/DAV/Client.php
@@ -174,7 +174,7 @@ class Client extends HTTP\Client
     }
 
     /**
-     * Does a PROPFIND request with filtered response.
+     * Does a PROPFIND request with filtered response returning only available properties.
      *
      * The list of requested properties must be specified as an array, in clark
      * notation.
@@ -191,12 +191,9 @@ class Client extends HTTP\Client
      * Only properties that are actually returned from the server without error will be
      * returned, anything else is discarded.
      *
-     * @param string $url
-     * @param int    $depth
-     *
-     * @return array
+     * @param 1|0 $depth
      */
-    public function propFind($url, array $properties, $depth = 0)
+    public function propFind(string $url, array $properties, int $depth = 0): array
     {
         $result = $this->doPropFind($url, $properties, $depth);
 
@@ -235,12 +232,9 @@ class Client extends HTTP\Client
      *
      * All properties that are actually returned from the server are returned by this method.
      *
-     * @param string $url
-     * @param int    $depth
-     *
-     * @return array
+     * @param 1|0 $depth
      */
-    public function propFindUnfiltered($url, array $properties, $depth = 0)
+    public function propFindUnfiltered(string $url, array $properties, int $depth = 0): array
     {
         $result = $this->doPropFind($url, $properties, $depth);
 
@@ -269,12 +263,9 @@ class Client extends HTTP\Client
      * The multi-level array of status and properties is formatted the same as what is
      * documented for parseMultiStatus.
      *
-     * @param string $url
-     * @param int    $depth
-     *
-     * @return array
+     * @param 1|0 $depth
      */
-    private function doPropFind($url, array $properties, $depth = 0)
+    private function doPropFind(string $url, array $properties, int $depth = 0): array
     {
         $dom = new \DOMDocument('1.0', 'UTF-8');
         $dom->formatOutput = true;

--- a/lib/DAV/Client.php
+++ b/lib/DAV/Client.php
@@ -196,6 +196,45 @@ class Client extends HTTP\Client
      */
     public function propFind($url, array $properties, $depth = 0)
     {
+        $result = $this->doPropFind($url, $properties, $depth);
+
+        // If depth was 0, we only return the top item
+        if (0 === $depth) {
+            reset($result);
+            $result = current($result);
+
+            return isset($result[200]) ? $result[200] : [];
+        }
+
+        $newResult = [];
+        foreach ($result as $href => $statusList) {
+            $newResult[$href] = isset($statusList[200]) ? $statusList[200] : [];
+        }
+
+        return $newResult;
+    }
+
+    /**
+     * Does a PROPFIND request.
+     *
+     * The list of requested properties must be specified as an array, in clark
+     * notation.
+     *
+     * The returned array will contain a list of filenames as keys, and
+     * properties as values.
+     *
+     * The properties array will contain the list of properties.
+     *
+     * Depth should be either 0 or 1. A depth of 1 will cause a request to be
+     * made to the server to also return all child resources.
+     *
+     * @param string $url
+     * @param int    $depth
+     *
+     * @return array
+     */
+    private function doPropFind($url, array $properties, $depth = 0)
+    {
         $dom = new \DOMDocument('1.0', 'UTF-8');
         $dom->formatOutput = true;
         $root = $dom->createElementNS('DAV:', 'd:propfind');
@@ -234,20 +273,7 @@ class Client extends HTTP\Client
 
         $result = $this->parseMultiStatus($response->getBodyAsString());
 
-        // If depth was 0, we only return the top item
-        if (0 === $depth) {
-            reset($result);
-            $result = current($result);
-
-            return isset($result[200]) ? $result[200] : [];
-        }
-
-        $newResult = [];
-        foreach ($result as $href => $statusList) {
-            $newResult[$href] = isset($statusList[200]) ? $statusList[200] : [];
-        }
-
-        return $newResult;
+        return $result;
     }
 
     /**

--- a/tests/Sabre/DAV/ClientTest.php
+++ b/tests/Sabre/DAV/ClientTest.php
@@ -304,8 +304,11 @@ XML;
         $result = $client->propFindUnfiltered('folder1', ['{DAV:}resourcetype', '{DAV:}displayname', '{urn:zim}gir']);
 
         self::assertEquals([
-            '{DAV:}resourcetype' => new Xml\Property\ResourceType('{DAV:}collection'),
-            '{DAV:}displayname' => 'Folder1',
+            'properties' => [
+                '{DAV:}resourcetype' => new Xml\Property\ResourceType('{DAV:}collection'),
+                '{DAV:}displayname' => 'Folder1',
+            ],
+            'status' => 200,
         ], $result);
 
         $request = $client->request;
@@ -382,20 +385,32 @@ XML;
 
         self::assertEquals([
             '/folder1' => [
-                '{DAV:}resourcetype' => new Xml\Property\ResourceType('{DAV:}collection'),
-                '{DAV:}displayname' => 'Folder1',
+                'properties' => [
+                    '{DAV:}resourcetype' => new Xml\Property\ResourceType('{DAV:}collection'),
+                    '{DAV:}displayname' => 'Folder1',
+                ],
+                'status' => 200,
             ],
             '/folder1/file1.txt' => [
-                '{DAV:}resourcetype' => null,
-                '{DAV:}displayname' => 'File1',
+                'properties' => [
+                    '{DAV:}resourcetype' => null,
+                    '{DAV:}displayname' => 'File1',
+                ],
+                'status' => 200,
             ],
             '/folder1/file2.txt' => [
-                '{DAV:}resourcetype' => null,
-                '{DAV:}displayname' => 'File2',
+                'properties' => [
+                    '{DAV:}resourcetype' => null,
+                    '{DAV:}displayname' => 'File2',
+                ],
+                'status' => 403,
             ],
             '/folder1/file3.txt' => [
-                '{DAV:}resourcetype' => null,
-                '{DAV:}displayname' => 'File3',
+                'properties' => [
+                    '{DAV:}resourcetype' => null,
+                    '{DAV:}displayname' => 'File3',
+                ],
+                'status' => 425,
             ],
         ], $result);
 

--- a/tests/Sabre/DAV/ClientTest.php
+++ b/tests/Sabre/DAV/ClientTest.php
@@ -270,6 +270,144 @@ XML;
         ], $request->getHeaders());
     }
 
+    /**
+     * An "unfiltered" PROPFIND on a folder containing resources will include the
+     * meta-data for resources that have a status that is not 200.
+     * For example, resources that are "403" (access is forbidden to the user)
+     * or "425" (too early), the resource may have been recently uploaded and
+     * still has some processing happening in the server before being made
+     * available for regular access.
+     */
+    public function testPropFindUnfilteredDepth0()
+    {
+        $client = new ClientMock([
+            'baseUri' => '/',
+        ]);
+
+        $responseBody = <<<XML
+<?xml version="1.0"?>
+<d:multistatus xmlns:d="DAV:">
+  <d:response>
+    <d:href>/folder1</d:href>
+    <d:propstat>
+      <d:prop>
+        <d:resourcetype><d:collection/></d:resourcetype>
+        <d:displayname>Folder1</d:displayname>
+      </d:prop>
+      <d:status>HTTP/1.1 200 OK</d:status>
+    </d:propstat>
+  </d:response>
+</d:multistatus>
+XML;
+
+        $client->response = new Response(207, [], $responseBody);
+        $result = $client->propFindUnfiltered('folder1', ['{DAV:}resourcetype', '{DAV:}displayname', '{urn:zim}gir']);
+
+        self::assertEquals([
+            '{DAV:}resourcetype' => new Xml\Property\ResourceType('{DAV:}collection'),
+            '{DAV:}displayname' => 'Folder1',
+        ], $result);
+
+        $request = $client->request;
+        self::assertEquals('PROPFIND', $request->getMethod());
+        self::assertEquals('/folder1', $request->getUrl());
+        self::assertEquals([
+            'Depth' => ['0'],
+            'Content-Type' => ['application/xml'],
+        ], $request->getHeaders());
+    }
+
+    /**
+     * An "unfiltered" PROPFIND on a folder containing resources will include the
+     * meta-data for resources that have a status that is not 200.
+     * For example, resources that are "403" (access is forbidden to the user)
+     * or "425" (too early), the resource may have been recently uploaded and
+     * still has some processing happening in the server before being made
+     * available for regular access.
+     */
+    public function testPropFindUnfiltered()
+    {
+        $client = new ClientMock([
+            'baseUri' => '/',
+        ]);
+
+        $responseBody = <<<XML
+<?xml version="1.0"?>
+<d:multistatus xmlns:d="DAV:">
+  <d:response>
+    <d:href>/folder1</d:href>
+    <d:propstat>
+      <d:prop>
+        <d:resourcetype><d:collection/></d:resourcetype>
+        <d:displayname>Folder1</d:displayname>
+      </d:prop>
+      <d:status>HTTP/1.1 200 OK</d:status>
+    </d:propstat>
+  </d:response>
+  <d:response>
+    <d:href>/folder1/file1.txt</d:href>
+    <d:propstat>
+      <d:prop>
+        <d:resourcetype/>
+        <d:displayname>File1</d:displayname>
+      </d:prop>
+      <d:status>HTTP/1.1 200 OK</d:status>
+    </d:propstat>
+  </d:response>
+  <d:response>
+    <d:href>/folder1/file2.txt</d:href>
+    <d:propstat>
+      <d:prop>
+        <d:resourcetype/>
+        <d:displayname>File2</d:displayname>
+      </d:prop>
+      <d:status>HTTP/1.1 403 Forbidden</d:status>
+    </d:propstat>
+  </d:response>
+  <d:response>
+    <d:href>/folder1/file3.txt</d:href>
+    <d:propstat>
+      <d:prop>
+        <d:resourcetype/>
+        <d:displayname>File3</d:displayname>
+      </d:prop>
+      <d:status>HTTP/1.1 425 Too Early</d:status>
+    </d:propstat>
+  </d:response>
+</d:multistatus>
+XML;
+
+        $client->response = new Response(207, [], $responseBody);
+        $result = $client->propFindUnfiltered('folder1', ['{DAV:}resourcetype', '{DAV:}displayname', '{urn:zim}gir'], 1);
+
+        self::assertEquals([
+            '/folder1' => [
+                '{DAV:}resourcetype' => new Xml\Property\ResourceType('{DAV:}collection'),
+                '{DAV:}displayname' => 'Folder1',
+            ],
+            '/folder1/file1.txt' => [
+                '{DAV:}resourcetype' => null,
+                '{DAV:}displayname' => 'File1',
+            ],
+            '/folder1/file2.txt' => [
+                '{DAV:}resourcetype' => null,
+                '{DAV:}displayname' => 'File2',
+            ],
+            '/folder1/file3.txt' => [
+                '{DAV:}resourcetype' => null,
+                '{DAV:}displayname' => 'File3',
+            ],
+        ], $result);
+
+        $request = $client->request;
+        self::assertEquals('PROPFIND', $request->getMethod());
+        self::assertEquals('/folder1', $request->getUrl());
+        self::assertEquals([
+            'Depth' => ['1'],
+            'Content-Type' => ['application/xml'],
+        ], $request->getHeaders());
+    }
+
     public function testPropPatch()
     {
         $client = new ClientMock([

--- a/tests/Sabre/DAV/ClientTest.php
+++ b/tests/Sabre/DAV/ClientTest.php
@@ -185,6 +185,91 @@ XML;
         ], $request->getHeaders());
     }
 
+    /**
+     * A PROPFIND on a folder containing resources will filter out the meta-data
+     * for resources that have a status that is not 200.
+     * For example, resources that are "403" (access is forbidden to the user)
+     * or "425" (too early), the resource may have been recently uploaded and
+     * still has some processing happening in the server before being made
+     * available for regular access.
+     */
+    public function testPropFindMixedErrors()
+    {
+        $client = new ClientMock([
+            'baseUri' => '/',
+        ]);
+
+        $responseBody = <<<XML
+<?xml version="1.0"?>
+<d:multistatus xmlns:d="DAV:">
+  <d:response>
+    <d:href>/folder1</d:href>
+    <d:propstat>
+      <d:prop>
+        <d:resourcetype><d:collection/></d:resourcetype>
+        <d:displayname>Folder1</d:displayname>
+      </d:prop>
+      <d:status>HTTP/1.1 200 OK</d:status>
+    </d:propstat>
+  </d:response>
+  <d:response>
+    <d:href>/folder1/file1.txt</d:href>
+    <d:propstat>
+      <d:prop>
+        <d:resourcetype/>
+        <d:displayname>File1</d:displayname>
+      </d:prop>
+      <d:status>HTTP/1.1 200 OK</d:status>
+    </d:propstat>
+  </d:response>
+  <d:response>
+    <d:href>/folder1/file2.txt</d:href>
+    <d:propstat>
+      <d:prop>
+        <d:resourcetype/>
+        <d:displayname>File2</d:displayname>
+      </d:prop>
+      <d:status>HTTP/1.1 403 Forbidden</d:status>
+    </d:propstat>
+  </d:response>
+  <d:response>
+    <d:href>/folder1/file3.txt</d:href>
+    <d:propstat>
+      <d:prop>
+        <d:resourcetype/>
+        <d:displayname>File3</d:displayname>
+      </d:prop>
+      <d:status>HTTP/1.1 425 Too Early</d:status>
+    </d:propstat>
+  </d:response>
+</d:multistatus>
+XML;
+
+        $client->response = new Response(207, [], $responseBody);
+        $result = $client->propFind('folder1', ['{DAV:}resourcetype', '{DAV:}displayname', '{urn:zim}gir'], 1);
+
+        self::assertEquals([
+            '/folder1' => [
+            '{DAV:}resourcetype' => new Xml\Property\ResourceType('{DAV:}collection'),
+            '{DAV:}displayname' => 'Folder1',
+            ],
+            '/folder1/file1.txt' => [
+                '{DAV:}resourcetype' => null,
+                '{DAV:}displayname' => 'File1',
+            ],
+            '/folder1/file2.txt' => [],
+            '/folder1/file3.txt' => [],
+        ], $result);
+
+        $request = $client->request;
+        self::assertEquals('PROPFIND', $request->getMethod());
+        self::assertEquals('/folder1', $request->getUrl());
+        self::assertEquals([
+            'Depth' => ['1'],
+            'Content-Type' => ['application/xml'],
+        ], $request->getHeaders());
+    }
+
     public function testPropPatch()
     {
         $client = new ClientMock([

--- a/tests/Sabre/DAV/ClientTest.php
+++ b/tests/Sabre/DAV/ClientTest.php
@@ -296,19 +296,33 @@ XML;
       </d:prop>
       <d:status>HTTP/1.1 200 OK</d:status>
     </d:propstat>
+    <d:propstat>
+      <d:prop>
+        <d:contentlength></d:contentlength>
+      </d:prop>
+      <d:status>HTTP/1.1 404 Not Found</d:status>
+    </d:propstat>
   </d:response>
 </d:multistatus>
 XML;
 
         $client->response = new Response(207, [], $responseBody);
-        $result = $client->propFindUnfiltered('folder1', ['{DAV:}resourcetype', '{DAV:}displayname', '{urn:zim}gir']);
+        $result = $client->propFindUnfiltered('folder1', ['{DAV:}resourcetype', '{DAV:}displayname', '{DAV:}contentlength', '{urn:zim}gir']);
 
         self::assertEquals([
-            'properties' => [
-                '{DAV:}resourcetype' => new Xml\Property\ResourceType('{DAV:}collection'),
-                '{DAV:}displayname' => 'Folder1',
+            [
+                'properties' => [
+                    '{DAV:}resourcetype' => new Xml\Property\ResourceType('{DAV:}collection'),
+                    '{DAV:}displayname' => 'Folder1',
+                ],
+                'status' => 200,
             ],
-            'status' => 200,
+            [
+                'properties' => [
+                    '{DAV:}contentlength' => null,
+                ],
+                'status' => 404,
+            ],
         ], $result);
 
         $request = $client->request;
@@ -410,42 +424,64 @@ XML;
 
         self::assertEquals([
             '/folder1' => [
-                'properties' => [
-                    '{DAV:}resourcetype' => new Xml\Property\ResourceType('{DAV:}collection'),
-                    '{DAV:}displayname' => 'Folder1',
+                [
+                    'properties' => [
+                        '{DAV:}resourcetype' => new Xml\Property\ResourceType('{DAV:}collection'),
+                        '{DAV:}displayname' => 'Folder1',
+                    ],
+                    'status' => 200,
                 ],
-                'status' => 200,
+                 [
+                    'properties' => [
+                        '{DAV:}contentlength' => null,
+                    ],
+                    'status' => 404,
+                ],
             ],
             '/folder1/file1.txt' => [
-                'properties' => [
-                    '{DAV:}resourcetype' => null,
-                    '{DAV:}displayname' => 'File1',
-                    '{DAV:}contentlength' => 12,
+                [
+                    'properties' => [
+                        '{DAV:}resourcetype' => null,
+                        '{DAV:}displayname' => 'File1',
+                        '{DAV:}contentlength' => 12,
+                    ],
+                    'status' => 200,
                 ],
-                'status' => 200,
             ],
             '/folder1/file2.txt' => [
-                'properties' => [
-                    '{DAV:}resourcetype' => null,
-                    '{DAV:}displayname' => 'File2',
-                    '{DAV:}contentlength' => 27,
+                [
+                    'properties' => [
+                        '{DAV:}resourcetype' => null,
+                        '{DAV:}displayname' => 'File2',
+                        '{DAV:}contentlength' => 27,
+                    ],
+                    'status' => 403,
                 ],
-                'status' => 403,
             ],
             '/folder1/file3.txt' => [
-                'properties' => [
-                    '{DAV:}resourcetype' => null,
-                    '{DAV:}displayname' => 'File3',
-                    '{DAV:}contentlength' => 42,
+                [
+                    'properties' => [
+                        '{DAV:}resourcetype' => null,
+                        '{DAV:}displayname' => 'File3',
+                        '{DAV:}contentlength' => 42,
+                    ],
+                    'status' => 425,
                 ],
-                'status' => 425,
             ],
             '/folder1/subfolder' => [
-                'properties' => [
-                    '{DAV:}resourcetype' => new Xml\Property\ResourceType('{DAV:}collection'),
-                    '{DAV:}displayname' => 'SubFolder',
+                [
+                    'properties' => [
+                        '{DAV:}resourcetype' => new Xml\Property\ResourceType('{DAV:}collection'),
+                        '{DAV:}displayname' => 'SubFolder',
+                    ],
+                    'status' => 200,
                 ],
-                'status' => 200,
+                [
+                    'properties' => [
+                        '{DAV:}contentlength' => null,
+                    ],
+                    'status' => 404,
+                ],
             ],
         ], $result);
 

--- a/tests/Sabre/DAV/ClientTest.php
+++ b/tests/Sabre/DAV/ClientTest.php
@@ -310,18 +310,12 @@ XML;
         $result = $client->propFindUnfiltered('folder1', ['{DAV:}resourcetype', '{DAV:}displayname', '{DAV:}contentlength', '{urn:zim}gir']);
 
         self::assertEquals([
-            [
-                'properties' => [
-                    '{DAV:}resourcetype' => new Xml\Property\ResourceType('{DAV:}collection'),
-                    '{DAV:}displayname' => 'Folder1',
-                ],
-                'status' => 200,
+            200 => [
+                '{DAV:}resourcetype' => new Xml\Property\ResourceType('{DAV:}collection'),
+                '{DAV:}displayname' => 'Folder1',
             ],
-            [
-                'properties' => [
-                    '{DAV:}contentlength' => null,
-                ],
-                'status' => 404,
+            404 => [
+                '{DAV:}contentlength' => null,
             ],
         ], $result);
 
@@ -424,63 +418,42 @@ XML;
 
         self::assertEquals([
             '/folder1' => [
-                [
-                    'properties' => [
-                        '{DAV:}resourcetype' => new Xml\Property\ResourceType('{DAV:}collection'),
-                        '{DAV:}displayname' => 'Folder1',
-                    ],
-                    'status' => 200,
+                200 => [
+                    '{DAV:}resourcetype' => new Xml\Property\ResourceType('{DAV:}collection'),
+                    '{DAV:}displayname' => 'Folder1',
                 ],
-                 [
-                    'properties' => [
-                        '{DAV:}contentlength' => null,
-                    ],
-                    'status' => 404,
+                404 => [
+                    '{DAV:}contentlength' => null,
                 ],
             ],
             '/folder1/file1.txt' => [
-                [
-                    'properties' => [
-                        '{DAV:}resourcetype' => null,
-                        '{DAV:}displayname' => 'File1',
-                        '{DAV:}contentlength' => 12,
-                    ],
-                    'status' => 200,
+                200 => [
+                    '{DAV:}resourcetype' => null,
+                    '{DAV:}displayname' => 'File1',
+                    '{DAV:}contentlength' => 12,
                 ],
             ],
             '/folder1/file2.txt' => [
-                [
-                    'properties' => [
-                        '{DAV:}resourcetype' => null,
-                        '{DAV:}displayname' => 'File2',
-                        '{DAV:}contentlength' => 27,
-                    ],
-                    'status' => 403,
+                403 => [
+                    '{DAV:}resourcetype' => null,
+                    '{DAV:}displayname' => 'File2',
+                    '{DAV:}contentlength' => 27,
                 ],
             ],
             '/folder1/file3.txt' => [
-                [
-                    'properties' => [
-                        '{DAV:}resourcetype' => null,
-                        '{DAV:}displayname' => 'File3',
-                        '{DAV:}contentlength' => 42,
-                    ],
-                    'status' => 425,
+                425 => [
+                    '{DAV:}resourcetype' => null,
+                    '{DAV:}displayname' => 'File3',
+                    '{DAV:}contentlength' => 42,
                 ],
             ],
             '/folder1/subfolder' => [
-                [
-                    'properties' => [
-                        '{DAV:}resourcetype' => new Xml\Property\ResourceType('{DAV:}collection'),
-                        '{DAV:}displayname' => 'SubFolder',
-                    ],
-                    'status' => 200,
+                200 => [
+                    '{DAV:}resourcetype' => new Xml\Property\ResourceType('{DAV:}collection'),
+                    '{DAV:}displayname' => 'SubFolder',
                 ],
-                [
-                    'properties' => [
-                        '{DAV:}contentlength' => null,
-                    ],
-                    'status' => 404,
+                404 => [
+                    '{DAV:}contentlength' => null,
                 ],
             ],
         ], $result);

--- a/tests/Sabre/DAV/ClientTest.php
+++ b/tests/Sabre/DAV/ClientTest.php
@@ -346,6 +346,12 @@ XML;
       </d:prop>
       <d:status>HTTP/1.1 200 OK</d:status>
     </d:propstat>
+    <d:propstat>
+      <d:prop>
+        <d:contentlength></d:contentlength>
+      </d:prop>
+      <d:status>HTTP/1.1 404 Not Found</d:status>
+    </d:propstat>
   </d:response>
   <d:response>
     <d:href>/folder1/file1.txt</d:href>
@@ -353,6 +359,7 @@ XML;
       <d:prop>
         <d:resourcetype/>
         <d:displayname>File1</d:displayname>
+        <d:contentlength>12</d:contentlength>
       </d:prop>
       <d:status>HTTP/1.1 200 OK</d:status>
     </d:propstat>
@@ -363,6 +370,7 @@ XML;
       <d:prop>
         <d:resourcetype/>
         <d:displayname>File2</d:displayname>
+        <d:contentlength>27</d:contentlength>
       </d:prop>
       <d:status>HTTP/1.1 403 Forbidden</d:status>
     </d:propstat>
@@ -373,15 +381,32 @@ XML;
       <d:prop>
         <d:resourcetype/>
         <d:displayname>File3</d:displayname>
+        <d:contentlength>42</d:contentlength>
       </d:prop>
       <d:status>HTTP/1.1 425 Too Early</d:status>
+    </d:propstat>
+  </d:response>
+  <d:response>
+    <d:href>/folder1/subfolder</d:href>
+    <d:propstat>
+      <d:prop>
+        <d:resourcetype><d:collection/></d:resourcetype>
+        <d:displayname>SubFolder</d:displayname>
+      </d:prop>
+      <d:status>HTTP/1.1 200 OK</d:status>
+    </d:propstat>
+    <d:propstat>
+      <d:prop>
+        <d:contentlength></d:contentlength>
+      </d:prop>
+      <d:status>HTTP/1.1 404 Not Found</d:status>
     </d:propstat>
   </d:response>
 </d:multistatus>
 XML;
 
         $client->response = new Response(207, [], $responseBody);
-        $result = $client->propFindUnfiltered('folder1', ['{DAV:}resourcetype', '{DAV:}displayname', '{urn:zim}gir'], 1);
+        $result = $client->propFindUnfiltered('folder1', ['{DAV:}resourcetype', '{DAV:}displayname', '{DAV:}contentlength', '{urn:zim}gir'], 1);
 
         self::assertEquals([
             '/folder1' => [
@@ -395,6 +420,7 @@ XML;
                 'properties' => [
                     '{DAV:}resourcetype' => null,
                     '{DAV:}displayname' => 'File1',
+                    '{DAV:}contentlength' => 12,
                 ],
                 'status' => 200,
             ],
@@ -402,6 +428,7 @@ XML;
                 'properties' => [
                     '{DAV:}resourcetype' => null,
                     '{DAV:}displayname' => 'File2',
+                    '{DAV:}contentlength' => 27,
                 ],
                 'status' => 403,
             ],
@@ -409,8 +436,16 @@ XML;
                 'properties' => [
                     '{DAV:}resourcetype' => null,
                     '{DAV:}displayname' => 'File3',
+                    '{DAV:}contentlength' => 42,
                 ],
                 'status' => 425,
+            ],
+            '/folder1/subfolder' => [
+                'properties' => [
+                    '{DAV:}resourcetype' => new Xml\Property\ResourceType('{DAV:}collection'),
+                    '{DAV:}displayname' => 'SubFolder',
+                ],
+                'status' => 200,
             ],
         ], $result);
 


### PR DESCRIPTION
This is on top of PR #1518 

See the latest commit - it returns the PROPFIND data keyed by status. All the items with status `200` are in an array with key `200`, all the items with status `400` are in an array with key `400`.

That simplifies the code a bit, and avoids having the keywords "properties" and "status'.

I'm not sure if this is a better way or not.