### PR TITLE
DAV\PropPatch::handleRemaining should only register one callback

### DIFF
--- a/lib/DAV/PropPatch.php
+++ b/lib/DAV/PropPatch.php
@@ -123,12 +123,12 @@ class PropPatch
         foreach ($properties as $propertyName) {
             // HTTP Accepted
             $this->result[$propertyName] = 202;
-
-            $this->propertyUpdateCallbacks[] = [
-                $properties,
-                $callback,
-            ];
         }
+
+        $this->propertyUpdateCallbacks[] = [
+            $properties,
+            $callback,
+        ];
     }
 
     /**

--- a/tests/Sabre/DAV/PropPatchTest.php
+++ b/tests/Sabre/DAV/PropPatchTest.php
@@ -121,6 +121,32 @@ class PropPatchTest extends \PHPUnit\Framework\TestCase
         self::assertTrue($hasRan);
     }
 
+    public function testHandleMultipleRemaining()
+    {
+        $cunCounter = 0;
+
+        $this->propPatch = new PropPatch([
+            '{DAV:}displayname' => 'foo',
+            'unittest' => 'bar',
+        ]);
+
+        $this->propPatch->handleRemaining(function ($mutations) use (&$cunCounter) {
+            ++$cunCounter;
+            self::assertCount(2, $mutations);
+
+            return true;
+        });
+
+        self::assertTrue($this->propPatch->commit());
+        $result = $this->propPatch->getResult();
+        self::assertEquals([
+            '{DAV:}displayname' => 200,
+            'unittest' => 200,
+        ], $result);
+
+        self::assertSame(1, $cunCounter);
+    }
+
     public function testHandleRemainingNothingToDo()
     {
         $hasRan = false;


### PR DESCRIPTION
currently handleRemaining() will create one callback for each remaining property update but with the whole array of remaining properties as parameter. Thus doCallBackMultiProp() is being used (in each callback! It should be either one callback with an array as parameter, or it should multiple callbacks with a string as parameter)