### PR TITLE
chore: bump dev dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,8 +34,8 @@
         "ext-sqlite3": "*",
         "friendsofphp/php-cs-fixer": "^2.19",
         "monolog/monolog": "^2.9",
-        "phpstan/phpstan": "^1.10",
-        "phpstan/phpstan-phpunit": "^1.3",
+        "phpstan/phpstan": "^1.11",
+        "phpstan/phpstan-phpunit": "^1.4",
         "phpunit/phpunit": "^9.6"
     },
     "suggest" : {


### PR DESCRIPTION
`phpstan` `1.11` was released yesterday and has quite a lot of code changes. So I wanted to make sure that the code is passing with the new `phpstan`