### PR TITLE
chore: remove old dev dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,10 +33,10 @@
     "require-dev" : {
         "ext-sqlite3": "*",
         "friendsofphp/php-cs-fixer": "^2.19",
-        "monolog/monolog": "^1.27 || ^2.0",
-        "phpstan/phpstan": "^0.12 || ^1.0",
-        "phpstan/phpstan-phpunit": "^1.0",
-        "phpunit/phpunit": "^7.5 || ^8.5 || ^9.6"
+        "monolog/monolog": "^2.9",
+        "phpstan/phpstan": "^1.10",
+        "phpstan/phpstan-phpunit": "^1.3",
+        "phpunit/phpunit": "^9.6"
     },
     "suggest" : {
         "ext-curl" : "*",


### PR DESCRIPTION
PHP 7.4 can use monolog v2, phpstan v1, phpunit v9.
So there is no need to mention the older major versions of dev dependencies.