### PR TITLE
Browser/Plugin improvements: counting nodes, ordering and Nodes section at top/bottom

### DIFF
--- a/lib/DAV/Browser/Plugin.php
+++ b/lib/DAV/Browser/Plugin.php
@@ -262,9 +262,6 @@ class Plugin extends DAV\ServerPlugin
 
         $node = $this->server->tree->getNodeForPath($path);
         if ($node instanceof DAV\ICollection) {
-            $html .= "<section><h1>Nodes</h1>\n";
-            $html .= '<table class="nodeTable">';
-
             $subNodes = $this->server->getPropertiesForChildren($path, [
                 '{DAV:}displayname',
                 '{DAV:}resourcetype',
@@ -272,6 +269,9 @@ class Plugin extends DAV\ServerPlugin
                 '{DAV:}getcontentlength',
                 '{DAV:}getlastmodified',
             ]);
+
+            $html .= "<section><h1>Nodes (" . count($subNodes) . ")</h1>\n";
+            $html .= '<table class="nodeTable">';
 
             foreach ($subNodes as $subPath => $subProps) {
                 $subNode = $this->server->tree->getNodeForPath($subPath);
@@ -322,9 +322,9 @@ class Plugin extends DAV\ServerPlugin
             }
 
             $html .= '</table>';
+            $html .= '</section>';
         }
 
-        $html .= '</section>';
         $html .= '<section><h1>Properties</h1>';
         $html .= '<table class="propTable">';
 

--- a/lib/DAV/Browser/Plugin.php
+++ b/lib/DAV/Browser/Plugin.php
@@ -608,8 +608,15 @@ HTML;
             ? (in_array('{DAV:}collection', $b['{DAV:}resourcetype']->getValue()))
             : false;
 
-        // If same type, sort alphabetically by filename:
         if ($typeA === $typeB) {
+            $lastModifiedA = $a['{DAV:}getlastmodified'] ? $a['{DAV:}getlastmodified']->getTime()->getTimestamp() : 0;
+            $lastModifiedB = $b['{DAV:}getlastmodified'] ? $b['{DAV:}getlastmodified']->getTime()->getTimestamp() : 0;
+
+            if ($lastModifiedA !== $lastModifiedB) {
+                return $lastModifiedB <=> $lastModifiedA; // Descending order
+            }
+
+            // If same type and last modified datetime, sort alphabetically by filename:
             return strnatcasecmp($a['displayPath'], $b['displayPath']);
         }
 

--- a/lib/DAV/Browser/Plugin.php
+++ b/lib/DAV/Browser/Plugin.php
@@ -275,8 +275,8 @@ class Plugin extends DAV\ServerPlugin
             ]);
             $numSubNodes = count($subNodes);
             if ($numSubNodes && $numSubNodes <= $maxNodesAtTopSection) {
-               $html .= $this->generateNodesSection($subNodes, $numSubNodes);
-               $numSubNodes = 0;
+                $html .= $this->generateNodesSection($subNodes, $numSubNodes);
+                $numSubNodes = 0;
             }
         }
 
@@ -329,13 +329,13 @@ class Plugin extends DAV\ServerPlugin
      * Generates the Nodes section block of HTML.
      *
      * @param array $subNodes
