### PR TITLE
chore: prepare release 4.6.0 (master)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ChangeLog
 =========
 
+4.6.0 (2023-12-11)
+-------------------------
+* #1526: feat: add propFindUnfiltered public method to Client (@phil-davis)
+
 4.5.1 (2023-11-23)
 -------------------------
 * #1514: fix: restore autoPrefix property of Href (@phil-davis)

--- a/lib/DAV/Version.php
+++ b/lib/DAV/Version.php
@@ -16,5 +16,5 @@ class Version
     /**
      * Full version number.
      */
-    public const VERSION = '4.5.1';
+    public const VERSION = '4.6.0';
 }


### PR DESCRIPTION
forward-port the changelog from #1527 4.6 branch to master so that the master changelog is kept up-to-date.