### PR TITLE
Fix showing owner of shared calendars on iOS

### DIFF
--- a/lib/CalDAV/Backend/PDO.php
+++ b/lib/CalDAV/Backend/PDO.php
@@ -192,9 +192,13 @@ SQL
             $calendar['share-access'] = (int) $row['access'];
             // 1 = owner, 2 = readonly, 3 = readwrite
             if ($row['access'] > 1) {
-                // We need to find more information about the original owner.
-                //$stmt2 = $this->pdo->prepare('SELECT principaluri FROM ' . $this->calendarInstancesTableName . ' WHERE access = 1 AND id = ?');
-                //$stmt2->execute([$row['id']]);
+                $ownerStmt = $this->pdo->prepare("SELECT principaluri FROM {$this->calendarInstancesTableName} WHERE access = 1 AND calendarid = ?");
+                $ownerStmt->execute([$row['calendarid']]);
+
+                $ownerRow = $ownerStmt->fetch(\PDO::FETCH_ASSOC);
+                if ($ownerRow && is_array($ownerRow) && array_key_exists('principaluri', $ownerRow)) {
+                    $calendar['owner-principal'] = $ownerRow['principaluri'];
+                }
 
                 // read-only is for backwards compatibility. Might go away in
                 // the future.

--- a/lib/CalDAV/Principal/User.php
+++ b/lib/CalDAV/Principal/User.php
@@ -131,6 +131,22 @@ class User extends DAVACL\Principal implements DAV\ICollection
             'protected' => true,
         ];
 
+        /**
+         * Members of shared calendars needs to be able to read information about the owner.
+         * 
+         * The Principal has no knowledge about the calendars and therefore it is not 
+         * possible to limit the access to members of a shared calendar 
+         * in DAVACL/Plugin.php getCurrentUserPrivilegeSet.
+         * 
+         * As workaround all authenticated users are getting the read privilege for other users.
+         */
+
+         $acl[] = [
+            'privilege' => '{DAV:}read',
+            'principal' => '{DAV:}authenticated',
+            'protected' => true,
+        ];
+
         return $acl;
     }
 }

--- a/lib/CalDAV/SharedCalendar.php
+++ b/lib/CalDAV/SharedCalendar.php
@@ -216,4 +216,16 @@ class SharedCalendar extends Calendar implements ISharedCalendar
 
         return $acl;
     }
+
+    /**
+     * Returns the 'original owner principal' for this shared resource.
+     *
+     * This must be a url to a principal, or null if there's no owner
+     *
+     * @return string|null
+     */
+    public function getOwnerPrincipal()
+    {
+        return isset($this->calendarInfo['owner-principal']) ? $this->calendarInfo['owner-principal'] : $this->getOwner();
+    }
 }

--- a/lib/DAV/Sharing/ISharedNode.php
+++ b/lib/DAV/Sharing/ISharedNode.php
@@ -66,4 +66,13 @@ interface ISharedNode extends INode
      * @return \Sabre\DAV\Xml\Element\Sharee[]
      */
     public function getInvites();
+
+    /**
+     * Returns the 'original owner principal' for this shared resource.
+     *
+     * This must be a url to a principal, or null if there's no owner
+     *
+     * @return string|null
+     */
+    public function getOwnerPrincipal();
 }


### PR DESCRIPTION
This PR fixes issue https://github.com/sabre-io/dav/issues/924 and depends on https://github.com/sabre-io/dav/pull/1581.

The iOS calendar uses the {DAV:}owner attribute to determine the owner of a shared calendar.

Therefore this attribute needs to be set as the real owner of the calendar not the user which whom the calendar is shared. This "real" owner needs to be set before the ACL plugin can set it.

To determine the name of the owner the iOS calendar queries the principal uri. Setting a mailto address is not working.

Unfortunatly the principal query is not allowed for other users by the ACL plugin. It is not easy to determine if the client is trying to query the principal information of a owner of a shared calendar, so as workaround all authenticated users are allowed to query the principal information.