### PR TITLE
[4.6] Add event to allow inspecting and changing multipart responses

### DIFF
--- a/lib/DAV/Server.php
+++ b/lib/DAV/Server.php
@@ -1635,6 +1635,8 @@ class Server implements LoggerAwareInterface, EmitterInterface
      */
     public function generateMultiStatus($fileProperties, $strip404s = false)
     {
+        $this->emit('beforeMultiStatus', [&$fileProperties]);
+
         $w = $this->xml->getWriter();
         if (self::$streamMultiStatus) {
             return function () use ($fileProperties, $strip404s, $w) {


### PR DESCRIPTION
port #1074 to the major version 4 release series.

Note: the branch is currently 4.6, I expect to make a 4.7 branch from this in the next days, before releasing whatever is waiting to release.