### PR TITLE
fix getNodeForPath caching

### DIFF
--- a/lib/DAV/Tree.php
+++ b/lib/DAV/Tree.php
@@ -62,8 +62,20 @@ class Tree implements INodeByPath
             return $this->rootNode;
         }
 
-        $parts = explode('/', $path);
         $node = $this->rootNode;
+
+        // look for any cached parent and collect the parts below the parent
+        $parts = [];
+        $remainingPath = $path;
+        do {
+            list($remainingPath, $baseName) = Uri\split($remainingPath);
+            array_unshift($parts, $baseName);
+
+            if (isset($this->cache[$remainingPath])) {
+                $node = $this->cache[$remainingPath];
+                break;
+            }
+        } while ('' !== $remainingPath);
 
         while (count($parts)) {
             if (!($node instanceof ICollection)) {

--- a/tests/Sabre/DAV/TreeTest.php
+++ b/tests/Sabre/DAV/TreeTest.php
@@ -107,6 +107,23 @@ class TreeTest extends \PHPUnit\Framework\TestCase
         $this->assertInstanceOf(INode::class, $tree->getNodeForPath('subtree/sub/1'));
         $this->assertInstanceOf(INode::class, $tree->getNodeForPath('subtree/2/3'));
     }
+
+    public function testGetNodeCacheParent()
+    {
+        $tree = new TreeMock();
+
+        /** @var TreeDirectoryTester $root */
+        $root = $tree->getNodeForPath('');
+        $root->createDirectory('new');
+        $parent = $tree->getNodeForPath('new');
+        $parent->createDirectory('child');
+
+        // make it so we can't create the 'new' folder again
+        unset($root->newDirectories['new']);
+
+        // we should still be able to query child items from the 'new' folder because it is cached in the tree
+        $this->assertInstanceOf(INode::class, $tree->getNodeForPath('new/child'));
+    }
 }
 
 class TreeMock extends Tree


### PR DESCRIPTION
The change https://github.com/sabre-io/dav/pull/1060 from the recursive to iterative `getNodeForPath` means that any cached parent node isn't used anymore.

This adds some logic to find the nearest parent that is cached and start the iterative logic from there.