### PR TITLE
Fixed issue with multiple invites being send out with a comma in the recipient name/address

### DIFF
--- a/lib/CalDAV/Schedule/IMipPlugin.php
+++ b/lib/CalDAV/Schedule/IMipPlugin.php
@@ -129,8 +129,12 @@ class IMipPlugin extends DAV\ServerPlugin
         if (DAV\Server::$exposeVersion) {
             $headers[] = 'X-Sabre-Version: '.DAV\Version::VERSION;
         }
+
+        preg_match_all("/[\._a-zA-Z0-9-]+@[\._a-zA-Z0-9-]+/i", $recipient, $matches);
+        $recipient_email = $matches[0][0];
+
         $this->mail(
-            $recipient,
+            $recipient_email,
             $subject,
             $iTipMessage->message->serialize(),
             $headers


### PR DESCRIPTION
When using for example Thunderbird to create an invite an adding Attendees that have a comma in their name in the addressbook (of from collected emailaddresses in received emails) like e.g.:

"test, test <test@test.com>"

multiple RCPT TO: commands are send over SMTP, potentially causing issues with the mail server (postfix/dovecot). In our case the mail server want to send the invite to both the user "test" as the email "test@test.com". User "test" does not exist, causing the invite to end up in the 'catch-all' email account.

By extracting the emailadress using a regular expression the issue is resolved.