### PR TITLE
refactor: Change class strings to ::class constants

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,8 @@
         "monolog/monolog": "^2.9",
         "phpstan/phpstan": "^1.11",
         "phpstan/phpstan-phpunit": "^1.4",
-        "phpunit/phpunit": "^9.6"
+        "phpunit/phpunit": "^9.6",
+        "rector/rector": "^1.2"
     },
     "suggest" : {
         "ext-curl" : "*",

--- a/composer.json
+++ b/composer.json
@@ -36,8 +36,7 @@
         "monolog/monolog": "^2.9",
         "phpstan/phpstan": "^1.11",
         "phpstan/phpstan-phpunit": "^1.4",
-        "phpunit/phpunit": "^9.6",
-        "rector/rector": "^1.2"
+        "phpunit/phpunit": "^9.6"
     },
     "suggest" : {
         "ext-curl" : "*",

--- a/lib/CalDAV/Notifications/Plugin.php
+++ b/lib/CalDAV/Notifications/Plugin.php
@@ -68,7 +68,7 @@ class Plugin extends ServerPlugin
         $server->on('propFind', [$this, 'propFind']);
 
         $server->xml->namespaceMap[self::NS_CALENDARSERVER] = 'cs';
-        $server->resourceTypeMapping['\\Sabre\\CalDAV\\Notifications\\ICollection'] = '{'.self::NS_CALENDARSERVER.'}notification';
+        $server->resourceTypeMapping[\Sabre\CalDAV\Notifications\ICollection::class] = '{'.self::NS_CALENDARSERVER.'}notification';
 
         array_push($server->protectedProperties,
             '{'.self::NS_CALENDARSERVER.'}notification-URL',

--- a/lib/CalDAV/Plugin.php
+++ b/lib/CalDAV/Plugin.php
@@ -200,18 +200,18 @@ class Plugin extends DAV\ServerPlugin
         $server->xml->namespaceMap[self::NS_CALDAV] = 'cal';
         $server->xml->namespaceMap[self::NS_CALENDARSERVER] = 'cs';
 
-        $server->xml->elementMap['{'.self::NS_CALDAV.'}supported-calendar-component-set'] = 'Sabre\\CalDAV\\Xml\\Property\\SupportedCalendarComponentSet';
-        $server->xml->elementMap['{'.self::NS_CALDAV.'}calendar-query'] = 'Sabre\\CalDAV\\Xml\\Request\\CalendarQueryReport';
-        $server->xml->elementMap['{'.self::NS_CALDAV.'}calendar-multiget'] = 'Sabre\\CalDAV\\Xml\\Request\\CalendarMultiGetReport';
-        $server->xml->elementMap['{'.self::NS_CALDAV.'}free-busy-query'] = 'Sabre\\CalDAV\\Xml\\Request\\FreeBusyQueryReport';
-        $server->xml->elementMap['{'.self::NS_CALDAV.'}mkcalendar'] = 'Sabre\\CalDAV\\Xml\\Request\\MkCalendar';
-        $server->xml->elementMap['{'.self::NS_CALDAV.'}schedule-calendar-transp'] = 'Sabre\\CalDAV\\Xml\\Property\\ScheduleCalendarTransp';
-        $server->xml->elementMap['{'.self::NS_CALDAV.'}supported-calendar-component-set'] = 'Sabre\\CalDAV\\Xml\\Property\\SupportedCalendarComponentSet';
+        $server->xml->elementMap['{'.self::NS_CALDAV.'}supported-calendar-component-set'] = \Sabre\CalDAV\Xml\Property\SupportedCalendarComponentSet::class;
+        $server->xml->elementMap['{'.self::NS_CALDAV.'}calendar-query'] = \Sabre\CalDAV\Xml\Request\CalendarQueryReport::class;
+        $server->xml->elementMap['{'.self::NS_CALDAV.'}calendar-multiget'] = \Sabre\CalDAV\Xml\Request\CalendarMultiGetReport::class;
+        $server->xml->elementMap['{'.self::NS_CALDAV.'}free-busy-query'] = \Sabre\CalDAV\Xml\Request\FreeBusyQueryReport::class;
+        $server->xml->elementMap['{'.self::NS_CALDAV.'}mkcalendar'] = \Sabre\CalDAV\Xml\Request\MkCalendar::class;
+        $server->xml->elementMap['{'.self::NS_CALDAV.'}schedule-calendar-transp'] = \Sabre\CalDAV\Xml\Property\ScheduleCalendarTransp::class;
+        $server->xml->elementMap['{'.self::NS_CALDAV.'}supported-calendar-component-set'] = \Sabre\CalDAV\Xml\Property\SupportedCalendarComponentSet::class;
 
-        $server->resourceTypeMapping['\\Sabre\\CalDAV\\ICalendar'] = '{urn:ietf:params:xml:ns:caldav}calendar';
+        $server->resourceTypeMapping[\Sabre\CalDAV\ICalendar::class] = '{urn:ietf:params:xml:ns:caldav}calendar';
 
-        $server->resourceTypeMapping['\\Sabre\\CalDAV\\Principal\\IProxyRead'] = '{http://calendarserver.org/ns/}calendar-proxy-read';
-        $server->resourceTypeMapping['\\Sabre\\CalDAV\\Principal\\IProxyWrite'] = '{http://calendarserver.org/ns/}calendar-proxy-write';
+        $server->resourceTypeMapping[\Sabre\CalDAV\Principal\IProxyRead::class] = '{http://calendarserver.org/ns/}calendar-proxy-read';
+        $server->resourceTypeMapping[\Sabre\CalDAV\Principal\IProxyWrite::class] = '{http://calendarserver.org/ns/}calendar-proxy-write';
 
         array_push($server->protectedProperties,
             '{'.self::NS_CALDAV.'}supported-calendar-component-set',

--- a/lib/CalDAV/Schedule/Plugin.php
+++ b/lib/CalDAV/Schedule/Plugin.php
@@ -113,8 +113,8 @@ class Plugin extends ServerPlugin
          * This information ensures that the {DAV:}resourcetype property has
          * the correct values.
          */
-        $server->resourceTypeMapping['\\Sabre\\CalDAV\\Schedule\\IOutbox'] = $ns.'schedule-outbox';
-        $server->resourceTypeMapping['\\Sabre\\CalDAV\\Schedule\\IInbox'] = $ns.'schedule-inbox';
+        $server->resourceTypeMapping[\Sabre\CalDAV\Schedule\IOutbox::class] = $ns.'schedule-outbox';
+        $server->resourceTypeMapping[\Sabre\CalDAV\Schedule\IInbox::class] = $ns.'schedule-inbox';
 
         /*
          * Properties we protect are made read-only by the server.

--- a/lib/CalDAV/SharingPlugin.php
+++ b/lib/CalDAV/SharingPlugin.php
@@ -83,8 +83,8 @@ class SharingPlugin extends DAV\ServerPlugin
             '{'.Plugin::NS_CALENDARSERVER.'}shared-url'
         );
 
-        $this->server->xml->elementMap['{'.Plugin::NS_CALENDARSERVER.'}share'] = 'Sabre\\CalDAV\\Xml\\Request\\Share';
-        $this->server->xml->elementMap['{'.Plugin::NS_CALENDARSERVER.'}invite-reply'] = 'Sabre\\CalDAV\\Xml\\Request\\InviteReply';
+        $this->server->xml->elementMap['{'.Plugin::NS_CALENDARSERVER.'}share'] = \Sabre\CalDAV\Xml\Request\Share::class;
+        $this->server->xml->elementMap['{'.Plugin::NS_CALENDARSERVER.'}invite-reply'] = \Sabre\CalDAV\Xml\Request\InviteReply::class;
 
         $this->server->on('propFind', [$this, 'propFindEarly']);
         $this->server->on('propFind', [$this, 'propFindLate'], 150);

--- a/lib/CalDAV/Subscriptions/Plugin.php
+++ b/lib/CalDAV/Subscriptions/Plugin.php
@@ -31,11 +31,11 @@ class Plugin extends ServerPlugin
      */
     public function initialize(Server $server)
     {
-        $server->resourceTypeMapping['Sabre\\CalDAV\\Subscriptions\\ISubscription'] =
+        $server->resourceTypeMapping[\Sabre\CalDAV\Subscriptions\ISubscription::class] =
             '{http://calendarserver.org/ns/}subscribed';
 
         $server->xml->elementMap['{http://calendarserver.org/ns/}source'] =
-            'Sabre\\DAV\\Xml\\Property\\Href';
+            \Sabre\DAV\Xml\Property\Href::class;
 
         $server->on('propFind', [$this, 'propFind'], 150);
     }

--- a/lib/CalDAV/Xml/Request/CalendarMultiGetReport.php
+++ b/lib/CalDAV/Xml/Request/CalendarMultiGetReport.php
@@ -86,8 +86,8 @@ class CalendarMultiGetReport implements XmlDeserializable
     public static function xmlDeserialize(Reader $reader)
     {
         $elems = $reader->parseInnerTree([
-            '{urn:ietf:params:xml:ns:caldav}calendar-data' => 'Sabre\\CalDAV\\Xml\\Filter\\CalendarData',
-            '{DAV:}prop' => 'Sabre\\Xml\\Element\\KeyValue',
+            '{urn:ietf:params:xml:ns:caldav}calendar-data' => \Sabre\CalDAV\Xml\Filter\CalendarData::class,
+            '{DAV:}prop' => \Sabre\Xml\Element\KeyValue::class,
         ]);
 
         $newProps = [

--- a/lib/CalDAV/Xml/Request/CalendarQueryReport.php
+++ b/lib/CalDAV/Xml/Request/CalendarQueryReport.php
@@ -86,11 +86,11 @@ class CalendarQueryReport implements XmlDeserializable
     public static function xmlDeserialize(Reader $reader)
     {
         $elems = $reader->parseInnerTree([
-            '{urn:ietf:params:xml:ns:caldav}comp-filter' => 'Sabre\\CalDAV\\Xml\\Filter\\CompFilter',
-            '{urn:ietf:params:xml:ns:caldav}prop-filter' => 'Sabre\\CalDAV\\Xml\\Filter\\PropFilter',
-            '{urn:ietf:params:xml:ns:caldav}param-filter' => 'Sabre\\CalDAV\\Xml\\Filter\\ParamFilter',
-            '{urn:ietf:params:xml:ns:caldav}calendar-data' => 'Sabre\\CalDAV\\Xml\\Filter\\CalendarData',
-            '{DAV:}prop' => 'Sabre\\Xml\\Element\\KeyValue',
+            '{urn:ietf:params:xml:ns:caldav}comp-filter' => \Sabre\CalDAV\Xml\Filter\CompFilter::class,
+            '{urn:ietf:params:xml:ns:caldav}prop-filter' => \Sabre\CalDAV\Xml\Filter\PropFilter::class,
+            '{urn:ietf:params:xml:ns:caldav}param-filter' => \Sabre\CalDAV\Xml\Filter\ParamFilter::class,
+            '{urn:ietf:params:xml:ns:caldav}calendar-data' => \Sabre\CalDAV\Xml\Filter\CalendarData::class,
+            '{DAV:}prop' => \Sabre\Xml\Element\KeyValue::class,
         ]);
 
         $newProps = [

--- a/lib/CalDAV/Xml/Request/MkCalendar.php
+++ b/lib/CalDAV/Xml/Request/MkCalendar.php
@@ -62,8 +62,8 @@ class MkCalendar implements XmlDeserializable
         $self = new self();
 
         $elementMap = $reader->elementMap;
-        $elementMap['{DAV:}prop'] = 'Sabre\DAV\Xml\Element\Prop';
-        $elementMap['{DAV:}set'] = 'Sabre\Xml\Element\KeyValue';
+        $elementMap['{DAV:}prop'] = \Sabre\DAV\Xml\Element\Prop::class;
+        $elementMap['{DAV:}set'] = \Sabre\Xml\Element\KeyValue::class;
         $elems = $reader->parseInnerTree($elementMap);
 
         foreach ($elems as $elem) {

--- a/lib/CalDAV/Xml/Request/Share.php
+++ b/lib/CalDAV/Xml/Request/Share.php
@@ -62,8 +62,8 @@ class Share implements XmlDeserializable
     public static function xmlDeserialize(Reader $reader)
     {
         $elems = $reader->parseGetElements([
-            '{'.Plugin::NS_CALENDARSERVER.'}set' => 'Sabre\\Xml\\Element\\KeyValue',
-            '{'.Plugin::NS_CALENDARSERVER.'}remove' => 'Sabre\\Xml\\Element\\KeyValue',
+            '{'.Plugin::NS_CALENDARSERVER.'}set' => \Sabre\Xml\Element\KeyValue::class,
+            '{'.Plugin::NS_CALENDARSERVER.'}remove' => \Sabre\Xml\Element\KeyValue::class,
         ]);
 
         $sharees = [];

--- a/lib/CardDAV/Plugin.php
+++ b/lib/CardDAV/Plugin.php
@@ -73,12 +73,12 @@ class Plugin extends DAV\ServerPlugin
 
         $server->xml->namespaceMap[self::NS_CARDDAV] = 'card';
 
-        $server->xml->elementMap['{'.self::NS_CARDDAV.'}addressbook-query'] = 'Sabre\\CardDAV\\Xml\\Request\\AddressBookQueryReport';
-        $server->xml->elementMap['{'.self::NS_CARDDAV.'}addressbook-multiget'] = 'Sabre\\CardDAV\\Xml\\Request\\AddressBookMultiGetReport';
+        $server->xml->elementMap['{'.self::NS_CARDDAV.'}addressbook-query'] = \Sabre\CardDAV\Xml\Request\AddressBookQueryReport::class;
+        $server->xml->elementMap['{'.self::NS_CARDDAV.'}addressbook-multiget'] = \Sabre\CardDAV\Xml\Request\AddressBookMultiGetReport::class;
 
         /* Mapping Interfaces to {DAV:}resourcetype values */
-        $server->resourceTypeMapping['Sabre\\CardDAV\\IAddressBook'] = '{'.self::NS_CARDDAV.'}addressbook';
-        $server->resourceTypeMapping['Sabre\\CardDAV\\IDirectory'] = '{'.self::NS_CARDDAV.'}directory';
+        $server->resourceTypeMapping[\Sabre\CardDAV\IAddressBook::class] = '{'.self::NS_CARDDAV.'}addressbook';
+        $server->resourceTypeMapping[\Sabre\CardDAV\IDirectory::class] = '{'.self::NS_CARDDAV.'}directory';
 
         /* Adding properties that may never be changed */
         $server->protectedProperties[] = '{'.self::NS_CARDDAV.'}supported-address-data';
@@ -86,7 +86,7 @@ class Plugin extends DAV\ServerPlugin
         $server->protectedProperties[] = '{'.self::NS_CARDDAV.'}addressbook-home-set';
         $server->protectedProperties[] = '{'.self::NS_CARDDAV.'}supported-collation-set';
 
-        $server->xml->elementMap['{http://calendarserver.org/ns/}me-card'] = 'Sabre\\DAV\\Xml\\Property\\Href';
+        $server->xml->elementMap['{http://calendarserver.org/ns/}me-card'] = \Sabre\DAV\Xml\Property\Href::class;
 
         $this->server = $server;
     }

--- a/lib/CardDAV/Xml/Request/AddressBookMultiGetReport.php
+++ b/lib/CardDAV/Xml/Request/AddressBookMultiGetReport.php
@@ -83,8 +83,8 @@ class AddressBookMultiGetReport implements XmlDeserializable
     public static function xmlDeserialize(Reader $reader)
     {
         $elems = $reader->parseInnerTree([
-            '{urn:ietf:params:xml:ns:carddav}address-data' => 'Sabre\\CardDAV\\Xml\\Filter\\AddressData',
-            '{DAV:}prop' => 'Sabre\\Xml\\Element\\KeyValue',
+            '{urn:ietf:params:xml:ns:carddav}address-data' => \Sabre\CardDAV\Xml\Filter\AddressData::class,
+            '{DAV:}prop' => \Sabre\Xml\Element\KeyValue::class,
         ]);
 
         $newProps = [

--- a/lib/CardDAV/Xml/Request/AddressBookQueryReport.php
+++ b/lib/CardDAV/Xml/Request/AddressBookQueryReport.php
@@ -120,10 +120,10 @@ class AddressBookQueryReport implements XmlDeserializable
     public static function xmlDeserialize(Reader $reader)
     {
         $elems = (array) $reader->parseInnerTree([
-            '{urn:ietf:params:xml:ns:carddav}prop-filter' => 'Sabre\\CardDAV\\Xml\\Filter\\PropFilter',
-            '{urn:ietf:params:xml:ns:carddav}param-filter' => 'Sabre\\CardDAV\\Xml\\Filter\\ParamFilter',
-            '{urn:ietf:params:xml:ns:carddav}address-data' => 'Sabre\\CardDAV\\Xml\\Filter\\AddressData',
-            '{DAV:}prop' => 'Sabre\\Xml\\Element\\KeyValue',
+            '{urn:ietf:params:xml:ns:carddav}prop-filter' => \Sabre\CardDAV\Xml\Filter\PropFilter::class,
+            '{urn:ietf:params:xml:ns:carddav}param-filter' => \Sabre\CardDAV\Xml\Filter\ParamFilter::class,
+            '{urn:ietf:params:xml:ns:carddav}address-data' => \Sabre\CardDAV\Xml\Filter\AddressData::class,
+            '{DAV:}prop' => \Sabre\Xml\Element\KeyValue::class,
         ]);
 
         $newProps = [

--- a/lib/DAV/Browser/Plugin.php
+++ b/lib/DAV/Browser/Plugin.php
@@ -499,7 +499,7 @@ HTML;
 
         // We also know fairly certain that if an object is a non-extended
         // SimpleCollection, we won't need to show the panel either.
-        if ('Sabre\\DAV\\SimpleCollection' === get_class($node)) {
+        if (\Sabre\DAV\SimpleCollection::class === get_class($node)) {
             return;
         }
 

--- a/lib/DAV/Locks/Plugin.php
+++ b/lib/DAV/Locks/Plugin.php
@@ -55,7 +55,7 @@ class Plugin extends DAV\ServerPlugin
     {
         $this->server = $server;
 
-        $this->server->xml->elementMap['{DAV:}lockinfo'] = 'Sabre\\DAV\\Xml\\Request\\Lock';
+        $this->server->xml->elementMap['{DAV:}lockinfo'] = \Sabre\DAV\Xml\Request\Lock::class;
 
         $server->on('method:LOCK', [$this, 'httpLock']);
         $server->on('method:UNLOCK', [$this, 'httpUnlock']);

--- a/lib/DAV/Server.php
+++ b/lib/DAV/Server.php
@@ -152,7 +152,7 @@ class Server implements LoggerAwareInterface, EmitterInterface
      * @var array
      */
     public $resourceTypeMapping = [
-        'Sabre\\DAV\\ICollection' => '{DAV:}collection',
+        \Sabre\DAV\ICollection::class => '{DAV:}collection',
     ];
 
     /**

--- a/lib/DAV/Sharing/Plugin.php
+++ b/lib/DAV/Sharing/Plugin.php
@@ -84,7 +84,7 @@ class Plugin extends ServerPlugin
     {
         $this->server = $server;
 
-        $server->xml->elementMap['{DAV:}share-resource'] = 'Sabre\\DAV\\Xml\\Request\\ShareResource';
+        $server->xml->elementMap['{DAV:}share-resource'] = \Sabre\DAV\Xml\Request\ShareResource::class;
 
         array_push(
             $server->protectedProperties,

--- a/lib/DAV/Sync/Plugin.php
+++ b/lib/DAV/Sync/Plugin.php
@@ -52,7 +52,7 @@ class Plugin extends DAV\ServerPlugin
     public function initialize(DAV\Server $server)
     {
         $this->server = $server;
-        $server->xml->elementMap['{DAV:}sync-collection'] = 'Sabre\\DAV\\Xml\\Request\\SyncCollectionReport';
+        $server->xml->elementMap['{DAV:}sync-collection'] = \Sabre\DAV\Xml\Request\SyncCollectionReport::class;
 
         $self = $this;
 

--- a/lib/DAV/Xml/Element/Prop.php
+++ b/lib/DAV/Xml/Element/Prop.php
@@ -85,7 +85,7 @@ class Prop implements XmlDeserializable
 
         if (array_key_exists($name, $reader->elementMap)) {
             $deserializer = $reader->elementMap[$name];
-            if (is_subclass_of($deserializer, 'Sabre\\Xml\\XmlDeserializable')) {
+            if (is_subclass_of($deserializer, \Sabre\Xml\XmlDeserializable::class)) {
                 $value = call_user_func([$deserializer, 'xmlDeserialize'], $reader);
             } elseif (is_callable($deserializer)) {
                 $value = call_user_func($deserializer, $reader);

--- a/lib/DAV/Xml/Element/Response.php
+++ b/lib/DAV/Xml/Element/Response.php
@@ -184,7 +184,7 @@ class Response implements Element
     {
         $reader->pushContext();
 
-        $reader->elementMap['{DAV:}propstat'] = 'Sabre\\Xml\\Element\\KeyValue';
+        $reader->elementMap['{DAV:}propstat'] = \Sabre\Xml\Element\KeyValue::class;
 
         // We are overriding the parser for {DAV:}prop. This deserializer is
         // almost identical to the one for Sabre\Xml\Element\KeyValue.

--- a/lib/DAV/Xml/Element/Sharee.php
+++ b/lib/DAV/Xml/Element/Sharee.php
@@ -159,7 +159,7 @@ class Sharee implements Element
     {
         // Temporarily override configuration
         $reader->pushContext();
-        $reader->elementMap['{DAV:}share-access'] = 'Sabre\DAV\Xml\Property\ShareAccess';
+        $reader->elementMap['{DAV:}share-access'] = \Sabre\DAV\Xml\Property\ShareAccess::class;
         $reader->elementMap['{DAV:}prop'] = 'Sabre\Xml\Deserializer\keyValue';
 
         $elems = Deserializer\keyValue($reader, 'DAV:');

--- a/lib/DAV/Xml/Request/Lock.php
+++ b/lib/DAV/Xml/Request/Lock.php
@@ -61,7 +61,7 @@ class Lock implements XmlDeserializable
     public static function xmlDeserialize(Reader $reader)
     {
         $reader->pushContext();
-        $reader->elementMap['{DAV:}owner'] = 'Sabre\\Xml\\Element\\XmlFragment';
+        $reader->elementMap['{DAV:}owner'] = \Sabre\Xml\Element\XmlFragment::class;
 
         $values = KeyValue::xmlDeserialize($reader);
 

--- a/lib/DAV/Xml/Request/MkCol.php
+++ b/lib/DAV/Xml/Request/MkCol.php
@@ -63,9 +63,9 @@ class MkCol implements XmlDeserializable
         $self = new self();
 
         $elementMap = $reader->elementMap;
-        $elementMap['{DAV:}prop'] = 'Sabre\DAV\Xml\Element\Prop';
-        $elementMap['{DAV:}set'] = 'Sabre\Xml\Element\KeyValue';
-        $elementMap['{DAV:}remove'] = 'Sabre\Xml\Element\KeyValue';
+        $elementMap['{DAV:}prop'] = \Sabre\DAV\Xml\Element\Prop::class;
+        $elementMap['{DAV:}set'] = \Sabre\Xml\Element\KeyValue::class;
+        $elementMap['{DAV:}remove'] = \Sabre\Xml\Element\KeyValue::class;
 
         $elems = $reader->parseInnerTree($elementMap);
 

--- a/lib/DAV/Xml/Request/PropFind.php
+++ b/lib/DAV/Xml/Request/PropFind.php
@@ -60,7 +60,7 @@ class PropFind implements XmlDeserializable
         $self = new self();
 
         $reader->pushContext();
-        $reader->elementMap['{DAV:}prop'] = 'Sabre\Xml\Element\Elements';
+        $reader->elementMap['{DAV:}prop'] = \Sabre\Xml\Element\Elements::class;
 
         foreach (KeyValue::xmlDeserialize($reader) as $k => $v) {
             switch ($k) {

--- a/lib/DAV/Xml/Request/PropPatch.php
+++ b/lib/DAV/Xml/Request/PropPatch.php
@@ -86,9 +86,9 @@ class PropPatch implements Element
         $self = new self();
 
         $elementMap = $reader->elementMap;
-        $elementMap['{DAV:}prop'] = 'Sabre\DAV\Xml\Element\Prop';
-        $elementMap['{DAV:}set'] = 'Sabre\Xml\Element\KeyValue';
-        $elementMap['{DAV:}remove'] = 'Sabre\Xml\Element\KeyValue';
+        $elementMap['{DAV:}prop'] = \Sabre\DAV\Xml\Element\Prop::class;
+        $elementMap['{DAV:}set'] = \Sabre\Xml\Element\KeyValue::class;
+        $elementMap['{DAV:}remove'] = \Sabre\Xml\Element\KeyValue::class;
 
         $elems = $reader->parseInnerTree($elementMap);
 

--- a/lib/DAV/Xml/Request/ShareResource.php
+++ b/lib/DAV/Xml/Request/ShareResource.php
@@ -61,8 +61,8 @@ class ShareResource implements XmlDeserializable
     public static function xmlDeserialize(Reader $reader)
     {
         $elems = $reader->parseInnerTree([
-            '{DAV:}sharee' => 'Sabre\DAV\Xml\Element\Sharee',
-            '{DAV:}share-access' => 'Sabre\DAV\Xml\Property\ShareAccess',
+            '{DAV:}sharee' => \Sabre\DAV\Xml\Element\Sharee::class,
+            '{DAV:}share-access' => \Sabre\DAV\Xml\Property\ShareAccess::class,
             '{DAV:}prop' => 'Sabre\Xml\Deserializer\keyValue',
         ]);
 

--- a/lib/DAV/Xml/Request/SyncCollectionReport.php
+++ b/lib/DAV/Xml/Request/SyncCollectionReport.php
@@ -76,7 +76,7 @@ class SyncCollectionReport implements XmlDeserializable
 
         $reader->pushContext();
 
-        $reader->elementMap['{DAV:}prop'] = 'Sabre\Xml\Element\Elements';
+        $reader->elementMap['{DAV:}prop'] = \Sabre\Xml\Element\Elements::class;
         $elems = KeyValue::xmlDeserialize($reader);
 
         $reader->popContext();

--- a/lib/DAV/Xml/Response/MultiStatus.php
+++ b/lib/DAV/Xml/Response/MultiStatus.php
@@ -114,7 +114,7 @@ class MultiStatus implements Element
     public static function xmlDeserialize(Reader $reader)
     {
         $elementMap = $reader->elementMap;
-        $elementMap['{DAV:}prop'] = 'Sabre\\DAV\\Xml\\Element\\Prop';
+        $elementMap['{DAV:}prop'] = \Sabre\DAV\Xml\Element\Prop::class;
         $elements = $reader->parseInnerTree($elementMap);
 
         $responses = [];

--- a/lib/DAV/Xml/Service.php
+++ b/lib/DAV/Xml/Service.php
@@ -20,16 +20,16 @@ class Service extends \Sabre\Xml\Service
      * be mapped to Sabre\DAV\Xml\Request\PropFind
      */
     public array $elementMap = [
-        '{DAV:}multistatus' => 'Sabre\\DAV\\Xml\\Response\\MultiStatus',
-        '{DAV:}response' => 'Sabre\\DAV\\Xml\\Element\\Response',
+        '{DAV:}multistatus' => \Sabre\DAV\Xml\Response\MultiStatus::class,
+        '{DAV:}response' => \Sabre\DAV\Xml\Element\Response::class,
 
         // Requests
-        '{DAV:}propfind' => 'Sabre\\DAV\\Xml\\Request\\PropFind',
-        '{DAV:}propertyupdate' => 'Sabre\\DAV\\Xml\\Request\\PropPatch',
-        '{DAV:}mkcol' => 'Sabre\\DAV\\Xml\\Request\\MkCol',
+        '{DAV:}propfind' => \Sabre\DAV\Xml\Request\PropFind::class,
+        '{DAV:}propertyupdate' => \Sabre\DAV\Xml\Request\PropPatch::class,
+        '{DAV:}mkcol' => \Sabre\DAV\Xml\Request\MkCol::class,
 
         // Properties
-        '{DAV:}resourcetype' => 'Sabre\\DAV\\Xml\\Property\\ResourceType',
+        '{DAV:}resourcetype' => \Sabre\DAV\Xml\Property\ResourceType::class,
     ];
 
     /**

--- a/lib/DAVACL/Plugin.php
+++ b/lib/DAVACL/Plugin.php
@@ -808,17 +808,17 @@ class Plugin extends DAV\ServerPlugin
 
         // Automatically mapping nodes implementing IPrincipal to the
         // {DAV:}principal resourcetype.
-        $server->resourceTypeMapping['Sabre\\DAVACL\\IPrincipal'] = '{DAV:}principal';
+        $server->resourceTypeMapping[\Sabre\DAVACL\IPrincipal::class] = '{DAV:}principal';
 
         // Mapping the group-member-set property to the HrefList property
         // class.
-        $server->xml->elementMap['{DAV:}group-member-set'] = 'Sabre\\DAV\\Xml\\Property\\Href';
-        $server->xml->elementMap['{DAV:}acl'] = 'Sabre\\DAVACL\\Xml\\Property\\Acl';
-        $server->xml->elementMap['{DAV:}acl-principal-prop-set'] = 'Sabre\\DAVACL\\Xml\\Request\\AclPrincipalPropSetReport';
-        $server->xml->elementMap['{DAV:}expand-property'] = 'Sabre\\DAVACL\\Xml\\Request\\ExpandPropertyReport';
-        $server->xml->elementMap['{DAV:}principal-property-search'] = 'Sabre\\DAVACL\\Xml\\Request\\PrincipalPropertySearchReport';
-        $server->xml->elementMap['{DAV:}principal-search-property-set'] = 'Sabre\\DAVACL\\Xml\\Request\\PrincipalSearchPropertySetReport';
-        $server->xml->elementMap['{DAV:}principal-match'] = 'Sabre\\DAVACL\\Xml\\Request\\PrincipalMatchReport';
+        $server->xml->elementMap['{DAV:}group-member-set'] = \Sabre\DAV\Xml\Property\Href::class;
+        $server->xml->elementMap['{DAV:}acl'] = \Sabre\DAVACL\Xml\Property\Acl::class;
+        $server->xml->elementMap['{DAV:}acl-principal-prop-set'] = \Sabre\DAVACL\Xml\Request\AclPrincipalPropSetReport::class;
+        $server->xml->elementMap['{DAV:}expand-property'] = \Sabre\DAVACL\Xml\Request\ExpandPropertyReport::class;
+        $server->xml->elementMap['{DAV:}principal-property-search'] = \Sabre\DAVACL\Xml\Request\PrincipalPropertySearchReport::class;
+        $server->xml->elementMap['{DAV:}principal-search-property-set'] = \Sabre\DAVACL\Xml\Request\PrincipalSearchPropertySetReport::class;
+        $server->xml->elementMap['{DAV:}principal-match'] = \Sabre\DAVACL\Xml\Request\PrincipalMatchReport::class;
     }
 
     /* {{{ Event handlers */

--- a/lib/DAVACL/Xml/Property/Acl.php
+++ b/lib/DAVACL/Xml/Property/Acl.php
@@ -161,9 +161,9 @@ class Acl implements Element, HtmlOutput
     public static function xmlDeserialize(Reader $reader)
     {
         $elementMap = [
-            '{DAV:}ace' => 'Sabre\Xml\Element\KeyValue',
-            '{DAV:}privilege' => 'Sabre\Xml\Element\Elements',
-            '{DAV:}principal' => 'Sabre\DAVACL\Xml\Property\Principal',
+            '{DAV:}ace' => \Sabre\Xml\Element\KeyValue::class,
+            '{DAV:}privilege' => \Sabre\Xml\Element\Elements::class,
+            '{DAV:}principal' => \Sabre\DAVACL\Xml\Property\Principal::class,
         ];
 
         $privileges = [];

--- a/lib/DAVACL/Xml/Property/CurrentUserPrivilegeSet.php
+++ b/lib/DAVACL/Xml/Property/CurrentUserPrivilegeSet.php
@@ -111,7 +111,7 @@ class CurrentUserPrivilegeSet implements Element, HtmlOutput
     {
         $result = [];
 
-        $tree = $reader->parseInnerTree(['{DAV:}privilege' => 'Sabre\\Xml\\Element\\Elements']);
+        $tree = $reader->parseInnerTree(['{DAV:}privilege' => \Sabre\Xml\Element\Elements::class]);
         foreach ($tree as $element) {
             if ('{DAV:}privilege' !== $element['name']) {
                 continue;

--- a/lib/DAVACL/Xml/Request/PrincipalPropertySearchReport.php
+++ b/lib/DAVACL/Xml/Request/PrincipalPropertySearchReport.php
@@ -86,8 +86,8 @@ class PrincipalPropertySearchReport implements XmlDeserializable
         }
 
         $elemMap = [
-            '{DAV:}property-search' => 'Sabre\\Xml\\Element\\KeyValue',
-            '{DAV:}prop' => 'Sabre\\Xml\\Element\\KeyValue',
+            '{DAV:}property-search' => \Sabre\Xml\Element\KeyValue::class,
+            '{DAV:}prop' => \Sabre\Xml\Element\KeyValue::class,
         ];
 
         foreach ($reader->parseInnerTree($elemMap) as $elem) {

--- a/tests/Sabre/CalDAV/Backend/AbstractPDOTestCase.php
+++ b/tests/Sabre/CalDAV/Backend/AbstractPDOTestCase.php
@@ -208,7 +208,7 @@ abstract class AbstractPDOTestCase extends TestCase
      */
     public function testCreateCalendarIncorrectComponentSet()
     {
-        $this->expectException('Sabre\DAV\Exception');
+        $this->expectException(\Sabre\DAV\Exception::class);
         $backend = new PDO($this->pdo);
 
         //Creating a new calendar
@@ -309,7 +309,7 @@ abstract class AbstractPDOTestCase extends TestCase
      */
     public function testCreateCalendarObjectNoComponent()
     {
-        $this->expectException('Sabre\DAV\Exception\BadRequest');
+        $this->expectException(\Sabre\DAV\Exception\BadRequest::class);
         $backend = new PDO($this->pdo);
         $returnedId = $backend->createCalendar('principals/user2', 'somerandomid', []);
 
@@ -1025,7 +1025,7 @@ abstract class AbstractPDOTestCase extends TestCase
 
     public function testCreateSubscriptionFail()
     {
-        $this->expectException('Sabre\DAV\Exception\Forbidden');
+        $this->expectException(\Sabre\DAV\Exception\Forbidden::class);
         $props = [
         ];
 
@@ -1510,7 +1510,7 @@ abstract class AbstractPDOTestCase extends TestCase
 
     public function testSetPublishStatus()
     {
-        $this->expectException('Sabre\DAV\Exception\NotImplemented');
+        $this->expectException(\Sabre\DAV\Exception\NotImplemented::class);
         $backend = new PDO($this->pdo);
         $backend->setPublishStatus([1, 1], true);
     }

--- a/tests/Sabre/CalDAV/CalendarHomeNotificationsTest.php
+++ b/tests/Sabre/CalDAV/CalendarHomeNotificationsTest.php
@@ -19,7 +19,7 @@ class CalendarHomeNotificationsTest extends \PHPUnit\Framework\TestCase
 
     public function testGetChildNoSupport()
     {
-        $this->expectException('Sabre\DAV\Exception\NotFound');
+        $this->expectException(\Sabre\DAV\Exception\NotFound::class);
         $backend = new Backend\Mock();
         $calendarHome = new CalendarHome($backend, ['uri' => 'principals/user']);
         $calendarHome->getChild('notifications');

--- a/tests/Sabre/CalDAV/CalendarHomeSubscriptionsTest.php
+++ b/tests/Sabre/CalDAV/CalendarHomeSubscriptionsTest.php
@@ -61,7 +61,7 @@ class CalendarHomeSubscriptionsTest extends \PHPUnit\Framework\TestCase
 
     public function testNoSubscriptionSupport()
     {
-        $this->expectException('Sabre\DAV\Exception\InvalidResourceType');
+        $this->expectException(\Sabre\DAV\Exception\InvalidResourceType::class);
         $principal = [
             'uri' => 'principals/user1',
         ];

--- a/tests/Sabre/CalDAV/CalendarHomeTest.php
+++ b/tests/Sabre/CalDAV/CalendarHomeTest.php
@@ -37,7 +37,7 @@ class CalendarHomeTest extends \PHPUnit\Framework\TestCase
      */
     public function testGetChildNotFound()
     {
-        $this->expectException('Sabre\DAV\Exception\NotFound');
+        $this->expectException(\Sabre\DAV\Exception\NotFound::class);
         $this->usercalendars->getChild('randomname');
     }
 
@@ -91,7 +91,7 @@ class CalendarHomeTest extends \PHPUnit\Framework\TestCase
 
     public function testSetACL()
     {
-        $this->expectException('Sabre\DAV\Exception\Forbidden');
+        $this->expectException(\Sabre\DAV\Exception\Forbidden::class);
         $this->usercalendars->setACL([]);
     }
 
@@ -100,7 +100,7 @@ class CalendarHomeTest extends \PHPUnit\Framework\TestCase
      */
     public function testSetName()
     {
-        $this->expectException('Sabre\DAV\Exception\Forbidden');
+        $this->expectException(\Sabre\DAV\Exception\Forbidden::class);
         $this->usercalendars->setName('bla');
     }
 
@@ -109,7 +109,7 @@ class CalendarHomeTest extends \PHPUnit\Framework\TestCase
      */
     public function testDelete()
     {
-        $this->expectException('Sabre\DAV\Exception\Forbidden');
+        $this->expectException(\Sabre\DAV\Exception\Forbidden::class);
         $this->usercalendars->delete();
     }
 
@@ -126,7 +126,7 @@ class CalendarHomeTest extends \PHPUnit\Framework\TestCase
      */
     public function testCreateFile()
     {
-        $this->expectException('Sabre\DAV\Exception\MethodNotAllowed');
+        $this->expectException(\Sabre\DAV\Exception\MethodNotAllowed::class);
         $this->usercalendars->createFile('bla');
     }
 
@@ -135,7 +135,7 @@ class CalendarHomeTest extends \PHPUnit\Framework\TestCase
      */
     public function testCreateDirectory()
     {
-        $this->expectException('Sabre\DAV\Exception\MethodNotAllowed');
+        $this->expectException(\Sabre\DAV\Exception\MethodNotAllowed::class);
         $this->usercalendars->createDirectory('bla');
     }
 
@@ -159,7 +159,7 @@ class CalendarHomeTest extends \PHPUnit\Framework\TestCase
      */
     public function testCreateExtendedCollectionBadResourceType()
     {
-        $this->expectException('Sabre\DAV\Exception\InvalidResourceType');
+        $this->expectException(\Sabre\DAV\Exception\InvalidResourceType::class);
         $mkCol = new MkCol(
             ['{DAV:}collection', '{DAV:}blabla'],
             []
@@ -172,7 +172,7 @@ class CalendarHomeTest extends \PHPUnit\Framework\TestCase
      */
     public function testCreateExtendedCollectionNotACalendar()
     {
-        $this->expectException('Sabre\DAV\Exception\InvalidResourceType');
+        $this->expectException(\Sabre\DAV\Exception\InvalidResourceType::class);
         $mkCol = new MkCol(
             ['{DAV:}collection'],
             []
@@ -187,7 +187,7 @@ class CalendarHomeTest extends \PHPUnit\Framework\TestCase
 
     public function testShareReplyFail()
     {
-        $this->expectException('Sabre\DAV\Exception\NotImplemented');
+        $this->expectException(\Sabre\DAV\Exception\NotImplemented::class);
         $this->usercalendars->shareReply('uri', DAV\Sharing\Plugin::INVITE_DECLINED, 'curi', '1');
     }
 }

--- a/tests/Sabre/CalDAV/CalendarObjectTest.php
+++ b/tests/Sabre/CalDAV/CalendarObjectTest.php
@@ -215,7 +215,7 @@ class CalendarObjectTest extends \PHPUnit\Framework\TestCase
 
     public function testSetACL()
     {
-        $this->expectException('Sabre\DAV\Exception\Forbidden');
+        $this->expectException(\Sabre\DAV\Exception\Forbidden::class);
         $children = $this->calendar->getChildren();
         self::assertTrue($children[0] instanceof CalendarObject);
 

--- a/tests/Sabre/CalDAV/CalendarTest.php
+++ b/tests/Sabre/CalDAV/CalendarTest.php
@@ -82,7 +82,7 @@ class CalendarTest extends \PHPUnit\Framework\TestCase
      */
     public function testGetChildNotFound()
     {
-        $this->expectException('Sabre\DAV\Exception\NotFound');
+        $this->expectException(\Sabre\DAV\Exception\NotFound::class);
         $this->calendar->getChild('randomname');
     }
 
@@ -110,13 +110,13 @@ class CalendarTest extends \PHPUnit\Framework\TestCase
 
     public function testCreateDirectory()
     {
-        $this->expectException('Sabre\DAV\Exception\MethodNotAllowed');
+        $this->expectException(\Sabre\DAV\Exception\MethodNotAllowed::class);
         $this->calendar->createDirectory('hello');
     }
 
     public function testSetName()
     {
-        $this->expectException('Sabre\DAV\Exception\MethodNotAllowed');
+        $this->expectException(\Sabre\DAV\Exception\MethodNotAllowed::class);
         $this->calendar->setName('hello');
     }
 
@@ -207,7 +207,7 @@ class CalendarTest extends \PHPUnit\Framework\TestCase
 
     public function testSetACL()
     {
-        $this->expectException('Sabre\DAV\Exception\Forbidden');
+        $this->expectException(\Sabre\DAV\Exception\Forbidden::class);
         $this->calendar->setACL([]);
     }
 

--- a/tests/Sabre/CalDAV/FreeBusyReportTest.php
+++ b/tests/Sabre/CalDAV/FreeBusyReportTest.php
@@ -110,7 +110,7 @@ XML;
 
     public function testFreeBusyReportNoTimeRange()
     {
-        $this->expectException('Sabre\DAV\Exception\BadRequest');
+        $this->expectException(\Sabre\DAV\Exception\BadRequest::class);
         $reportXML = <<<XML
 <?xml version="1.0"?>
 <c:free-busy-query xmlns:c="urn:ietf:params:xml:ns:caldav">
@@ -122,7 +122,7 @@ XML;
 
     public function testFreeBusyReportWrongNode()
     {
-        $this->expectException('Sabre\DAV\Exception\NotImplemented');
+        $this->expectException(\Sabre\DAV\Exception\NotImplemented::class);
         $request = new HTTP\Request('REPORT', '/');
         $this->server->httpRequest = $request;
 
@@ -139,7 +139,7 @@ XML;
 
     public function testFreeBusyReportNoACLPlugin()
     {
-        $this->expectException('Sabre\DAV\Exception');
+        $this->expectException(\Sabre\DAV\Exception::class);
         $this->server = new DAV\Server();
         $this->server->httpRequest = new HTTP\Request('REPORT', '/');
         $this->plugin = new Plugin();

--- a/tests/Sabre/CalDAV/Notifications/CollectionTest.php
+++ b/tests/Sabre/CalDAV/Notifications/CollectionTest.php
@@ -65,7 +65,7 @@ class CollectionTest extends \PHPUnit\Framework\TestCase
 
     public function testSetACL()
     {
-        $this->expectException('Sabre\DAV\Exception\Forbidden');
+        $this->expectException(\Sabre\DAV\Exception\Forbidden::class);
         $col = $this->getInstance();
         $col->setACL([]);
     }

--- a/tests/Sabre/CalDAV/Notifications/NodeTest.php
+++ b/tests/Sabre/CalDAV/Notifications/NodeTest.php
@@ -75,7 +75,7 @@ class NodeTest extends \PHPUnit\Framework\TestCase
 
     public function testSetACL()
     {
-        $this->expectException('Sabre\DAV\Exception\Forbidden');
+        $this->expectException(\Sabre\DAV\Exception\Forbidden::class);
         $node = $this->getInstance();
         $node->setACL([]);
     }

--- a/tests/Sabre/CalDAV/PluginTest.php
+++ b/tests/Sabre/CalDAV/PluginTest.php
@@ -445,22 +445,22 @@ END:VCALENDAR';
 
         self::assertArrayHasKey('{urn:ietf:params:xml:ns:caldav}calendar-home-set', $props[0][200]);
         $prop = $props[0][200]['{urn:ietf:params:xml:ns:caldav}calendar-home-set'];
-        self::assertInstanceOf('Sabre\\DAV\\Xml\\Property\\Href', $prop);
+        self::assertInstanceOf(\Sabre\DAV\Xml\Property\Href::class, $prop);
         self::assertEquals('calendars/user1/', $prop->getHref());
 
         self::assertArrayHasKey('{http://calendarserver.org/ns/}calendar-proxy-read-for', $props[0][200]);
         $prop = $props[0][200]['{http://calendarserver.org/ns/}calendar-proxy-read-for'];
-        self::assertInstanceOf('Sabre\\DAV\\Xml\\Property\\Href', $prop);
+        self::assertInstanceOf(\Sabre\DAV\Xml\Property\Href::class, $prop);
         self::assertEquals(['principals/admin/'], $prop->getHrefs());
 
         self::assertArrayHasKey('{http://calendarserver.org/ns/}calendar-proxy-write-for', $props[0][200]);
         $prop = $props[0][200]['{http://calendarserver.org/ns/}calendar-proxy-write-for'];
-        self::assertInstanceOf('Sabre\\DAV\\Xml\\Property\\Href', $prop);
+        self::assertInstanceOf(\Sabre\DAV\Xml\Property\Href::class, $prop);
         self::assertEquals(['principals/admin/'], $prop->getHrefs());
 
         self::assertArrayHasKey('{'.Plugin::NS_CALENDARSERVER.'}email-address-set', $props[0][200]);
         $prop = $props[0][200]['{'.Plugin::NS_CALENDARSERVER.'}email-address-set'];
-        self::assertInstanceOf('Sabre\\CalDAV\\Xml\\Property\\EmailAddressSet', $prop);
+        self::assertInstanceOf(\Sabre\CalDAV\Xml\Property\EmailAddressSet::class, $prop);
         self::assertEquals(['user1.sabredav@sabredav.org'], $prop->getValue());
     }
 
@@ -476,7 +476,7 @@ END:VCALENDAR';
 
         $prop = $props[0][200]['{DAV:}supported-report-set'];
 
-        self::assertInstanceOf('\\Sabre\\DAV\\Xml\\Property\\SupportedReportSet', $prop);
+        self::assertInstanceOf(\Sabre\DAV\Xml\Property\SupportedReportSet::class, $prop);
         $value = [
             '{DAV:}expand-property',
             '{DAV:}principal-match',
@@ -501,7 +501,7 @@ END:VCALENDAR';
 
         $prop = $props[0][200]['{DAV:}supported-report-set'];
 
-        self::assertInstanceOf('\\Sabre\\DAV\\Xml\\Property\\SupportedReportSet', $prop);
+        self::assertInstanceOf(\Sabre\DAV\Xml\Property\SupportedReportSet::class, $prop);
         $value = [
             '{urn:ietf:params:xml:ns:caldav}calendar-multiget',
             '{urn:ietf:params:xml:ns:caldav}calendar-query',
@@ -528,7 +528,7 @@ END:VCALENDAR';
 
         $prop = $props[0][200]['{DAV:}supported-report-set'];
 
-        self::assertInstanceOf('\\Sabre\\DAV\\Xml\\Property\\SupportedReportSet', $prop);
+        self::assertInstanceOf(\Sabre\DAV\Xml\Property\SupportedReportSet::class, $prop);
         $value = [
             '{DAV:}sync-collection',
             '{DAV:}expand-property',

--- a/tests/Sabre/CalDAV/Principal/CollectionTest.php
+++ b/tests/Sabre/CalDAV/Principal/CollectionTest.php
@@ -15,6 +15,6 @@ class CollectionTest extends \PHPUnit\Framework\TestCase
         $r = $col->getChildForPrincipal([
             'uri' => 'principals/admin',
         ]);
-        self::assertInstanceOf('Sabre\\CalDAV\\Principal\\User', $r);
+        self::assertInstanceOf(\Sabre\CalDAV\Principal\User::class, $r);
     }
 }

--- a/tests/Sabre/CalDAV/Principal/ProxyReadTest.php
+++ b/tests/Sabre/CalDAV/Principal/ProxyReadTest.php
@@ -41,14 +41,14 @@ class ProxyReadTest extends \PHPUnit\Framework\TestCase
 
     public function testDelete()
     {
-        $this->expectException('Sabre\DAV\Exception\Forbidden');
+        $this->expectException(\Sabre\DAV\Exception\Forbidden::class);
         $i = $this->getInstance();
         $i->delete();
     }
 
     public function testSetName()
     {
-        $this->expectException('Sabre\DAV\Exception\Forbidden');
+        $this->expectException(\Sabre\DAV\Exception\Forbidden::class);
         $i = $this->getInstance();
         $i->setName('foo');
     }

--- a/tests/Sabre/CalDAV/Principal/UserTest.php
+++ b/tests/Sabre/CalDAV/Principal/UserTest.php
@@ -28,14 +28,14 @@ class UserTest extends \PHPUnit\Framework\TestCase
 
     public function testCreateFile()
     {
-        $this->expectException('Sabre\DAV\Exception\Forbidden');
+        $this->expectException(\Sabre\DAV\Exception\Forbidden::class);
         $u = $this->getInstance();
         $u->createFile('test');
     }
 
     public function testCreateDirectory()
     {
-        $this->expectException('Sabre\DAV\Exception\Forbidden');
+        $this->expectException(\Sabre\DAV\Exception\Forbidden::class);
         $u = $this->getInstance();
         $u->createDirectory('test');
     }
@@ -44,26 +44,26 @@ class UserTest extends \PHPUnit\Framework\TestCase
     {
         $u = $this->getInstance();
         $child = $u->getChild('calendar-proxy-read');
-        self::assertInstanceOf('Sabre\\CalDAV\\Principal\\ProxyRead', $child);
+        self::assertInstanceOf(\Sabre\CalDAV\Principal\ProxyRead::class, $child);
     }
 
     public function testGetChildProxyWrite()
     {
         $u = $this->getInstance();
         $child = $u->getChild('calendar-proxy-write');
-        self::assertInstanceOf('Sabre\\CalDAV\\Principal\\ProxyWrite', $child);
+        self::assertInstanceOf(\Sabre\CalDAV\Principal\ProxyWrite::class, $child);
     }
 
     public function testGetChildNotFound()
     {
-        $this->expectException('Sabre\DAV\Exception\NotFound');
+        $this->expectException(\Sabre\DAV\Exception\NotFound::class);
         $u = $this->getInstance();
         $child = $u->getChild('foo');
     }
 
     public function testGetChildNotFound2()
     {
-        $this->expectException('Sabre\DAV\Exception\NotFound');
+        $this->expectException(\Sabre\DAV\Exception\NotFound::class);
         $u = $this->getInstance();
         $child = $u->getChild('random');
     }
@@ -73,8 +73,8 @@ class UserTest extends \PHPUnit\Framework\TestCase
         $u = $this->getInstance();
         $children = $u->getChildren();
         self::assertEquals(2, count($children));
-        self::assertInstanceOf('Sabre\\CalDAV\\Principal\\ProxyRead', $children[0]);
-        self::assertInstanceOf('Sabre\\CalDAV\\Principal\\ProxyWrite', $children[1]);
+        self::assertInstanceOf(\Sabre\CalDAV\Principal\ProxyRead::class, $children[0]);
+        self::assertInstanceOf(\Sabre\CalDAV\Principal\ProxyWrite::class, $children[1]);
     }
 
     public function testChildExist()

--- a/tests/Sabre/CalDAV/Schedule/DeliverNewEventTest.php
+++ b/tests/Sabre/CalDAV/Schedule/DeliverNewEventTest.php
@@ -77,7 +77,7 @@ ICS
         self::assertEquals(1, count($messages));
         $message = $messages[0];
 
-        self::assertInstanceOf('\Sabre\VObject\ITip\Message', $message);
+        self::assertInstanceOf(\Sabre\VObject\ITip\Message::class, $message);
         self::assertEquals('mailto:user2.sabredav@sabredav.org', $message->recipient);
         self::assertEquals('Roxy Kesh', $message->recipientName);
         self::assertEquals('mailto:user1.sabredav@sabredav.org', $message->sender);

--- a/tests/Sabre/CalDAV/Schedule/FreeBusyRequestTest.php
+++ b/tests/Sabre/CalDAV/Schedule/FreeBusyRequestTest.php
@@ -141,7 +141,7 @@ END:VCALENDAR',
 
     public function testNoItipMethod()
     {
-        $this->expectException('Sabre\DAV\Exception\BadRequest');
+        $this->expectException(\Sabre\DAV\Exception\BadRequest::class);
         $this->server->httpRequest = new HTTP\Request(
             'POST',
             '/calendars/user1/outbox',
@@ -161,7 +161,7 @@ ICS;
 
     public function testNoVFreeBusy()
     {
-        $this->expectException('Sabre\DAV\Exception\NotImplemented');
+        $this->expectException(\Sabre\DAV\Exception\NotImplemented::class);
         $this->server->httpRequest = new HTTP\Request(
             'POST',
             '/calendars/user1/outbox',
@@ -182,7 +182,7 @@ ICS;
 
     public function testIncorrectOrganizer()
     {
-        $this->expectException('Sabre\DAV\Exception\Forbidden');
+        $this->expectException(\Sabre\DAV\Exception\Forbidden::class);
         $this->server->httpRequest = new HTTP\Request(
             'POST',
             '/calendars/user1/outbox',
@@ -204,7 +204,7 @@ ICS;
 
     public function testNoAttendees()
     {
-        $this->expectException('Sabre\DAV\Exception\BadRequest');
+        $this->expectException(\Sabre\DAV\Exception\BadRequest::class);
         $this->server->httpRequest = new HTTP\Request(
             'POST',
             '/calendars/user1/outbox',
@@ -226,7 +226,7 @@ ICS;
 
     public function testNoDTStart()
     {
-        $this->expectException('Sabre\DAV\Exception\BadRequest');
+        $this->expectException(\Sabre\DAV\Exception\BadRequest::class);
         $this->server->httpRequest = new HTTP\Request(
             'POST',
             '/calendars/user1/outbox',

--- a/tests/Sabre/CalDAV/Schedule/InboxTest.php
+++ b/tests/Sabre/CalDAV/Schedule/InboxTest.php
@@ -70,7 +70,7 @@ class InboxTest extends \PHPUnit\Framework\TestCase
             1,
             count($inbox->getChildren())
         );
-        self::assertInstanceOf('Sabre\CalDAV\Schedule\SchedulingObject', $inbox->getChildren()[0]);
+        self::assertInstanceOf(\Sabre\CalDAV\Schedule\SchedulingObject::class, $inbox->getChildren()[0]);
         self::assertEquals(
             'schedule1.ics',
             $inbox->getChildren()[0]->getName()
@@ -97,7 +97,7 @@ class InboxTest extends \PHPUnit\Framework\TestCase
             1,
             count($inbox->getChildren())
         );
-        self::assertInstanceOf('Sabre\CalDAV\Schedule\SchedulingObject', $inbox->getChildren()[0]);
+        self::assertInstanceOf(\Sabre\CalDAV\Schedule\SchedulingObject::class, $inbox->getChildren()[0]);
         self::assertEquals(
             'schedule1.ics',
             $inbox->getChildren()[0]->getName()

--- a/tests/Sabre/CalDAV/Schedule/SchedulingObjectTest.php
+++ b/tests/Sabre/CalDAV/Schedule/SchedulingObjectTest.php
@@ -90,7 +90,7 @@ ICS;
      */
     public function testPut()
     {
-        $this->expectException('Sabre\DAV\Exception\MethodNotAllowed');
+        $this->expectException(\Sabre\DAV\Exception\MethodNotAllowed::class);
         $children = $this->inbox->getChildren();
         self::assertTrue($children[0] instanceof SchedulingObject);
 
@@ -211,7 +211,7 @@ ICS;
 
     public function testSetACL()
     {
-        $this->expectException('Sabre\DAV\Exception\Forbidden');
+        $this->expectException(\Sabre\DAV\Exception\Forbidden::class);
         $children = $this->inbox->getChildren();
         self::assertTrue($children[0] instanceof SchedulingObject);
 

--- a/tests/Sabre/CalDAV/SharingPluginTest.php
+++ b/tests/Sabre/CalDAV/SharingPluginTest.php
@@ -45,7 +45,7 @@ class SharingPluginTest extends AbstractDAVServerTestCase
 
     public function testSimple()
     {
-        self::assertInstanceOf('Sabre\\CalDAV\\SharingPlugin', $this->server->getPlugin('caldav-sharing'));
+        self::assertInstanceOf(\Sabre\CalDAV\SharingPlugin::class, $this->server->getPlugin('caldav-sharing'));
         self::assertEquals(
             'caldav-sharing',
             $this->caldavSharingPlugin->getPluginInfo()['name']
@@ -75,8 +75,8 @@ class SharingPluginTest extends AbstractDAVServerTestCase
             '{'.Plugin::NS_CALENDARSERVER.'}allowed-sharing-modes',
         ]);
 
-        self::assertInstanceOf('Sabre\\CalDAV\\Xml\\Property\\Invite', $props['{'.Plugin::NS_CALENDARSERVER.'}invite']);
-        self::assertInstanceOf('Sabre\\CalDAV\\Xml\\Property\\AllowedSharingModes', $props['{'.Plugin::NS_CALENDARSERVER.'}allowed-sharing-modes']);
+        self::assertInstanceOf(\Sabre\CalDAV\Xml\Property\Invite::class, $props['{'.Plugin::NS_CALENDARSERVER.'}invite']);
+        self::assertInstanceOf(\Sabre\CalDAV\Xml\Property\AllowedSharingModes::class, $props['{'.Plugin::NS_CALENDARSERVER.'}allowed-sharing-modes']);
     }
 
     public function testBeforeGetSharedCalendar()
@@ -86,7 +86,7 @@ class SharingPluginTest extends AbstractDAVServerTestCase
             '{'.Plugin::NS_CALENDARSERVER.'}invite',
         ]);
 
-        self::assertInstanceOf('Sabre\\CalDAV\\Xml\\Property\\Invite', $props['{'.Plugin::NS_CALENDARSERVER.'}invite']);
+        self::assertInstanceOf(\Sabre\CalDAV\Xml\Property\Invite::class, $props['{'.Plugin::NS_CALENDARSERVER.'}invite']);
         //self::assertInstanceOf('Sabre\\DAV\\Xml\\Property\\Href', $props['{' . Plugin::NS_CALENDARSERVER . '}shared-url']);
     }
 

--- a/tests/Sabre/CalDAV/Subscriptions/PluginTest.php
+++ b/tests/Sabre/CalDAV/Subscriptions/PluginTest.php
@@ -17,10 +17,10 @@ class PluginTest extends \PHPUnit\Framework\TestCase
 
         self::assertEquals(
             '{http://calendarserver.org/ns/}subscribed',
-            $server->resourceTypeMapping['Sabre\\CalDAV\\Subscriptions\\ISubscription']
+            $server->resourceTypeMapping[\Sabre\CalDAV\Subscriptions\ISubscription::class]
         );
         self::assertEquals(
-            'Sabre\\DAV\\Xml\\Property\\Href',
+            \Sabre\DAV\Xml\Property\Href::class,
             $server->xml->elementMap['{http://calendarserver.org/ns/}source']
         );
 

--- a/tests/Sabre/CalDAV/Subscriptions/SubscriptionTest.php
+++ b/tests/Sabre/CalDAV/Subscriptions/SubscriptionTest.php
@@ -84,7 +84,7 @@ class SubscriptionTest extends \PHPUnit\Framework\TestCase
 
     public function testSetACL()
     {
-        $this->expectException('Sabre\DAV\Exception\Forbidden');
+        $this->expectException(\Sabre\DAV\Exception\Forbidden::class);
         $sub = $this->getSub();
         $sub->setACL([]);
     }

--- a/tests/Sabre/CalDAV/Xml/Property/AllowedSharingModesTest.php
+++ b/tests/Sabre/CalDAV/Xml/Property/AllowedSharingModesTest.php
@@ -12,7 +12,7 @@ class AllowedSharingModesTest extends DAV\Xml\AbstractXmlTestCase
     public function testSimple()
     {
         $sccs = new AllowedSharingModes(true, true);
-        self::assertInstanceOf('Sabre\CalDAV\Xml\Property\AllowedSharingModes', $sccs);
+        self::assertInstanceOf(\Sabre\CalDAV\Xml\Property\AllowedSharingModes::class, $sccs);
     }
 
     /**

--- a/tests/Sabre/CalDAV/Xml/Property/InviteTest.php
+++ b/tests/Sabre/CalDAV/Xml/Property/InviteTest.php
@@ -20,7 +20,7 @@ class InviteTest extends DAV\Xml\AbstractXmlTestCase
     public function testSimple()
     {
         $invite = new Invite([]);
-        self::assertInstanceOf('Sabre\CalDAV\Xml\Property\Invite', $invite);
+        self::assertInstanceOf(\Sabre\CalDAV\Xml\Property\Invite::class, $invite);
         self::assertEquals([], $invite->getValue());
     }
 

--- a/tests/Sabre/CalDAV/Xml/Property/ScheduleCalendarTranspTest.php
+++ b/tests/Sabre/CalDAV/Xml/Property/ScheduleCalendarTranspTest.php
@@ -76,7 +76,7 @@ XML;
 
         $result = $this->parse(
             $xml,
-            ['{DAV:}root' => 'Sabre\\CalDAV\\Xml\\Property\\ScheduleCalendarTransp']
+            ['{DAV:}root' => \Sabre\CalDAV\Xml\Property\ScheduleCalendarTransp::class]
         );
 
         self::assertEquals(
@@ -99,7 +99,7 @@ XML;
 
         $result = $this->parse(
             $xml,
-            ['{DAV:}root' => 'Sabre\\CalDAV\\Xml\\Property\\ScheduleCalendarTransp']
+            ['{DAV:}root' => \Sabre\CalDAV\Xml\Property\ScheduleCalendarTransp::class]
         );
 
         self::assertEquals(

--- a/tests/Sabre/CalDAV/Xml/Property/SupportedCalendarComponentSetTest.php
+++ b/tests/Sabre/CalDAV/Xml/Property/SupportedCalendarComponentSetTest.php
@@ -66,7 +66,7 @@ XML;
 
         $result = $this->parse(
             $xml,
-            ['{DAV:}root' => 'Sabre\\CalDAV\\Xml\\Property\\SupportedCalendarComponentSet']
+            ['{DAV:}root' => \Sabre\CalDAV\Xml\Property\SupportedCalendarComponentSet::class]
         );
 
         self::assertEquals(
@@ -77,7 +77,7 @@ XML;
 
     public function testUnserializeEmpty()
     {
-        $this->expectException('Sabre\Xml\ParseException');
+        $this->expectException(\Sabre\Xml\ParseException::class);
         $cal = CalDAV\Plugin::NS_CALDAV;
         $cs = CalDAV\Plugin::NS_CALENDARSERVER;
 
@@ -89,7 +89,7 @@ XML;
 
         $result = $this->parse(
             $xml,
-            ['{DAV:}root' => 'Sabre\\CalDAV\\Xml\\Property\\SupportedCalendarComponentSet']
+            ['{DAV:}root' => \Sabre\CalDAV\Xml\Property\SupportedCalendarComponentSet::class]
         );
     }
 }

--- a/tests/Sabre/CalDAV/Xml/Property/SupportedCalendarDataTest.php
+++ b/tests/Sabre/CalDAV/Xml/Property/SupportedCalendarDataTest.php
@@ -12,7 +12,7 @@ class SupportedCalendarDataTest extends DAV\Xml\AbstractXmlTestCase
     public function testSimple()
     {
         $sccs = new SupportedCalendarData();
-        self::assertInstanceOf('Sabre\CalDAV\Xml\Property\SupportedCalendarData', $sccs);
+        self::assertInstanceOf(\Sabre\CalDAV\Xml\Property\SupportedCalendarData::class, $sccs);
     }
 
     /**

--- a/tests/Sabre/CalDAV/Xml/Property/SupportedCollationSetTest.php
+++ b/tests/Sabre/CalDAV/Xml/Property/SupportedCollationSetTest.php
@@ -12,7 +12,7 @@ class SupportedCollationSetTest extends DAV\Xml\AbstractXmlTestCase
     public function testSimple()
     {
         $scs = new SupportedCollationSet();
-        self::assertInstanceOf('Sabre\CalDAV\Xml\Property\SupportedCollationSet', $scs);
+        self::assertInstanceOf(\Sabre\CalDAV\Xml\Property\SupportedCollationSet::class, $scs);
     }
 
     /**

--- a/tests/Sabre/CalDAV/Xml/Request/CalendarQueryReportTest.php
+++ b/tests/Sabre/CalDAV/Xml/Request/CalendarQueryReportTest.php
@@ -11,7 +11,7 @@ use Sabre\DAV\Xml\AbstractXmlTestCase;
 class CalendarQueryReportTest extends AbstractXmlTestCase
 {
     protected $elementMap = [
-        '{urn:ietf:params:xml:ns:caldav}calendar-query' => 'Sabre\\CalDAV\\Xml\\Request\CalendarQueryReport',
+        '{urn:ietf:params:xml:ns:caldav}calendar-query' => \Sabre\CalDAV\Xml\Request\CalendarQueryReport::class,
     ];
 
     public function testDeserialize()
@@ -49,7 +49,7 @@ XML;
 
     public function testDeserializeNoFilter()
     {
-        $this->expectException('Sabre\DAV\Exception\BadRequest');
+        $this->expectException(\Sabre\DAV\Exception\BadRequest::class);
         $xml = <<<XML
 <?xml version="1.0"?>
 <c:calendar-query xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav">
@@ -215,7 +215,7 @@ XML;
 
     public function testDeserializeDoubleTopCompFilter()
     {
-        $this->expectException('Sabre\DAV\Exception\BadRequest');
+        $this->expectException(\Sabre\DAV\Exception\BadRequest::class);
         $xml = <<<XML
 <?xml version="1.0"?>
 <c:calendar-query xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav">
@@ -237,7 +237,7 @@ XML;
 
     public function testDeserializeMissingExpandEnd()
     {
-        $this->expectException('Sabre\DAV\Exception\BadRequest');
+        $this->expectException(\Sabre\DAV\Exception\BadRequest::class);
         $xml = <<<XML
 <?xml version="1.0"?>
 <c:calendar-query xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav">
@@ -258,7 +258,7 @@ XML;
 
     public function testDeserializeExpandEndBeforeStart()
     {
-        $this->expectException('Sabre\DAV\Exception\BadRequest');
+        $this->expectException(\Sabre\DAV\Exception\BadRequest::class);
         $xml = <<<XML
 <?xml version="1.0"?>
 <c:calendar-query xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav">
@@ -279,7 +279,7 @@ XML;
 
     public function testDeserializeTimeRangeOnVCALENDAR()
     {
-        $this->expectException('Sabre\DAV\Exception\BadRequest');
+        $this->expectException(\Sabre\DAV\Exception\BadRequest::class);
         $xml = <<<XML
 <?xml version="1.0"?>
 <c:calendar-query xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav">
@@ -300,7 +300,7 @@ XML;
 
     public function testDeserializeTimeRangeEndBeforeStart()
     {
-        $this->expectException('Sabre\DAV\Exception\BadRequest');
+        $this->expectException(\Sabre\DAV\Exception\BadRequest::class);
         $xml = <<<XML
 <?xml version="1.0"?>
 <c:calendar-query xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav">
@@ -323,7 +323,7 @@ XML;
 
     public function testDeserializeTimeRangePropEndBeforeStart()
     {
-        $this->expectException('Sabre\DAV\Exception\BadRequest');
+        $this->expectException(\Sabre\DAV\Exception\BadRequest::class);
         $xml = <<<XML
 <?xml version="1.0"?>
 <c:calendar-query xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav">

--- a/tests/Sabre/CalDAV/Xml/Request/InviteReplyTest.php
+++ b/tests/Sabre/CalDAV/Xml/Request/InviteReplyTest.php
@@ -10,7 +10,7 @@ use Sabre\DAV\Xml\AbstractXmlTestCase;
 class InviteReplyTest extends AbstractXmlTestCase
 {
     protected $elementMap = [
-        '{http://calendarserver.org/ns/}invite-reply' => 'Sabre\\CalDAV\\Xml\\Request\\InviteReply',
+        '{http://calendarserver.org/ns/}invite-reply' => \Sabre\CalDAV\Xml\Request\InviteReply::class,
     ];
 
     public function testDeserialize()
@@ -59,7 +59,7 @@ XML;
 
     public function testDeserializeNoHostUrl()
     {
-        $this->expectException('Sabre\DAV\Exception\BadRequest');
+        $this->expectException(\Sabre\DAV\Exception\BadRequest::class);
         $xml = <<<XML
 <?xml version="1.0"?>
 <cs:invite-reply xmlns:cs="http://calendarserver.org/ns/" xmlns:d="DAV:">

--- a/tests/Sabre/CalDAV/Xml/Request/ShareTest.php
+++ b/tests/Sabre/CalDAV/Xml/Request/ShareTest.php
@@ -10,7 +10,7 @@ use Sabre\DAV\Xml\Element\Sharee;
 class ShareTest extends AbstractXmlTestCase
 {
     protected $elementMap = [
-        '{http://calendarserver.org/ns/}share' => 'Sabre\\CalDAV\\Xml\\Request\\Share',
+        '{http://calendarserver.org/ns/}share' => \Sabre\CalDAV\Xml\Request\Share::class,
     ];
 
     public function testDeserialize()

--- a/tests/Sabre/CardDAV/AddressBookHomeTest.php
+++ b/tests/Sabre/CardDAV/AddressBookHomeTest.php
@@ -30,13 +30,13 @@ class AddressBookHomeTest extends \PHPUnit\Framework\TestCase
 
     public function testSetName()
     {
-        $this->expectException('Sabre\DAV\Exception\MethodNotAllowed');
+        $this->expectException(\Sabre\DAV\Exception\MethodNotAllowed::class);
         $this->s->setName('user2');
     }
 
     public function testDelete()
     {
-        $this->expectException('Sabre\DAV\Exception\MethodNotAllowed');
+        $this->expectException(\Sabre\DAV\Exception\MethodNotAllowed::class);
         $this->s->delete();
     }
 
@@ -47,26 +47,26 @@ class AddressBookHomeTest extends \PHPUnit\Framework\TestCase
 
     public function testCreateFile()
     {
-        $this->expectException('Sabre\DAV\Exception\MethodNotAllowed');
+        $this->expectException(\Sabre\DAV\Exception\MethodNotAllowed::class);
         $this->s->createFile('bla');
     }
 
     public function testCreateDirectory()
     {
-        $this->expectException('Sabre\DAV\Exception\MethodNotAllowed');
+        $this->expectException(\Sabre\DAV\Exception\MethodNotAllowed::class);
         $this->s->createDirectory('bla');
     }
 
     public function testGetChild()
     {
         $child = $this->s->getChild('book1');
-        self::assertInstanceOf('Sabre\\CardDAV\\AddressBook', $child);
+        self::assertInstanceOf(\Sabre\CardDAV\AddressBook::class, $child);
         self::assertEquals('book1', $child->getName());
     }
 
     public function testGetChild404()
     {
-        $this->expectException('Sabre\DAV\Exception\NotFound');
+        $this->expectException(\Sabre\DAV\Exception\NotFound::class);
         $this->s->getChild('book2');
     }
 
@@ -74,7 +74,7 @@ class AddressBookHomeTest extends \PHPUnit\Framework\TestCase
     {
         $children = $this->s->getChildren();
         self::assertEquals(2, count($children));
-        self::assertInstanceOf('Sabre\\CardDAV\\AddressBook', $children[0]);
+        self::assertInstanceOf(\Sabre\CardDAV\AddressBook::class, $children[0]);
         self::assertEquals('book1', $children[0]->getName());
     }
 
@@ -96,7 +96,7 @@ class AddressBookHomeTest extends \PHPUnit\Framework\TestCase
 
     public function testCreateExtendedCollectionInvalid()
     {
-        $this->expectException('Sabre\DAV\Exception\InvalidResourceType');
+        $this->expectException(\Sabre\DAV\Exception\InvalidResourceType::class);
         $resourceType = [
             '{DAV:}collection',
         ];
@@ -118,7 +118,7 @@ class AddressBookHomeTest extends \PHPUnit\Framework\TestCase
 
     public function testSetACL()
     {
-        $this->expectException('Sabre\DAV\Exception\Forbidden');
+        $this->expectException(\Sabre\DAV\Exception\Forbidden::class);
         $this->s->setACL([]);
     }
 

--- a/tests/Sabre/CardDAV/AddressBookRootTest.php
+++ b/tests/Sabre/CardDAV/AddressBookRootTest.php
@@ -25,7 +25,7 @@ class AddressBookRootTest extends \PHPUnit\Framework\TestCase
         $children = $root->getChildren();
         self::assertEquals(3, count($children));
 
-        self::assertInstanceOf('Sabre\\CardDAV\\AddressBookHome', $children[0]);
+        self::assertInstanceOf(\Sabre\CardDAV\AddressBookHome::class, $children[0]);
         self::assertEquals('user1', $children[0]->getName());
     }
 }

--- a/tests/Sabre/CardDAV/AddressBookTest.php
+++ b/tests/Sabre/CardDAV/AddressBookTest.php
@@ -38,13 +38,13 @@ class AddressBookTest extends \PHPUnit\Framework\TestCase
     public function testGetChild()
     {
         $card = $this->ab->getChild('card1');
-        self::assertInstanceOf('Sabre\\CardDAV\\Card', $card);
+        self::assertInstanceOf(\Sabre\CardDAV\Card::class, $card);
         self::assertEquals('card1', $card->getName());
     }
 
     public function testGetChildNotFound()
     {
-        $this->expectException('Sabre\DAV\Exception\NotFound');
+        $this->expectException(\Sabre\DAV\Exception\NotFound::class);
         $card = $this->ab->getChild('card3');
     }
 
@@ -59,7 +59,7 @@ class AddressBookTest extends \PHPUnit\Framework\TestCase
 
     public function testCreateDirectory()
     {
-        $this->expectException('Sabre\DAV\Exception\MethodNotAllowed');
+        $this->expectException(\Sabre\DAV\Exception\MethodNotAllowed::class);
         $this->ab->createDirectory('name');
     }
 
@@ -81,7 +81,7 @@ class AddressBookTest extends \PHPUnit\Framework\TestCase
 
     public function testSetName()
     {
-        $this->expectException('Sabre\DAV\Exception\MethodNotAllowed');
+        $this->expectException(\Sabre\DAV\Exception\MethodNotAllowed::class);
         $this->ab->setName('foo');
     }
 
@@ -124,7 +124,7 @@ class AddressBookTest extends \PHPUnit\Framework\TestCase
 
     public function testSetACL()
     {
-        $this->expectException('Sabre\DAV\Exception\Forbidden');
+        $this->expectException(\Sabre\DAV\Exception\Forbidden::class);
         $this->ab->setACL([]);
     }
 

--- a/tests/Sabre/CardDAV/Backend/AbstractPDOTestCase.php
+++ b/tests/Sabre/CardDAV/Backend/AbstractPDOTestCase.php
@@ -146,7 +146,7 @@ abstract class AbstractPDOTestCase extends TestCase
 
     public function testCreateAddressBookUnsupportedProp()
     {
-        $this->expectException('Sabre\DAV\Exception\BadRequest');
+        $this->expectException(\Sabre\DAV\Exception\BadRequest::class);
         $this->backend->createAddressBook('principals/user1', 'book2', [
             '{DAV:}foo' => 'bar',
         ]);

--- a/tests/Sabre/CardDAV/CardTest.php
+++ b/tests/Sabre/CardDAV/CardTest.php
@@ -181,7 +181,7 @@ class CardTest extends \PHPUnit\Framework\TestCase
 
     public function testSetACL()
     {
-        $this->expectException('Sabre\DAV\Exception\Forbidden');
+        $this->expectException(\Sabre\DAV\Exception\Forbidden::class);
         $this->card->setACL([]);
     }
 

--- a/tests/Sabre/CardDAV/PluginTest.php
+++ b/tests/Sabre/CardDAV/PluginTest.php
@@ -10,7 +10,7 @@ class PluginTest extends AbstractPluginTestCase
 {
     public function testConstruct()
     {
-        self::assertEquals('{'.Plugin::NS_CARDDAV.'}addressbook', $this->server->resourceTypeMapping['Sabre\\CardDAV\\IAddressBook']);
+        self::assertEquals('{'.Plugin::NS_CARDDAV.'}addressbook', $this->server->resourceTypeMapping[\Sabre\CardDAV\IAddressBook::class]);
 
         self::assertContains('addressbook', $this->plugin->getFeatures());
         self::assertEquals('carddav', $this->plugin->getPluginInfo()['name']);
@@ -73,11 +73,11 @@ class PluginTest extends AbstractPluginTestCase
         $this->plugin->propFindEarly($propFind, $node);
 
         self::assertInstanceOf(
-            'Sabre\\CardDAV\\Xml\\Property\\SupportedAddressData',
+            \Sabre\CardDAV\Xml\Property\SupportedAddressData::class,
             $propFind->get($ns.'supported-address-data')
         );
         self::assertInstanceOf(
-            'Sabre\\CardDAV\\Xml\\Property\\SupportedCollationSet',
+            \Sabre\CardDAV\Xml\Property\SupportedCollationSet::class,
             $propFind->get($ns.'supported-collation-set')
         );
     }

--- a/tests/Sabre/CardDAV/VCFExportTest.php
+++ b/tests/Sabre/CardDAV/VCFExportTest.php
@@ -40,7 +40,7 @@ class VCFExportTest extends \Sabre\AbstractDAVServerTestCase
     public function testSimple()
     {
         $plugin = $this->server->getPlugin('vcf-export');
-        self::assertInstanceOf('Sabre\\CardDAV\\VCFExportPlugin', $plugin);
+        self::assertInstanceOf(\Sabre\CardDAV\VCFExportPlugin::class, $plugin);
 
         self::assertEquals(
             'vcf-export',

--- a/tests/Sabre/CardDAV/Xml/Property/SupportedAddressDataTest.php
+++ b/tests/Sabre/CardDAV/Xml/Property/SupportedAddressDataTest.php
@@ -12,7 +12,7 @@ class SupportedAddressDataTest extends DAV\Xml\AbstractXmlTestCase
     public function testSimple()
     {
         $property = new SupportedAddressData();
-        self::assertInstanceOf('Sabre\CardDAV\Xml\Property\SupportedAddressData', $property);
+        self::assertInstanceOf(\Sabre\CardDAV\Xml\Property\SupportedAddressData::class, $property);
     }
 
     /**

--- a/tests/Sabre/CardDAV/Xml/Property/SupportedCollationSetTest.php
+++ b/tests/Sabre/CardDAV/Xml/Property/SupportedCollationSetTest.php
@@ -12,7 +12,7 @@ class SupportedCollationSetTest extends DAV\Xml\AbstractXmlTestCase
     public function testSimple()
     {
         $property = new SupportedCollationSet();
-        self::assertInstanceOf('Sabre\CardDAV\Xml\Property\SupportedCollationSet', $property);
+        self::assertInstanceOf(\Sabre\CardDAV\Xml\Property\SupportedCollationSet::class, $property);
     }
 
     /**

--- a/tests/Sabre/CardDAV/Xml/Request/AddressBookMultiGetReportTest.php
+++ b/tests/Sabre/CardDAV/Xml/Request/AddressBookMultiGetReportTest.php
@@ -7,7 +7,7 @@ use Sabre\DAV\Xml\AbstractXmlTestCase;
 class AddressBookMultiGetReportTest extends AbstractXmlTestCase
 {
     protected $elementMap = [
-        '{urn:ietf:params:xml:ns:carddav}addressbook-multiget' => 'Sabre\\CardDAV\\Xml\\Request\AddressBookMultiGetReport',
+        '{urn:ietf:params:xml:ns:carddav}addressbook-multiget' => \Sabre\CardDAV\Xml\Request\AddressBookMultiGetReport::class,
     ];
 
     /**

--- a/tests/Sabre/CardDAV/Xml/Request/AddressBookQueryReportTest.php
+++ b/tests/Sabre/CardDAV/Xml/Request/AddressBookQueryReportTest.php
@@ -9,7 +9,7 @@ use Sabre\DAV\Xml\AbstractXmlTestCase;
 class AddressBookQueryReportTest extends AbstractXmlTestCase
 {
     protected $elementMap = [
-        '{urn:ietf:params:xml:ns:carddav}addressbook-query' => 'Sabre\\CardDAV\\Xml\\Request\AddressBookQueryReport',
+        '{urn:ietf:params:xml:ns:carddav}addressbook-query' => \Sabre\CardDAV\Xml\Request\AddressBookQueryReport::class,
     ];
 
     public function testDeserialize()
@@ -86,7 +86,7 @@ XML;
 
     public function testDeserializeBadTest()
     {
-        $this->expectException('Sabre\DAV\Exception\BadRequest');
+        $this->expectException(\Sabre\DAV\Exception\BadRequest::class);
         $xml = <<<XML
 <?xml version="1.0"?>
 <c:addressbook-query xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:carddav">
@@ -231,7 +231,7 @@ XML;
 
     public function testDeserializeBadMatchType()
     {
-        $this->expectException('Sabre\DAV\Exception\BadRequest');
+        $this->expectException(\Sabre\DAV\Exception\BadRequest::class);
         $xml = <<<XML
 <?xml version="1.0"?>
 <c:addressbook-query xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:carddav">
@@ -252,7 +252,7 @@ XML;
 
     public function testDeserializeBadMatchType2()
     {
-        $this->expectException('Sabre\DAV\Exception\BadRequest');
+        $this->expectException(\Sabre\DAV\Exception\BadRequest::class);
         $xml = <<<XML
 <?xml version="1.0"?>
 <c:addressbook-query xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:carddav">
@@ -271,7 +271,7 @@ XML;
 
     public function testDeserializeDoubleFilter()
     {
-        $this->expectException('Sabre\DAV\Exception\BadRequest');
+        $this->expectException(\Sabre\DAV\Exception\BadRequest::class);
         $xml = <<<XML
 <?xml version="1.0"?>
 <c:addressbook-query xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:carddav">

--- a/tests/Sabre/DAV/Auth/Backend/AbstractDigestTest.php
+++ b/tests/Sabre/DAV/Auth/Backend/AbstractDigestTest.php
@@ -37,7 +37,7 @@ class AbstractDigestTest extends \PHPUnit\Framework\TestCase
 
     public function testCheckBadGetUserInfoResponse2()
     {
-        $this->expectException('Sabre\DAV\Exception');
+        $this->expectException(\Sabre\DAV\Exception::class);
         $header = 'username=array, realm=myRealm, nonce=12345, uri=/, response=HASH, opaque=1, qop=auth, nc=1, cnonce=1';
         $request = HTTP\Sapi::createFromServerArray([
             'REQUEST_METHOD' => 'GET',

--- a/tests/Sabre/DAV/Auth/Backend/ApacheTest.php
+++ b/tests/Sabre/DAV/Auth/Backend/ApacheTest.php
@@ -11,7 +11,7 @@ class ApacheTest extends \PHPUnit\Framework\TestCase
     public function testConstruct()
     {
         $backend = new Apache();
-        self::assertInstanceOf('Sabre\DAV\Auth\Backend\Apache', $backend);
+        self::assertInstanceOf(\Sabre\DAV\Auth\Backend\Apache::class, $backend);
     }
 
     public function testNoHeader()

--- a/tests/Sabre/DAV/Auth/Backend/FileTest.php
+++ b/tests/Sabre/DAV/Auth/Backend/FileTest.php
@@ -21,7 +21,7 @@ class FileTest extends \PHPUnit\Framework\TestCase
 
     public function testLoadFileBroken()
     {
-        $this->expectException('Sabre\DAV\Exception');
+        $this->expectException(\Sabre\DAV\Exception::class);
         file_put_contents(\Sabre\TestUtil::SABRE_TEMPDIR.'/backend', 'user:realm:hash');
         $file = new File(\Sabre\TestUtil::SABRE_TEMPDIR.'/backend');
     }

--- a/tests/Sabre/DAV/Auth/PluginTest.php
+++ b/tests/Sabre/DAV/Auth/PluginTest.php
@@ -37,7 +37,7 @@ class PluginTest extends \PHPUnit\Framework\TestCase
      */
     public function testAuthenticateFail()
     {
-        $this->expectException('Sabre\DAV\Exception\NotAuthenticated');
+        $this->expectException(\Sabre\DAV\Exception\NotAuthenticated::class);
         $fakeServer = new DAV\Server(new DAV\SimpleCollection('bla'));
         $backend = new Backend\Mock();
         $backend->fail = true;
@@ -90,7 +90,7 @@ class PluginTest extends \PHPUnit\Framework\TestCase
      */
     public function testNoAuthBackend()
     {
-        $this->expectException('Sabre\DAV\Exception');
+        $this->expectException(\Sabre\DAV\Exception::class);
         $fakeServer = new DAV\Server(new DAV\SimpleCollection('bla'));
 
         $plugin = new Plugin();
@@ -103,7 +103,7 @@ class PluginTest extends \PHPUnit\Framework\TestCase
      */
     public function testInvalidCheckResponse()
     {
-        $this->expectException('Sabre\DAV\Exception');
+        $this->expectException(\Sabre\DAV\Exception::class);
         $fakeServer = new DAV\Server(new DAV\SimpleCollection('bla'));
         $backend = new Backend\Mock();
         $backend->invalidCheckResponse = true;

--- a/tests/Sabre/DAV/BasicNodeTest.php
+++ b/tests/Sabre/DAV/BasicNodeTest.php
@@ -8,14 +8,14 @@ class BasicNodeTest extends \PHPUnit\Framework\TestCase
 {
     public function testPut()
     {
-        $this->expectException('Sabre\DAV\Exception\Forbidden');
+        $this->expectException(\Sabre\DAV\Exception\Forbidden::class);
         $file = new FileMock();
         $file->put('hi');
     }
 
     public function testGet()
     {
-        $this->expectException('Sabre\DAV\Exception\Forbidden');
+        $this->expectException(\Sabre\DAV\Exception\Forbidden::class);
         $file = new FileMock();
         $file->get();
     }
@@ -40,14 +40,14 @@ class BasicNodeTest extends \PHPUnit\Framework\TestCase
 
     public function testDelete()
     {
-        $this->expectException('Sabre\DAV\Exception\Forbidden');
+        $this->expectException(\Sabre\DAV\Exception\Forbidden::class);
         $file = new FileMock();
         $file->delete();
     }
 
     public function testSetName()
     {
-        $this->expectException('Sabre\DAV\Exception\Forbidden');
+        $this->expectException(\Sabre\DAV\Exception\Forbidden::class);
         $file = new FileMock();
         $file->setName('hi');
     }
@@ -82,21 +82,21 @@ class BasicNodeTest extends \PHPUnit\Framework\TestCase
 
     public function testGetChild404()
     {
-        $this->expectException('Sabre\DAV\Exception\NotFound');
+        $this->expectException(\Sabre\DAV\Exception\NotFound::class);
         $dir = new DirectoryMock();
         $file = $dir->getChild('blabla');
     }
 
     public function testCreateFile()
     {
-        $this->expectException('Sabre\DAV\Exception\Forbidden');
+        $this->expectException(\Sabre\DAV\Exception\Forbidden::class);
         $dir = new DirectoryMock();
         $dir->createFile('hello', 'data');
     }
 
     public function testCreateDirectory()
     {
-        $this->expectException('Sabre\DAV\Exception\Forbidden');
+        $this->expectException(\Sabre\DAV\Exception\Forbidden::class);
         $dir = new DirectoryMock();
         $dir->createDirectory('hello');
     }

--- a/tests/Sabre/DAV/ClientTest.php
+++ b/tests/Sabre/DAV/ClientTest.php
@@ -20,7 +20,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
         $client = new ClientMock([
             'baseUri' => '/',
         ]);
-        self::assertInstanceOf('Sabre\DAV\ClientMock', $client);
+        self::assertInstanceOf(\Sabre\DAV\ClientMock::class, $client);
     }
 
     public function testConstructNoBaseUri()
@@ -137,7 +137,7 @@ XML;
 
     public function testPropFindError()
     {
-        $this->expectException('Sabre\HTTP\ClientHttpException');
+        $this->expectException(\Sabre\HTTP\ClientHttpException::class);
         $client = new ClientMock([
             'baseUri' => '/',
         ]);
@@ -504,7 +504,7 @@ XML;
      */
     public function testPropPatchHTTPError()
     {
-        $this->expectException('Sabre\HTTP\ClientHttpException');
+        $this->expectException(\Sabre\HTTP\ClientHttpException::class);
         $client = new ClientMock([
             'baseUri' => '/',
         ]);
@@ -518,7 +518,7 @@ XML;
      */
     public function testPropPatchMultiStatusError()
     {
-        $this->expectException('Sabre\HTTP\ClientException');
+        $this->expectException(\Sabre\HTTP\ClientException::class);
         $client = new ClientMock([
             'baseUri' => '/',
         ]);

--- a/tests/Sabre/DAV/ExceptionTest.php
+++ b/tests/Sabre/DAV/ExceptionTest.php
@@ -15,8 +15,8 @@ class ExceptionTest extends \PHPUnit\Framework\TestCase
     public function testExceptionStatuses()
     {
         $c = [
-            'Sabre\\DAV\\Exception\\NotAuthenticated' => 401,
-            'Sabre\\DAV\\Exception\\InsufficientStorage' => 507,
+            \Sabre\DAV\Exception\NotAuthenticated::class => 401,
+            \Sabre\DAV\Exception\InsufficientStorage::class => 507,
         ];
 
         foreach ($c as $class => $status) {

--- a/tests/Sabre/DAV/FS/NodeTest.php
+++ b/tests/Sabre/DAV/FS/NodeTest.php
@@ -23,7 +23,7 @@ class NodeTest extends \PHPUnit\Framework\TestCase
 
     public function testOverrideNameSetName()
     {
-        $this->expectException('Sabre\DAV\Exception\Forbidden');
+        $this->expectException(\Sabre\DAV\Exception\Forbidden::class);
         $node = new File(__FILE__, 'foo.txt');
         $node->setName('foo2.txt');
     }

--- a/tests/Sabre/DAV/FSExt/DirectoryTest.php
+++ b/tests/Sabre/DAV/FSExt/DirectoryTest.php
@@ -19,7 +19,7 @@ class DirectoryTest extends \PHPUnit\Framework\TestCase
 
     public function testChildExistDot()
     {
-        $this->expectException('Sabre\DAV\Exception\Forbidden');
+        $this->expectException(\Sabre\DAV\Exception\Forbidden::class);
         $dir = $this->create();
         $dir->childExists('..');
     }

--- a/tests/Sabre/DAV/Locks/Backend/AbstractTestCase.php
+++ b/tests/Sabre/DAV/Locks/Backend/AbstractTestCase.php
@@ -19,7 +19,7 @@ abstract class AbstractTestCase extends TestCase
     public function testSetup()
     {
         $backend = $this->getBackend();
-        self::assertInstanceOf('Sabre\\DAV\\Locks\\Backend\\AbstractBackend', $backend);
+        self::assertInstanceOf(\Sabre\DAV\Locks\Backend\AbstractBackend::class, $backend);
     }
 
     /**

--- a/tests/Sabre/DAV/Locks/PluginTest.php
+++ b/tests/Sabre/DAV/Locks/PluginTest.php
@@ -914,7 +914,7 @@ class PluginTest extends DAV\AbstractServerTestCase
 
     public function testGetTimeoutHeaderInvalid()
     {
-        $this->expectException('Sabre\DAV\Exception\BadRequest');
+        $this->expectException(\Sabre\DAV\Exception\BadRequest::class);
         $request = new HTTP\Request('GET', '/', ['Timeout' => 'yourmom']);
 
         $this->server->httpRequest = $request;

--- a/tests/Sabre/DAV/ObjectTreeTest.php
+++ b/tests/Sabre/DAV/ObjectTreeTest.php
@@ -27,13 +27,13 @@ class ObjectTreeTest extends \PHPUnit\Framework\TestCase
     public function testGetRootNode()
     {
         $root = $this->tree->getNodeForPath('');
-        self::assertInstanceOf('Sabre\\DAV\\FSExt\\Directory', $root);
+        self::assertInstanceOf(\Sabre\DAV\FSExt\Directory::class, $root);
     }
 
     public function testGetSubDir()
     {
         $root = $this->tree->getNodeForPath('subdir');
-        self::assertInstanceOf('Sabre\\DAV\\FSExt\\Directory', $root);
+        self::assertInstanceOf(\Sabre\DAV\FSExt\Directory::class, $root);
     }
 
     public function testCopyFile()

--- a/tests/Sabre/DAV/PSR3Test.php
+++ b/tests/Sabre/DAV/PSR3Test.php
@@ -10,7 +10,7 @@ class PSR3Test extends \PHPUnit\Framework\TestCase
     {
         $server = new Server();
         self::assertInstanceOf(
-            'Psr\Log\LoggerAwareInterface',
+            \Psr\Log\LoggerAwareInterface::class,
             $server
         );
     }
@@ -19,7 +19,7 @@ class PSR3Test extends \PHPUnit\Framework\TestCase
     {
         $server = new Server();
         self::assertInstanceOf(
-            'Psr\Log\NullLogger',
+            \Psr\Log\NullLogger::class,
             $server->getLogger()
         );
     }

--- a/tests/Sabre/DAV/ServerEventsTest.php
+++ b/tests/Sabre/DAV/ServerEventsTest.php
@@ -159,7 +159,7 @@ class ServerEventsTest extends AbstractServerTestCase
         $this->server->httpRequest = $req;
         $this->server->exec();
 
-        self::assertInstanceOf('Sabre\\DAV\\Exception\\NotFound', $this->exception);
+        self::assertInstanceOf(\Sabre\DAV\Exception\NotFound::class, $this->exception);
     }
 
     public function exceptionHandler(Exception $exception)

--- a/tests/Sabre/DAV/ServerPluginTest.php
+++ b/tests/Sabre/DAV/ServerPluginTest.php
@@ -29,7 +29,7 @@ class ServerPluginTest extends AbstractServerTestCase
         self::assertEquals([], $p->getHTTPMethods(''));
         self::assertEquals(
             [
-                'name' => 'Sabre\DAV\ServerPluginMock',
+                'name' => \Sabre\DAV\ServerPluginMock::class,
                 'description' => null,
                 'link' => null,
             ], $p->getPluginInfo()

--- a/tests/Sabre/DAV/ServerPreconditionsTest.php
+++ b/tests/Sabre/DAV/ServerPreconditionsTest.php
@@ -10,7 +10,7 @@ class ServerPreconditionsTest extends \PHPUnit\Framework\TestCase
 {
     public function testIfMatchNoNode()
     {
-        $this->expectException('Sabre\DAV\Exception\PreconditionFailed');
+        $this->expectException(\Sabre\DAV\Exception\PreconditionFailed::class);
         $root = new SimpleCollection('root', [new ServerPreconditionsNode()]);
         $server = new Server($root);
         $httpRequest = new HTTP\Request('GET', '/bar', ['If-Match' => '*']);
@@ -29,7 +29,7 @@ class ServerPreconditionsTest extends \PHPUnit\Framework\TestCase
 
     public function testIfMatchWrongEtag()
     {
-        $this->expectException('Sabre\DAV\Exception\PreconditionFailed');
+        $this->expectException(\Sabre\DAV\Exception\PreconditionFailed::class);
         $root = new SimpleCollection('root', [new ServerPreconditionsNode()]);
         $server = new Server($root);
         $httpRequest = new HTTP\Request('GET', '/foo', ['If-Match' => '1234']);
@@ -80,7 +80,7 @@ class ServerPreconditionsTest extends \PHPUnit\Framework\TestCase
 
     public function testIfNoneMatchHasNode()
     {
-        $this->expectException('Sabre\DAV\Exception\PreconditionFailed');
+        $this->expectException(\Sabre\DAV\Exception\PreconditionFailed::class);
         $root = new SimpleCollection('root', [new ServerPreconditionsNode()]);
         $server = new Server($root);
         $httpRequest = new HTTP\Request('POST', '/foo', ['If-None-Match' => '*']);
@@ -108,7 +108,7 @@ class ServerPreconditionsTest extends \PHPUnit\Framework\TestCase
 
     public function testIfNoneMatchCorrectEtag()
     {
-        $this->expectException('Sabre\DAV\Exception\PreconditionFailed');
+        $this->expectException(\Sabre\DAV\Exception\PreconditionFailed::class);
         $root = new SimpleCollection('root', [new ServerPreconditionsNode()]);
         $server = new Server($root);
         $httpRequest = new HTTP\Request('POST', '/foo', ['If-None-Match' => '"abc123"']);
@@ -118,7 +118,7 @@ class ServerPreconditionsTest extends \PHPUnit\Framework\TestCase
 
     public function testIfNoneMatchCorrectEtagMultiple()
     {
-        $this->expectException('Sabre\DAV\Exception\PreconditionFailed');
+        $this->expectException(\Sabre\DAV\Exception\PreconditionFailed::class);
         $root = new SimpleCollection('root', [new ServerPreconditionsNode()]);
         $server = new Server($root);
         $httpRequest = new HTTP\Request('POST', '/foo', ['If-None-Match' => '"1234, "abc123"']);
@@ -227,7 +227,7 @@ class ServerPreconditionsTest extends \PHPUnit\Framework\TestCase
 
     public function testIfUnmodifiedSinceModified()
     {
-        $this->expectException('Sabre\DAV\Exception\PreconditionFailed');
+        $this->expectException(\Sabre\DAV\Exception\PreconditionFailed::class);
         $root = new SimpleCollection('root', [new ServerPreconditionsNode()]);
         $server = new Server($root);
         $httpRequest = new HTTP\Request('GET', '/foo', [

--- a/tests/Sabre/DAV/ServerSimpleTest.php
+++ b/tests/Sabre/DAV/ServerSimpleTest.php
@@ -20,7 +20,7 @@ class ServerSimpleTest extends AbstractServerTestCase
 
     public function testConstructInvalidArg()
     {
-        $this->expectException('Sabre\DAV\Exception');
+        $this->expectException(\Sabre\DAV\Exception::class);
         $server = new Server(1);
     }
 
@@ -189,7 +189,7 @@ class ServerSimpleTest extends AbstractServerTestCase
 
     public function testCalculateUriBreakout()
     {
-        $this->expectException('Sabre\DAV\Exception\Forbidden');
+        $this->expectException(\Sabre\DAV\Exception\Forbidden::class);
         $uri = '/path1/';
 
         $this->server->setBaseUri('/path2/');
@@ -310,7 +310,7 @@ class ServerSimpleTest extends AbstractServerTestCase
      */
     public function testGuessBaseUriBadConfig()
     {
-        $this->expectException('Sabre\DAV\Exception');
+        $this->expectException(\Sabre\DAV\Exception::class);
         $serverVars = [
             'REQUEST_METHOD' => 'GET',
             'REQUEST_URI' => '/index.php/root/heyyy',

--- a/tests/Sabre/DAV/Sharing/PluginTest.php
+++ b/tests/Sabre/DAV/Sharing/PluginTest.php
@@ -129,7 +129,7 @@ class PluginTest extends \Sabre\AbstractDAVServerTestCase
 
     public function testBrowserPostActionNoHref()
     {
-        $this->expectException('Sabre\DAV\Exception\BadRequest');
+        $this->expectException(\Sabre\DAV\Exception\BadRequest::class);
         $this->sharingPlugin->browserPostAction(
             'shareable',
             'share',
@@ -141,7 +141,7 @@ class PluginTest extends \Sabre\AbstractDAVServerTestCase
 
     public function testBrowserPostActionNoAccess()
     {
-        $this->expectException('Sabre\DAV\Exception\BadRequest');
+        $this->expectException(\Sabre\DAV\Exception\BadRequest::class);
         $this->sharingPlugin->browserPostAction(
             'shareable',
             'share',
@@ -153,7 +153,7 @@ class PluginTest extends \Sabre\AbstractDAVServerTestCase
 
     public function testBrowserPostActionBadAccess()
     {
-        $this->expectException('Sabre\DAV\Exception\BadRequest');
+        $this->expectException(\Sabre\DAV\Exception\BadRequest::class);
         $this->sharingPlugin->browserPostAction(
             'shareable',
             'share',
@@ -166,7 +166,7 @@ class PluginTest extends \Sabre\AbstractDAVServerTestCase
 
     public function testBrowserPostActionAccessDenied()
     {
-        $this->expectException('Sabre\DAV\Exception\Forbidden');
+        $this->expectException(\Sabre\DAV\Exception\Forbidden::class);
         $this->aclPlugin->setDefaultAcl([]);
         $this->sharingPlugin->browserPostAction(
             'shareable',

--- a/tests/Sabre/DAV/SimpleCollectionTest.php
+++ b/tests/Sabre/DAV/SimpleCollectionTest.php
@@ -42,7 +42,7 @@ class SimpleCollectionTest extends \PHPUnit\Framework\TestCase
 
     public function testGetChild404()
     {
-        $this->expectException('Sabre\DAV\Exception\NotFound');
+        $this->expectException(\Sabre\DAV\Exception\NotFound::class);
         $s = new SimpleCollection('foo', []);
         $s->getChild('404');
     }

--- a/tests/Sabre/DAV/StringUtilTest.php
+++ b/tests/Sabre/DAV/StringUtilTest.php
@@ -74,13 +74,13 @@ class StringUtilTest extends \PHPUnit\Framework\TestCase
 
     public function testBadCollation()
     {
-        $this->expectException('Sabre\DAV\Exception\BadRequest');
+        $this->expectException(\Sabre\DAV\Exception\BadRequest::class);
         StringUtil::textMatch('foobar', 'foo', 'blabla', 'contains');
     }
 
     public function testBadMatchType()
     {
-        $this->expectException('Sabre\DAV\Exception\BadRequest');
+        $this->expectException(\Sabre\DAV\Exception\BadRequest::class);
         StringUtil::textMatch('foobar', 'foo', 'i;octet', 'booh');
     }
 

--- a/tests/Sabre/DAV/Xml/Element/PropTest.php
+++ b/tests/Sabre/DAV/Xml/Element/PropTest.php
@@ -69,7 +69,7 @@ XML;
         ];
 
         $elementMap = [
-            '{DAV:}foo' => 'Sabre\DAV\Xml\Property\Href',
+            '{DAV:}foo' => \Sabre\DAV\Xml\Property\Href::class,
         ];
 
         self::assertDecodeProp($input, $expected, $elementMap);
@@ -139,7 +139,7 @@ XML;
 
     public function assertDecodeProp($input, array $expected, array $elementMap = [])
     {
-        $elementMap['{DAV:}root'] = 'Sabre\DAV\Xml\Element\Prop';
+        $elementMap['{DAV:}root'] = \Sabre\DAV\Xml\Element\Prop::class;
 
         $result = $this->parse($input, $elementMap);
         self::assertIsArray($result);

--- a/tests/Sabre/DAV/Xml/Element/ResponseTest.php
+++ b/tests/Sabre/DAV/Xml/Element/ResponseTest.php
@@ -189,7 +189,7 @@ class ResponseTest extends DAV\Xml\AbstractXmlTestCase
 ';
 
         $result = $this->parse($xml, [
-            '{DAV:}response' => 'Sabre\DAV\Xml\Element\Response',
+            '{DAV:}response' => \Sabre\DAV\Xml\Element\Response::class,
             '{DAV:}foo' => function ($reader) {
                 $reader->next();
 
@@ -346,7 +346,7 @@ class ResponseTest extends DAV\Xml\AbstractXmlTestCase
 ';
 
         $result = $this->parse($xml, [
-            '{DAV:}response' => 'Sabre\DAV\Xml\Element\Response',
+            '{DAV:}response' => \Sabre\DAV\Xml\Element\Response::class,
             '{DAV:}foo' => function ($reader) {
                 throw new \LogicException('This should never happen');
             },

--- a/tests/Sabre/DAV/Xml/Element/ShareeTest.php
+++ b/tests/Sabre/DAV/Xml/Element/ShareeTest.php
@@ -32,7 +32,7 @@ class ShareeTest extends AbstractXmlTestCase
 XML;
 
         $result = $this->parse($xml, [
-            '{DAV:}sharee' => 'Sabre\\DAV\\Xml\\Element\\Sharee',
+            '{DAV:}sharee' => \Sabre\DAV\Xml\Element\Sharee::class,
         ]);
 
         $expected = new Sharee([
@@ -49,7 +49,7 @@ XML;
 
     public function testDeserializeNoHref()
     {
-        $this->expectException('Sabre\DAV\Exception\BadRequest');
+        $this->expectException(\Sabre\DAV\Exception\BadRequest::class);
         $xml = <<<XML
 <?xml version="1.0" encoding="utf-8" ?>
 <D:sharee xmlns:D="DAV:">
@@ -64,13 +64,13 @@ XML;
 XML;
 
         $this->parse($xml, [
-            '{DAV:}sharee' => 'Sabre\\DAV\\Xml\\Element\\Sharee',
+            '{DAV:}sharee' => \Sabre\DAV\Xml\Element\Sharee::class,
         ]);
     }
 
     public function testDeserializeNoShareeAccess()
     {
-        $this->expectException('Sabre\DAV\Exception\BadRequest');
+        $this->expectException(\Sabre\DAV\Exception\BadRequest::class);
         $xml = <<<XML
 <?xml version="1.0" encoding="utf-8" ?>
 <D:sharee xmlns:D="DAV:">
@@ -83,7 +83,7 @@ XML;
 XML;
 
         $this->parse($xml, [
-            '{DAV:}sharee' => 'Sabre\\DAV\\Xml\\Element\\Sharee',
+            '{DAV:}sharee' => \Sabre\DAV\Xml\Element\Sharee::class,
         ]);
     }
 }

--- a/tests/Sabre/DAV/Xml/Property/HrefTest.php
+++ b/tests/Sabre/DAV/Xml/Property/HrefTest.php
@@ -36,11 +36,11 @@ class HrefTest extends AbstractXmlTestCase
 <d:anything xmlns:d="DAV:"><d:href>/bla/path</d:href></d:anything>
 ';
 
-        $result = $this->parse($xml, ['{DAV:}anything' => 'Sabre\\DAV\\Xml\\Property\\Href']);
+        $result = $this->parse($xml, ['{DAV:}anything' => \Sabre\DAV\Xml\Property\Href::class]);
 
         $href = $result['value'];
 
-        self::assertInstanceOf('Sabre\\DAV\\Xml\\Property\\Href', $href);
+        self::assertInstanceOf(\Sabre\DAV\Xml\Property\Href::class, $href);
 
         self::assertEquals('/bla/path', $href->getHref());
     }
@@ -50,7 +50,7 @@ class HrefTest extends AbstractXmlTestCase
         $xml = '<?xml version="1.0"?>
 <d:anything xmlns:d="DAV:"><d:href2>/bla/path</d:href2></d:anything>
 ';
-        $result = $this->parse($xml, ['{DAV:}anything' => 'Sabre\\DAV\\Xml\\Property\\Href']);
+        $result = $this->parse($xml, ['{DAV:}anything' => \Sabre\DAV\Xml\Property\Href::class]);
         $href = $result['value'];
         self::assertNull($href);
     }
@@ -60,7 +60,7 @@ class HrefTest extends AbstractXmlTestCase
         $xml = '<?xml version="1.0"?>
 <d:anything xmlns:d="DAV:"></d:anything>
 ';
-        $result = $this->parse($xml, ['{DAV:}anything' => 'Sabre\\DAV\\Xml\\Property\\Href']);
+        $result = $this->parse($xml, ['{DAV:}anything' => \Sabre\DAV\Xml\Property\Href::class]);
         $href = $result['value'];
         self::assertNull($href);
     }

--- a/tests/Sabre/DAV/Xml/Property/LastModifiedTest.php
+++ b/tests/Sabre/DAV/Xml/Property/LastModifiedTest.php
@@ -46,7 +46,7 @@ XML;
 <d:getlastmodified xmlns:d="DAV:">Tue, 24 Mar 2015 18:47:00 GMT</d:getlastmodified>
 XML;
 
-        $elementMap = ['{DAV:}getlastmodified' => 'Sabre\DAV\Xml\Property\GetLastModified'];
+        $elementMap = ['{DAV:}getlastmodified' => \Sabre\DAV\Xml\Property\GetLastModified::class];
         $result = $this->parse($input, $elementMap);
 
         self::assertEquals(

--- a/tests/Sabre/DAV/Xml/Property/ShareAccessTest.php
+++ b/tests/Sabre/DAV/Xml/Property/ShareAccessTest.php
@@ -100,7 +100,7 @@ XML;
 
     public function testDeserializeInvalid()
     {
-        $this->expectException('Sabre\DAV\Exception\BadRequest');
+        $this->expectException(\Sabre\DAV\Exception\BadRequest::class);
         $input = <<<XML
 <?xml version="1.0"?>
 <d:root xmlns:d="DAV:">

--- a/tests/Sabre/DAV/Xml/Request/PropFindTest.php
+++ b/tests/Sabre/DAV/Xml/Request/PropFindTest.php
@@ -18,7 +18,7 @@ class PropFindTest extends AbstractXmlTestCase
 </d:root>
 ';
 
-        $result = $this->parse($xml, ['{DAV:}root' => 'Sabre\\DAV\\Xml\\Request\PropFind']);
+        $result = $this->parse($xml, ['{DAV:}root' => \Sabre\DAV\Xml\Request\PropFind::class]);
 
         $propFind = new PropFind();
         $propFind->properties = ['{DAV:}hello'];
@@ -34,7 +34,7 @@ class PropFindTest extends AbstractXmlTestCase
 </d:root>
 ';
 
-        $result = $this->parse($xml, ['{DAV:}root' => 'Sabre\\DAV\\Xml\\Request\PropFind']);
+        $result = $this->parse($xml, ['{DAV:}root' => \Sabre\DAV\Xml\Request\PropFind::class]);
 
         $propFind = new PropFind();
         $propFind->allProp = true;

--- a/tests/Sabre/DAV/Xml/Request/ShareResourceTest.php
+++ b/tests/Sabre/DAV/Xml/Request/ShareResourceTest.php
@@ -41,11 +41,11 @@ class ShareResourceTest extends AbstractXmlTestCase
 XML;
 
         $result = $this->parse($xml, [
-            '{DAV:}share-resource' => 'Sabre\\DAV\\Xml\\Request\\ShareResource',
+            '{DAV:}share-resource' => \Sabre\DAV\Xml\Request\ShareResource::class,
         ]);
 
         self::assertInstanceOf(
-            'Sabre\\DAV\\Xml\\Request\\ShareResource',
+            \Sabre\DAV\Xml\Request\ShareResource::class,
             $result['value']
         );
 

--- a/tests/Sabre/DAV/Xml/Request/SyncCollectionTest.php
+++ b/tests/Sabre/DAV/Xml/Request/SyncCollectionTest.php
@@ -20,7 +20,7 @@ class SyncCollectionTest extends AbstractXmlTestCase
 </d:sync-collection>
 ';
 
-        $result = $this->parse($xml, ['{DAV:}sync-collection' => 'Sabre\\DAV\\Xml\\Request\\SyncCollectionReport']);
+        $result = $this->parse($xml, ['{DAV:}sync-collection' => \Sabre\DAV\Xml\Request\SyncCollectionReport::class]);
 
         $elem = new SyncCollectionReport();
         $elem->syncLevel = 1;
@@ -42,7 +42,7 @@ class SyncCollectionTest extends AbstractXmlTestCase
 </d:sync-collection>
 ';
 
-        $result = $this->parse($xml, ['{DAV:}sync-collection' => 'Sabre\\DAV\\Xml\\Request\\SyncCollectionReport']);
+        $result = $this->parse($xml, ['{DAV:}sync-collection' => \Sabre\DAV\Xml\Request\SyncCollectionReport::class]);
 
         $elem = new SyncCollectionReport();
         $elem->syncLevel = 1;
@@ -64,7 +64,7 @@ class SyncCollectionTest extends AbstractXmlTestCase
 </d:sync-collection>
 ';
 
-        $result = $this->parse($xml, ['{DAV:}sync-collection' => 'Sabre\\DAV\\Xml\\Request\\SyncCollectionReport']);
+        $result = $this->parse($xml, ['{DAV:}sync-collection' => \Sabre\DAV\Xml\Request\SyncCollectionReport::class]);
 
         $elem = new SyncCollectionReport();
         $elem->syncLevel = \Sabre\DAV\Server::DEPTH_INFINITY;
@@ -75,13 +75,13 @@ class SyncCollectionTest extends AbstractXmlTestCase
 
     public function testDeserializeMissingElem()
     {
-        $this->expectException('Sabre\DAV\Exception\BadRequest');
+        $this->expectException(\Sabre\DAV\Exception\BadRequest::class);
         $xml = '<?xml version="1.0"?>
 <d:sync-collection xmlns:d="DAV:">
     <d:sync-token />
 </d:sync-collection>
 ';
 
-        $result = $this->parse($xml, ['{DAV:}sync-collection' => 'Sabre\\DAV\\Xml\\Request\\SyncCollectionReport']);
+        $result = $this->parse($xml, ['{DAV:}sync-collection' => \Sabre\DAV\Xml\Request\SyncCollectionReport::class]);
     }
 }

--- a/tests/Sabre/DAV/Xml/ServiceTest.php
+++ b/tests/Sabre/DAV/Xml/ServiceTest.php
@@ -10,7 +10,7 @@ class ServiceTest extends TestCase
 {
     public function testInvalidNameSpace()
     {
-        $this->expectException('Sabre\Xml\LibXMLException');
+        $this->expectException(\Sabre\Xml\LibXMLException::class);
         $xml = '<D:propfind xmlns:D="DAV:"><D:prop><bar:foo xmlns:bar=""/></D:prop></D:propfind>';
         $util = new Service();
         $util->expect('{DAV:}propfind', $xml);

--- a/tests/Sabre/DAVACL/ACLMethodTest.php
+++ b/tests/Sabre/DAVACL/ACLMethodTest.php
@@ -11,7 +11,7 @@ class ACLMethodTest extends \PHPUnit\Framework\TestCase
 {
     public function testCallback()
     {
-        $this->expectException('Sabre\DAV\Exception\BadRequest');
+        $this->expectException(\Sabre\DAV\Exception\BadRequest::class);
         $acl = new Plugin();
         $server = new DAV\Server();
         $server->addPlugin(new DAV\Auth\Plugin());
@@ -25,7 +25,7 @@ class ACLMethodTest extends \PHPUnit\Framework\TestCase
      */
     public function testNotSupportedByNode()
     {
-        $this->expectException('Sabre\DAV\Exception\MethodNotAllowed');
+        $this->expectException(\Sabre\DAV\Exception\MethodNotAllowed::class);
         $tree = [
             new DAV\SimpleCollection('test'),
         ];
@@ -64,7 +64,7 @@ class ACLMethodTest extends \PHPUnit\Framework\TestCase
 
     public function testUnrecognizedPrincipal()
     {
-        $this->expectException('Sabre\DAVACL\Exception\NotRecognizedPrincipal');
+        $this->expectException(\Sabre\DAVACL\Exception\NotRecognizedPrincipal::class);
         $tree = [
             new MockACLNode('test', []),
         ];
@@ -87,7 +87,7 @@ class ACLMethodTest extends \PHPUnit\Framework\TestCase
 
     public function testUnrecognizedPrincipal2()
     {
-        $this->expectException('Sabre\DAVACL\Exception\NotRecognizedPrincipal');
+        $this->expectException(\Sabre\DAVACL\Exception\NotRecognizedPrincipal::class);
         $tree = [
             new MockACLNode('test', []),
             new DAV\SimpleCollection('principals', [
@@ -113,7 +113,7 @@ class ACLMethodTest extends \PHPUnit\Framework\TestCase
 
     public function testUnknownPrivilege()
     {
-        $this->expectException('Sabre\DAVACL\Exception\NotSupportedPrivilege');
+        $this->expectException(\Sabre\DAVACL\Exception\NotSupportedPrivilege::class);
         $tree = [
             new MockACLNode('test', []),
         ];
@@ -136,7 +136,7 @@ class ACLMethodTest extends \PHPUnit\Framework\TestCase
 
     public function testAbstractPrivilege()
     {
-        $this->expectException('Sabre\DAVACL\Exception\NoAbstract');
+        $this->expectException(\Sabre\DAVACL\Exception\NoAbstract::class);
         $tree = [
             new MockACLNode('test', []),
         ];
@@ -162,7 +162,7 @@ class ACLMethodTest extends \PHPUnit\Framework\TestCase
 
     public function testUpdateProtectedPrivilege()
     {
-        $this->expectException('Sabre\DAVACL\Exception\AceConflict');
+        $this->expectException(\Sabre\DAVACL\Exception\AceConflict::class);
         $oldACL = [
             [
                 'principal' => 'principals/notfound',
@@ -193,7 +193,7 @@ class ACLMethodTest extends \PHPUnit\Framework\TestCase
 
     public function testUpdateProtectedPrivilege2()
     {
-        $this->expectException('Sabre\DAVACL\Exception\AceConflict');
+        $this->expectException(\Sabre\DAVACL\Exception\AceConflict::class);
         $oldACL = [
             [
                 'principal' => 'principals/notfound',
@@ -224,7 +224,7 @@ class ACLMethodTest extends \PHPUnit\Framework\TestCase
 
     public function testUpdateProtectedPrivilege3()
     {
-        $this->expectException('Sabre\DAVACL\Exception\AceConflict');
+        $this->expectException(\Sabre\DAVACL\Exception\AceConflict::class);
         $oldACL = [
             [
                 'principal' => 'principals/notfound',

--- a/tests/Sabre/DAVACL/BlockAccessTest.php
+++ b/tests/Sabre/DAVACL/BlockAccessTest.php
@@ -38,7 +38,7 @@ class BlockAccessTest extends \PHPUnit\Framework\TestCase
 
     public function testGet()
     {
-        $this->expectException('Sabre\DAVACL\Exception\NeedPrivileges');
+        $this->expectException(\Sabre\DAVACL\Exception\NeedPrivileges::class);
         $this->server->httpRequest->setMethod('GET');
         $this->server->httpRequest->setUrl('/testdir');
 
@@ -56,7 +56,7 @@ class BlockAccessTest extends \PHPUnit\Framework\TestCase
 
     public function testHEAD()
     {
-        $this->expectException('Sabre\DAVACL\Exception\NeedPrivileges');
+        $this->expectException(\Sabre\DAVACL\Exception\NeedPrivileges::class);
         $this->server->httpRequest->setMethod('HEAD');
         $this->server->httpRequest->setUrl('/testdir');
 
@@ -65,7 +65,7 @@ class BlockAccessTest extends \PHPUnit\Framework\TestCase
 
     public function testOPTIONS()
     {
-        $this->expectException('Sabre\DAVACL\Exception\NeedPrivileges');
+        $this->expectException(\Sabre\DAVACL\Exception\NeedPrivileges::class);
         $this->server->httpRequest->setMethod('OPTIONS');
         $this->server->httpRequest->setUrl('/testdir');
 
@@ -74,7 +74,7 @@ class BlockAccessTest extends \PHPUnit\Framework\TestCase
 
     public function testPUT()
     {
-        $this->expectException('Sabre\DAVACL\Exception\NeedPrivileges');
+        $this->expectException(\Sabre\DAVACL\Exception\NeedPrivileges::class);
         $this->server->httpRequest->setMethod('PUT');
         $this->server->httpRequest->setUrl('/testdir');
 
@@ -83,7 +83,7 @@ class BlockAccessTest extends \PHPUnit\Framework\TestCase
 
     public function testPROPPATCH()
     {
-        $this->expectException('Sabre\DAVACL\Exception\NeedPrivileges');
+        $this->expectException(\Sabre\DAVACL\Exception\NeedPrivileges::class);
         $this->server->httpRequest->setMethod('PROPPATCH');
         $this->server->httpRequest->setUrl('/testdir');
 
@@ -92,7 +92,7 @@ class BlockAccessTest extends \PHPUnit\Framework\TestCase
 
     public function testCOPY()
     {
-        $this->expectException('Sabre\DAVACL\Exception\NeedPrivileges');
+        $this->expectException(\Sabre\DAVACL\Exception\NeedPrivileges::class);
         $this->server->httpRequest->setMethod('COPY');
         $this->server->httpRequest->setUrl('/testdir');
 
@@ -101,7 +101,7 @@ class BlockAccessTest extends \PHPUnit\Framework\TestCase
 
     public function testMOVE()
     {
-        $this->expectException('Sabre\DAVACL\Exception\NeedPrivileges');
+        $this->expectException(\Sabre\DAVACL\Exception\NeedPrivileges::class);
         $this->server->httpRequest->setMethod('MOVE');
         $this->server->httpRequest->setUrl('/testdir');
 
@@ -110,7 +110,7 @@ class BlockAccessTest extends \PHPUnit\Framework\TestCase
 
     public function testACL()
     {
-        $this->expectException('Sabre\DAVACL\Exception\NeedPrivileges');
+        $this->expectException(\Sabre\DAVACL\Exception\NeedPrivileges::class);
         $this->server->httpRequest->setMethod('ACL');
         $this->server->httpRequest->setUrl('/testdir');
 
@@ -119,7 +119,7 @@ class BlockAccessTest extends \PHPUnit\Framework\TestCase
 
     public function testLOCK()
     {
-        $this->expectException('Sabre\DAVACL\Exception\NeedPrivileges');
+        $this->expectException(\Sabre\DAVACL\Exception\NeedPrivileges::class);
         $this->server->httpRequest->setMethod('LOCK');
         $this->server->httpRequest->setUrl('/testdir');
 
@@ -128,13 +128,13 @@ class BlockAccessTest extends \PHPUnit\Framework\TestCase
 
     public function testBeforeBind()
     {
-        $this->expectException('Sabre\DAVACL\Exception\NeedPrivileges');
+        $this->expectException(\Sabre\DAVACL\Exception\NeedPrivileges::class);
         $this->server->emit('beforeBind', ['testdir/file']);
     }
 
     public function testBeforeUnbind()
     {
-        $this->expectException('Sabre\DAVACL\Exception\NeedPrivileges');
+        $this->expectException(\Sabre\DAVACL\Exception\NeedPrivileges::class);
         $this->server->emit('beforeUnbind', ['testdir']);
     }
 

--- a/tests/Sabre/DAVACL/FS/CollectionTest.php
+++ b/tests/Sabre/DAVACL/FS/CollectionTest.php
@@ -24,7 +24,7 @@ class CollectionTest extends FileTest
     {
         file_put_contents(TestUtil::SABRE_TEMPDIR.'/file.txt', 'hello');
         $child = $this->sut->getChild('file.txt');
-        self::assertInstanceOf('Sabre\\DAVACL\\FS\\File', $child);
+        self::assertInstanceOf(\Sabre\DAVACL\FS\File::class, $child);
 
         self::assertEquals('file.txt', $child->getName());
         self::assertEquals($this->acl, $child->getACL());
@@ -35,7 +35,7 @@ class CollectionTest extends FileTest
     {
         mkdir(TestUtil::SABRE_TEMPDIR.'/dir');
         $child = $this->sut->getChild('dir');
-        self::assertInstanceOf('Sabre\\DAVACL\\FS\\Collection', $child);
+        self::assertInstanceOf(\Sabre\DAVACL\FS\Collection::class, $child);
 
         self::assertEquals('dir', $child->getName());
         self::assertEquals($this->acl, $child->getACL());

--- a/tests/Sabre/DAVACL/FS/FileTest.php
+++ b/tests/Sabre/DAVACL/FS/FileTest.php
@@ -53,7 +53,7 @@ class FileTest extends \PHPUnit\Framework\TestCase
 
     public function testSetAcl()
     {
-        $this->expectException('Sabre\DAV\Exception\Forbidden');
+        $this->expectException(\Sabre\DAV\Exception\Forbidden::class);
         $this->sut->setACL([]);
     }
 

--- a/tests/Sabre/DAVACL/FS/HomeCollectionTest.php
+++ b/tests/Sabre/DAVACL/FS/HomeCollectionTest.php
@@ -44,7 +44,7 @@ class HomeCollectionTest extends \PHPUnit\Framework\TestCase
     public function testGetChild()
     {
         $child = $this->sut->getChild('user1');
-        self::assertInstanceOf('Sabre\\DAVACL\\FS\\Collection', $child);
+        self::assertInstanceOf(\Sabre\DAVACL\FS\Collection::class, $child);
         self::assertEquals('user1', $child->getName());
 
         $owner = 'principals/user1';
@@ -92,7 +92,7 @@ class HomeCollectionTest extends \PHPUnit\Framework\TestCase
 
     public function testSetAcl()
     {
-        $this->expectException('Sabre\DAV\Exception\Forbidden');
+        $this->expectException(\Sabre\DAV\Exception\Forbidden::class);
         $this->sut->setACL([]);
     }
 

--- a/tests/Sabre/DAVACL/PluginPropertiesTest.php
+++ b/tests/Sabre/DAVACL/PluginPropertiesTest.php
@@ -37,7 +37,7 @@ class PluginPropertiesTest extends \PHPUnit\Framework\TestCase
 
         self::assertEquals(1, count($result[200]));
         self::assertArrayHasKey('{DAV:}principal-collection-set', $result[200]);
-        self::assertInstanceOf('Sabre\\DAV\\Xml\\Property\\Href', $result[200]['{DAV:}principal-collection-set']);
+        self::assertInstanceOf(\Sabre\DAV\Xml\Property\Href::class, $result[200]['{DAV:}principal-collection-set']);
 
         $expected = [
             'principals1/',
@@ -70,7 +70,7 @@ class PluginPropertiesTest extends \PHPUnit\Framework\TestCase
 
         self::assertEquals(1, count($result[200]));
         self::assertArrayHasKey('{DAV:}current-user-principal', $result[200]);
-        self::assertInstanceOf('Sabre\DAVACL\Xml\Property\Principal', $result[200]['{DAV:}current-user-principal']);
+        self::assertInstanceOf(\Sabre\DAVACL\Xml\Property\Principal::class, $result[200]['{DAV:}current-user-principal']);
         self::assertEquals(Xml\Property\Principal::UNAUTHENTICATED, $result[200]['{DAV:}current-user-principal']->getType());
 
         // This will force the login
@@ -81,7 +81,7 @@ class PluginPropertiesTest extends \PHPUnit\Framework\TestCase
 
         self::assertEquals(1, count($result[200]));
         self::assertArrayHasKey('{DAV:}current-user-principal', $result[200]);
-        self::assertInstanceOf('Sabre\DAVACL\Xml\Property\Principal', $result[200]['{DAV:}current-user-principal']);
+        self::assertInstanceOf(\Sabre\DAVACL\Xml\Property\Principal::class, $result[200]['{DAV:}current-user-principal']);
         self::assertEquals(Xml\Property\Principal::HREF, $result[200]['{DAV:}current-user-principal']->getType());
         self::assertEquals('principals/admin/', $result[200]['{DAV:}current-user-principal']->getHref());
     }
@@ -108,7 +108,7 @@ class PluginPropertiesTest extends \PHPUnit\Framework\TestCase
 
         self::assertEquals(1, count($result[200]));
         self::assertArrayHasKey('{DAV:}supported-privilege-set', $result[200]);
-        self::assertInstanceOf('Sabre\\DAVACL\\Xml\\Property\\SupportedPrivilegeSet', $result[200]['{DAV:}supported-privilege-set']);
+        self::assertInstanceOf(\Sabre\DAVACL\Xml\Property\SupportedPrivilegeSet::class, $result[200]['{DAV:}supported-privilege-set']);
 
         $server = new DAV\Server();
 
@@ -188,7 +188,7 @@ class PluginPropertiesTest extends \PHPUnit\Framework\TestCase
 
         self::assertEquals(1, count($result[200]), 'The {DAV:}acl property did not return from the list. Full list: '.print_r($result, true));
         self::assertArrayHasKey('{DAV:}acl', $result[200]);
-        self::assertInstanceOf('Sabre\\DAVACL\\Xml\Property\\Acl', $result[200]['{DAV:}acl']);
+        self::assertInstanceOf(\Sabre\DAVACL\Xml\Property\Acl::class, $result[200]['{DAV:}acl']);
     }
 
     public function testACLRestrictions()
@@ -225,7 +225,7 @@ class PluginPropertiesTest extends \PHPUnit\Framework\TestCase
 
         self::assertEquals(1, count($result[200]), 'The {DAV:}acl-restrictions property did not return from the list. Full list: '.print_r($result, true));
         self::assertArrayHasKey('{DAV:}acl-restrictions', $result[200]);
-        self::assertInstanceOf('Sabre\\DAVACL\\Xml\\Property\\AclRestrictions', $result[200]['{DAV:}acl-restrictions']);
+        self::assertInstanceOf(\Sabre\DAVACL\Xml\Property\AclRestrictions::class, $result[200]['{DAV:}acl-restrictions']);
     }
 
     public function testAlternateUriSet()
@@ -257,7 +257,7 @@ class PluginPropertiesTest extends \PHPUnit\Framework\TestCase
 
         self::assertTrue(isset($result[200]));
         self::assertTrue(isset($result[200]['{DAV:}alternate-URI-set']));
-        self::assertInstanceOf('Sabre\\DAV\\Xml\\Property\\Href', $result[200]['{DAV:}alternate-URI-set']);
+        self::assertInstanceOf(\Sabre\DAV\Xml\Property\Href::class, $result[200]['{DAV:}alternate-URI-set']);
 
         self::assertEquals([], $result[200]['{DAV:}alternate-URI-set']->getHrefs());
     }
@@ -292,7 +292,7 @@ class PluginPropertiesTest extends \PHPUnit\Framework\TestCase
 
         self::assertTrue(isset($result[200]));
         self::assertTrue(isset($result[200]['{DAV:}principal-URL']));
-        self::assertInstanceOf('Sabre\\DAV\\Xml\\Property\\Href', $result[200]['{DAV:}principal-URL']);
+        self::assertInstanceOf(\Sabre\DAV\Xml\Property\Href::class, $result[200]['{DAV:}principal-URL']);
 
         self::assertEquals('principals/user/', $result[200]['{DAV:}principal-URL']->getHref());
     }
@@ -327,7 +327,7 @@ class PluginPropertiesTest extends \PHPUnit\Framework\TestCase
 
         self::assertTrue(isset($result[200]));
         self::assertTrue(isset($result[200]['{DAV:}group-member-set']));
-        self::assertInstanceOf('Sabre\\DAV\\Xml\\Property\\Href', $result[200]['{DAV:}group-member-set']);
+        self::assertInstanceOf(\Sabre\DAV\Xml\Property\Href::class, $result[200]['{DAV:}group-member-set']);
 
         self::assertEquals([], $result[200]['{DAV:}group-member-set']->getHrefs());
     }
@@ -360,7 +360,7 @@ class PluginPropertiesTest extends \PHPUnit\Framework\TestCase
 
         self::assertTrue(isset($result[200]));
         self::assertTrue(isset($result[200]['{DAV:}group-membership']));
-        self::assertInstanceOf('Sabre\\DAV\\Xml\\Property\\Href', $result[200]['{DAV:}group-membership']);
+        self::assertInstanceOf(\Sabre\DAV\Xml\Property\Href::class, $result[200]['{DAV:}group-membership']);
 
         self::assertEquals([], $result[200]['{DAV:}group-membership']->getHrefs());
     }

--- a/tests/Sabre/DAVACL/PluginUpdatePropertiesTest.php
+++ b/tests/Sabre/DAVACL/PluginUpdatePropertiesTest.php
@@ -74,7 +74,7 @@ class PluginUpdatePropertiesTest extends \PHPUnit\Framework\TestCase
 
     public function testSetBadValue()
     {
-        $this->expectException('Sabre\DAV\Exception');
+        $this->expectException(\Sabre\DAV\Exception::class);
         $tree = [
             new MockPrincipal('foo', 'foo'),
         ];

--- a/tests/Sabre/DAVACL/PrincipalCollectionTest.php
+++ b/tests/Sabre/DAVACL/PrincipalCollectionTest.php
@@ -36,7 +36,7 @@ class PrincipalCollectionTest extends \PHPUnit\Framework\TestCase
      */
     public function testGetChildrenDisable()
     {
-        $this->expectException('Sabre\DAV\Exception\MethodNotAllowed');
+        $this->expectException(\Sabre\DAV\Exception\MethodNotAllowed::class);
         $backend = new PrincipalBackend\Mock();
         $pc = new PrincipalCollection($backend);
         $pc->disableListing = true;

--- a/tests/Sabre/DAVACL/PrincipalTest.php
+++ b/tests/Sabre/DAVACL/PrincipalTest.php
@@ -17,7 +17,7 @@ class PrincipalTest extends \PHPUnit\Framework\TestCase
 
     public function testConstructNoUri()
     {
-        $this->expectException('Sabre\DAV\Exception');
+        $this->expectException(\Sabre\DAV\Exception::class);
         $principalBackend = new PrincipalBackend\Mock();
         $principal = new Principal($principalBackend, []);
     }
@@ -177,7 +177,7 @@ class PrincipalTest extends \PHPUnit\Framework\TestCase
 
     public function testSetACl()
     {
-        $this->expectException('Sabre\DAV\Exception\Forbidden');
+        $this->expectException(\Sabre\DAV\Exception\Forbidden::class);
         $principalBackend = new PrincipalBackend\Mock();
         $principal = new Principal($principalBackend, ['uri' => 'principals/admin']);
         $principal->setACL([]);

--- a/tests/Sabre/DAVACL/Xml/Property/ACLTest.php
+++ b/tests/Sabre/DAVACL/Xml/Property/ACLTest.php
@@ -12,7 +12,7 @@ class ACLTest extends \PHPUnit\Framework\TestCase
     public function testConstruct()
     {
         $acl = new Acl([]);
-        self::assertInstanceOf('Sabre\DAVACL\Xml\Property\ACL', $acl);
+        self::assertInstanceOf(\Sabre\DAVACL\Xml\Property\ACL::class, $acl);
     }
 
     public function testSerializeEmpty()
@@ -157,13 +157,13 @@ class ACLTest extends \PHPUnit\Framework\TestCase
 ';
 
         $reader = new \Sabre\Xml\Reader();
-        $reader->elementMap['{DAV:}root'] = 'Sabre\DAVACL\Xml\Property\Acl';
+        $reader->elementMap['{DAV:}root'] = \Sabre\DAVACL\Xml\Property\Acl::class;
         $reader->xml($source);
 
         $result = $reader->parse();
         $result = $result['value'];
 
-        self::assertInstanceOf('Sabre\\DAVACL\\Xml\\Property\\Acl', $result);
+        self::assertInstanceOf(\Sabre\DAVACL\Xml\Property\Acl::class, $result);
 
         $expected = [
             [
@@ -183,7 +183,7 @@ class ACLTest extends \PHPUnit\Framework\TestCase
 
     public function testUnserializeNoPrincipal()
     {
-        $this->expectException('Sabre\DAV\Exception\BadRequest');
+        $this->expectException(\Sabre\DAV\Exception\BadRequest::class);
         $source = '<?xml version="1.0"?>
 <d:root xmlns:d="DAV:">
   <d:ace>
@@ -197,7 +197,7 @@ class ACLTest extends \PHPUnit\Framework\TestCase
 ';
 
         $reader = new \Sabre\Xml\Reader();
-        $reader->elementMap['{DAV:}root'] = 'Sabre\DAVACL\Xml\Property\Acl';
+        $reader->elementMap['{DAV:}root'] = \Sabre\DAVACL\Xml\Property\Acl::class;
         $reader->xml($source);
 
         $result = $reader->parse();
@@ -236,13 +236,13 @@ class ACLTest extends \PHPUnit\Framework\TestCase
 ';
 
         $reader = new \Sabre\Xml\Reader();
-        $reader->elementMap['{DAV:}root'] = 'Sabre\DAVACL\Xml\Property\Acl';
+        $reader->elementMap['{DAV:}root'] = \Sabre\DAVACL\Xml\Property\Acl::class;
         $reader->xml($source);
 
         $result = $reader->parse();
         $result = $result['value'];
 
-        self::assertInstanceOf('Sabre\\DAVACL\\Xml\\Property\\Acl', $result);
+        self::assertInstanceOf(\Sabre\DAVACL\Xml\Property\Acl::class, $result);
 
         $expected = [
             [
@@ -267,7 +267,7 @@ class ACLTest extends \PHPUnit\Framework\TestCase
 
     public function testUnserializeDeny()
     {
-        $this->expectException('Sabre\DAV\Exception\NotImplemented');
+        $this->expectException(\Sabre\DAV\Exception\NotImplemented::class);
         $source = '<?xml version="1.0"?>
 <d:root xmlns:d="DAV:">
   <d:ignore-me />
@@ -283,7 +283,7 @@ class ACLTest extends \PHPUnit\Framework\TestCase
 ';
 
         $reader = new \Sabre\Xml\Reader();
-        $reader->elementMap['{DAV:}root'] = 'Sabre\DAVACL\Xml\Property\Acl';
+        $reader->elementMap['{DAV:}root'] = \Sabre\DAVACL\Xml\Property\Acl::class;
         $reader->xml($source);
 
         $result = $reader->parse();

--- a/tests/Sabre/DAVACL/Xml/Property/ACLTest.php
+++ b/tests/Sabre/DAVACL/Xml/Property/ACLTest.php
@@ -12,7 +12,7 @@ class ACLTest extends \PHPUnit\Framework\TestCase
     public function testConstruct()
     {
         $acl = new Acl([]);
-        self::assertInstanceOf(\Sabre\DAVACL\Xml\Property\ACL::class, $acl);
+        self::assertInstanceOf(\Sabre\DAVACL\Xml\Property\Acl::class, $acl);
     }
 
     public function testSerializeEmpty()

--- a/tests/Sabre/DAVACL/Xml/Property/AclRestrictionsTest.php
+++ b/tests/Sabre/DAVACL/Xml/Property/AclRestrictionsTest.php
@@ -11,7 +11,7 @@ class AclRestrictionsTest extends \PHPUnit\Framework\TestCase
     public function testConstruct()
     {
         $prop = new AclRestrictions();
-        self::assertInstanceOf('Sabre\DAVACL\Xml\Property\AclRestrictions', $prop);
+        self::assertInstanceOf(\Sabre\DAVACL\Xml\Property\AclRestrictions::class, $prop);
     }
 
     public function testSerialize()

--- a/tests/Sabre/DAVACL/Xml/Property/CurrentUserPrivilegeSetTest.php
+++ b/tests/Sabre/DAVACL/Xml/Property/CurrentUserPrivilegeSetTest.php
@@ -56,7 +56,7 @@ XML;
     public function parse($xml)
     {
         $reader = new Reader();
-        $reader->elementMap['{DAV:}root'] = 'Sabre\\DAVACL\\Xml\\Property\\CurrentUserPrivilegeSet';
+        $reader->elementMap['{DAV:}root'] = \Sabre\DAVACL\Xml\Property\CurrentUserPrivilegeSet::class;
         $reader->xml($xml);
         $result = $reader->parse();
 

--- a/tests/Sabre/DAVACL/Xml/Property/PrincipalTest.php
+++ b/tests/Sabre/DAVACL/Xml/Property/PrincipalTest.php
@@ -30,7 +30,7 @@ class PrincipalTest extends \PHPUnit\Framework\TestCase
      */
     public function testNoHref()
     {
-        $this->expectException('Sabre\DAV\Exception');
+        $this->expectException(\Sabre\DAV\Exception::class);
         $principal = new Principal(Principal::HREF);
     }
 
@@ -113,7 +113,7 @@ class PrincipalTest extends \PHPUnit\Framework\TestCase
 
     public function testUnserializeUnknown()
     {
-        $this->expectException('Sabre\DAV\Exception\BadRequest');
+        $this->expectException(\Sabre\DAV\Exception\BadRequest::class);
         $xml = '<?xml version="1.0"?>
 <d:principal xmlns:d="DAV:">'.
 '  <d:foo />'.
@@ -125,7 +125,7 @@ class PrincipalTest extends \PHPUnit\Framework\TestCase
     public function parse($xml)
     {
         $reader = new Reader();
-        $reader->elementMap['{DAV:}principal'] = 'Sabre\\DAVACL\\Xml\\Property\\Principal';
+        $reader->elementMap['{DAV:}principal'] = \Sabre\DAVACL\Xml\Property\Principal::class;
         $reader->xml($xml);
         $result = $reader->parse();
 

--- a/tests/Sabre/DAVACL/Xml/Property/SupportedPrivilegeSetTest.php
+++ b/tests/Sabre/DAVACL/Xml/Property/SupportedPrivilegeSetTest.php
@@ -14,7 +14,7 @@ class SupportedPrivilegeSetTest extends \PHPUnit\Framework\TestCase
         $prop = new SupportedPrivilegeSet([
             'privilege' => '{DAV:}all',
         ]);
-        self::assertInstanceOf('Sabre\DAVACL\Xml\Property\SupportedPrivilegeSet', $prop);
+        self::assertInstanceOf(\Sabre\DAVACL\Xml\Property\SupportedPrivilegeSet::class, $prop);
     }
 
     /**

--- a/tests/Sabre/DAVACL/Xml/Request/AclPrincipalPropSetReportTest.php
+++ b/tests/Sabre/DAVACL/Xml/Request/AclPrincipalPropSetReportTest.php
@@ -7,7 +7,7 @@ namespace Sabre\DAVACL\Xml\Request;
 class AclPrincipalPropSetReportTest extends \Sabre\DAV\Xml\AbstractXmlTestCase
 {
     protected $elementMap = [
-        '{DAV:}acl-principal-prop-set' => 'Sabre\DAVACL\Xml\Request\AclPrincipalPropSetReport',
+        '{DAV:}acl-principal-prop-set' => \Sabre\DAVACL\Xml\Request\AclPrincipalPropSetReport::class,
     ];
 
     public function testDeserialize()

--- a/tests/Sabre/DAVACL/Xml/Request/PrincipalMatchReportTest.php
+++ b/tests/Sabre/DAVACL/Xml/Request/PrincipalMatchReportTest.php
@@ -9,7 +9,7 @@ use Sabre\DAV\Xml\AbstractXmlTestCase;
 class PrincipalMatchReportTest extends AbstractXmlTestCase
 {
     protected $elementMap = [
-        '{DAV:}principal-match' => 'Sabre\DAVACL\Xml\Request\PrincipalMatchReport',
+        '{DAV:}principal-match' => \Sabre\DAVACL\Xml\Request\PrincipalMatchReport::class,
     ];
 
     public function testDeserialize()


### PR DESCRIPTION
This is a scripted refactoring to replace class strings with ::class constant references.

I chose not to import the classes to keep the diff clean.