-     * @param int $numSubNodes
+     * @param int   $numSubNodes
      *
      * @return string
      */
     protected function generateNodesSection($subNodes, $numSubNodes)
     {
-        $html = "<section><h1>Nodes (" . $numSubNodes . ")</h1>\n";
+        $html = '<section><h1>Nodes ('.$numSubNodes.")</h1>\n";
         $html .= '<table class="nodeTable">';
 
         foreach ($subNodes as $subPath => $subProps) {
@@ -388,6 +388,7 @@ class Plugin extends DAV\ServerPlugin
 
         $html .= '</table>';
         $html .= '</section>';
+
         return $html;
     }
 

--- a/lib/DAV/Browser/Plugin.php
+++ b/lib/DAV/Browser/Plugin.php
@@ -590,8 +590,8 @@ HTML;
     }
 
     /**
-     * Sort helper function: compares two directory entries based on type and
-     * display name. Collections sort above other types.
+     * Sort helper function: compares two directory entries based on type, last modified date
+     * and display name. Collections sort above other types.
      *
      * @param array $a
      * @param array $b
@@ -609,8 +609,8 @@ HTML;
             : false;
 
         if ($typeA === $typeB) {
-            $lastModifiedA = $a['{DAV:}getlastmodified'] ? $a['{DAV:}getlastmodified']->getTime()->getTimestamp() : 0;
-            $lastModifiedB = $b['{DAV:}getlastmodified'] ? $b['{DAV:}getlastmodified']->getTime()->getTimestamp() : 0;
+            $lastModifiedA = isset($a['{DAV:}getlastmodified']) ? $a['{DAV:}getlastmodified']->getTime()->getTimestamp() : 0;
+            $lastModifiedB = isset($b['{DAV:}getlastmodified']) ? $b['{DAV:}getlastmodified']->getTime()->getTimestamp() : 0;
 
             if ($lastModifiedA !== $lastModifiedB) {
                 return $lastModifiedB <=> $lastModifiedA; // Descending order

--- a/tests/Sabre/DAV/Browser/PluginTest.php
+++ b/tests/Sabre/DAV/Browser/PluginTest.php
@@ -6,8 +6,8 @@ namespace Sabre\DAV\Browser;
 
 use DateTime;
 use Sabre\DAV;
-use Sabre\HTTP;
 use Sabre\DAV\Xml\Property\GetLastModified;
+use Sabre\HTTP;
 
 class PluginTest extends DAV\AbstractServerTestCase
 {
@@ -204,7 +204,7 @@ class PluginTest extends DAV\AbstractServerTestCase
         $dir = $this->server->tree->getNodeForPath('dir2');
         $dir->createDirectory('subdir');
         $maxNodes = 20; // directory + 20 files
-        for ($i = 1; $i <= $maxNodes; $i++) {
+        for ($i = 1; $i <= $maxNodes; ++$i) {
             $dir->createFile("file$i");
         }
 
@@ -229,7 +229,6 @@ class PluginTest extends DAV\AbstractServerTestCase
         }
         self::assertTrue($lastSectionContainsNodes, 'Last section is listing Nodes (21)');
     }
-
 
     public function testCollectionNodesOrder()
     {

--- a/tests/Sabre/DAV/Browser/PluginTest.php
+++ b/tests/Sabre/DAV/Browser/PluginTest.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Sabre\DAV\Browser;
 
-use Sabre\DAV\Xml\Property\GetLastModified;
 use DateTime;
 use Sabre\DAV;
 use Sabre\HTTP;
+use Sabre\DAV\Xml\Property\GetLastModified;
 
 class PluginTest extends DAV\AbstractServerTestCase
 {
@@ -241,19 +241,19 @@ class PluginTest extends DAV\AbstractServerTestCase
 
         $file1 = [
             '{DAV:}getlastmodified' => $day1,
-            'displayPath' => 'file1'
+            'displayPath' => 'file1',
         ];
         $file1_clon = [
             '{DAV:}getlastmodified' => $day1,
-            'displayPath' => 'file1'
+            'displayPath' => 'file1',
         ];
         $file2 = [
             '{DAV:}getlastmodified' => $day1,
-            'displayPath' => 'file2'
+            'displayPath' => 'file2',
         ];
         $file2_newer = [
             '{DAV:}getlastmodified' => $day2,
-            'displayPath' => 'file2'
+            'displayPath' => 'file2',
         ];
 
         // Case 1: Newer node should come before older node


### PR DESCRIPTION
### What am I doing?

Providing some tweaks to `Sabre\DAV\Browser\Plugin.php`:
- showing the number of nodes
- ordering by last modified datetime and then by displayPath.
- Nodes section is displayed at the bottom if the number of nodes are greater than 20 (considering UX).

Example with this PR:

1. When accessing a collection with more than 20 nodes (e.g., calendar)

![image](https://github.com/user-attachments/assets/b63eaa6c-4189-4029-846b-12c38aea192b)

2. When traversing collections with <=20 nodes, so it is comfortable and quick to jump from collections as it is the most used action in these types of resources.

![image](https://github.com/user-attachments/assets/df459a6b-3979-4173-aac6-3b6e421f1277)

3. When there are no nodes, there is no "Nodes (0)" section generated. Zoomed out:

![image](https://github.com/user-attachments/assets/ef91c36b-632d-45b2-b533-674171063021)

4. When accessing a collection with more than 20 nodes (e.g., addressbook). Zoomed out:

![image](https://github.com/user-attachments/assets/7dfe9f87-0800-4a16-8efc-b43e6a7d5cf0)


### Why?

More context: [issue](https://github.com/sabre-io/dav/issues/1571)

I have added a test to evaluate the new `compareNodes` protected function, as I didn't see a way to easily replace `lastmodified` values for a set of files and just parsing the table rows of the response body. So I am using reflection to verify all the possibilities when comparing.

Originally, I had another function (see below) to evaluate specifically the counting of nodes, but I think it will be fine just using what is provided by the `parent::setUp()` + `setUp` (3 nodes).

```php
public function testCollectionNodes()
{
    $dir = $this->server->tree->getNodeForPath('dir2');
    $dir->createDirectory('subdir2');
    $dir->createDirectory('subdir1');
    $dir->createFile('file2');
    $dir->createFile('file1');

    $request = new HTTP\Request('GET', '/dir2');
    $this->server->httpRequest = ($request);
    $this->server->exec();

    $body = $this->response->getBodyAsString();
    self::assertTrue(false !== strpos($body, 'Nodes (4)'), $body);
    self::assertTrue(false !== strpos($body, '<a href="/dir2/subdir1/">'));
}
```

All passing:
```
> phpunit --configuration tests/phpunit.xml tests
PHPUnit 9.6.21 by Sebastian Bergmann and contributors.

....SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS   61 / 1646 (  3%)
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS............  122 / 1646 (  7%)
.............................................................  183 / 1646 ( 11%)
.............................................................  244 / 1646 ( 14%)
.............................................................  305 / 1646 ( 18%)
.............................................................  366 / 1646 ( 22%)
.............................................................  427 / 1646 ( 25%)
.............................................................  488 / 1646 ( 29%)
.............................................................  549 / 1646 ( 33%)
.............................................................  610 / 1646 ( 37%)
.............................................................  671 / 1646 ( 40%)
.........SSSSSSSSSSSSSSSSSSSSSSSSSSSS........................  732 / 1646 ( 44%)
.............................................................  793 / 1646 ( 48%)
.................................................SSSS........  854 / 1646 ( 51%)
.............................................................  915 / 1646 ( 55%)
.............................................................  976 / 1646 ( 59%)
........................................SSSSSSSSSSSSSSSS..... 1037 / 1646 ( 63%)
............................................................. 1098 / 1646 ( 66%)
..........................................SSSSSSSSSSSSSSSSSS. 1159 / 1646 ( 70%)
............................................................. 1220 / 1646 ( 74%)
............................................................. 1281 / 1646 ( 77%)
............................................................. 1342 / 1646 ( 81%)
............................................................. 1403 / 1646 ( 85%)
............................................................. 1464 / 1646 ( 88%)
............................................................. 1525 / 1646 ( 92%)
......SSSSSSSSSSSSSSSSSSSSSSSSSS............................. 1586 / 1646 ( 96%)
............................................................  1646 / 1646 (100%)

Time: 00:06.069, Memory: 48.00 MB

OK, but incomplete, skipped, or risky tests!
Tests: 1646, Assertions: 2915, Skipped: 198.
```

Let me know if something else is necessary ;)