### PR TITLE
chore: prepare 4.5.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ChangeLog
 =========
 
+4.5.1 (2023-11-23)
+-------------------------
+* #1514: fix: restore autoPrefix property of Href (@phil-davis)
+
 4.5.0 (2023-11-14)
 -------------------------
 * #1488: fix: The WebDAV response element must only contain `propstat` OR `status` element(s) (@susnux)

--- a/lib/DAV/Version.php
+++ b/lib/DAV/Version.php
@@ -16,5 +16,5 @@ class Version
     /**
      * Full version number.
      */
-    public const VERSION = '4.5.0';
+    public const VERSION = '4.5.1';
 }


### PR DESCRIPTION
This was done in the 4.5 branch and 4.5.1 was released.
Bring the changelog up-to-date in master branch.