### PR TITLE
Set access to 1 on new calendars to handle share with null

### DIFF
--- a/lib/CalDAV/Backend/PDO.php
+++ b/lib/CalDAV/Backend/PDO.php
@@ -228,12 +228,14 @@ SQL
             'principaluri',
             'uri',
             'transparent',
+            'access',
             'calendarid',
         ];
         $values = [
             ':principaluri' => $principalUri,
             ':uri' => $calendarUri,
             ':transparent' => 0,
+            ':access' => 1,
         ];
 
         $sccs = '{urn:ietf:params:xml:ns:caldav}supported-calendar-component-set';


### PR DESCRIPTION
When a new calendar is created via DAV or from the iOS calendar app a "empty" shared user (null) is always created.
Apparently the iOS calendar app assumes to have a shared-owner calendar even when the calendar is not shared.
see https://github.com/sabre-io/Baikal/issues/1090

This PR sets the access value for new calendars to '1' like it is already done in baikal