### PR TITLE
Allow for custom iTipBroker

### DIFF
--- a/lib/CalDAV/Schedule/Plugin.php
+++ b/lib/CalDAV/Schedule/Plugin.php
@@ -25,6 +25,7 @@ use Sabre\HTTP\ResponseInterface;
 use Sabre\VObject;
 use Sabre\VObject\Component\VCalendar;
 use Sabre\VObject\ITip;
+use Sabre\VObject\ITip\Broker;
 use Sabre\VObject\ITip\Message;
 use Sabre\VObject\Reader;
 
@@ -389,7 +390,7 @@ class Plugin extends ServerPlugin
             $node->getOwner()
         );
 
-        $broker = new ITip\Broker();
+        $broker = $this->createITipBroker();
         $messages = $broker->parseEvent(null, $addresses, $node->get());
 
         foreach ($messages as $message) {
@@ -500,7 +501,7 @@ class Plugin extends ServerPlugin
             $isNewNode = true;
         }
 
-        $broker = new ITip\Broker();
+        $broker = $this->createITipBroker();
         $newObject = $broker->processMessage($iTipMessage, $currentObject);
 
         $inbox->createFile($newFileName, $iTipMessage->message->serialize());
@@ -611,7 +612,7 @@ class Plugin extends ServerPlugin
      */
     protected function processICalendarChange($oldObject, VCalendar $newObject, array $addresses, array $ignore = [], &$modified = false)
     {
-        $broker = new ITip\Broker();
+        $broker = $this->createITipBroker();
         $messages = $broker->parseEvent($newObject, $addresses, $oldObject);
 
         if ($messages) {
@@ -993,5 +994,13 @@ class Plugin extends ServerPlugin
             'description' => 'Adds calendar-auto-schedule, as defined in rfc6638',
             'link' => 'http://sabre.io/dav/scheduling/',
         ];
+    }
+
+    /**
+     * Returns an instance of the iTip\Broker.
+     */
+    protected function createITipBroker(): Broker
+    {
+        return new Broker();
     }
 }


### PR DESCRIPTION
Uses a protected function to generate the iTipBroker so that is can be overriden and used to generate a custom broker class.