### PR TITLE
Pass OPTION_FORGIVING to VObject Reader

### DIFF
--- a/lib/CalDAV/Plugin.php
+++ b/lib/CalDAV/Plugin.php
@@ -793,14 +793,14 @@ class Plugin extends DAV\ServerPlugin
             // If the data starts with a [, we can reasonably assume we're dealing
             // with a jCal object.
             if ('[' === substr($data, 0, 1)) {
-                $vobj = VObject\Reader::readJson($data);
+                $vobj = VObject\Reader::readJson($data, VObject\Reader::OPTION_FORGIVING);
 
                 // Converting $data back to iCalendar, as that's what we
                 // technically support everywhere.
                 $data = $vobj->serialize();
                 $modified = true;
             } else {
-                $vobj = VObject\Reader::read($data);
+                $vobj = VObject\Reader::read($data, VObject\Reader::OPTION_FORGIVING);
             }
         } catch (VObject\ParseException $e) {
             throw new DAV\Exception\UnsupportedMediaType('This resource only supports valid iCalendar 2.0 data. Parse error: '.$e->getMessage());


### PR DESCRIPTION
See https://github.com/nextcloud/3rdparty/pull/902

By passing the "forgiving" option, some ICS files that would otherwise be rejected, can be successfully imported.

Specifically, Outlook for Mac generates ICS files with an invalid key `X-ENTOURAGE_UUID` (underscore is invalid). By being forgiving, this key is ignored instead of rejected and I think a majority of calendar invitations from that client can now be processed successfully for NextCloud users. See issues https://github.com/nextcloud/server/issues/16679 and https://github.com/nextcloud/server/issues/17915 for more context.

I haven't seen other calls to `VObject\Reader::read` or `VObject\Reader::readJson` outside of `validateICalendar` where the same option should be passed, but it's possible I missed something.