### PR TITLE
Uri in xml response must be url encoded.

### DIFF
--- a/lib/DAV/Browser/Plugin.php
+++ b/lib/DAV/Browser/Plugin.php
@@ -512,111 +512,11 @@ HTML;
 </form>
 <form method="post" action="" enctype="multipart/form-data">
 <h3>Upload file</h3>
-Select one or more file(s), then you can upload.<BR>
-<form action="#" id="uploadFiles" onsubmit="uploadFiles(); return false">
-<label for="filesInput">File(s):</label><input id="filesInput" type="file" multiple /><br />
-<input type="submit" id="submit" disabled style="visibility:hidden;" value="upload" />
-<div id="uploadProgress"></div>
+<input type="hidden" name="sabreAction" value="put" />
+<label>Name (optional):</label> <input type="text" name="name" /><br />
+<label>File:</label> <input type="file" name="file" /><br />
+<input type="submit" value="upload" />
 </form>
-<script>
-function updateProgress(text) {
-  document.getElementById("uploadProgress").innerHTML = text;
-}
-
-var uploads = [];
-
-function uploadFiles() {
-  document.forms["uploadFiles"].filesInput.disabled = true;
-  document.forms["uploadFiles"].submit.disabled = true;
-  document.forms["uploadFiles"].submit.style.visibility = "hidden";
-  var remoteURL = window.location.href.split('?')[0];
-  if (!remoteURL.endsWith("/")) { remoteURL = remoteURL + "/"; }
-  var files = document.forms["uploadFiles"].filesInput.files;
-  var nrFiles = files.length;
-  for (i = 0; i < files.length; i++) {
-    var file = files[i];
-    var xhr = new XMLHttpRequest();
-    uploads.push(xhr);
-    xhr.upload.url = remoteURL + encodeURIComponent(file.name);
-    xhr.upload.nr = i;
-    xhr.upload.filename = file;
-    xhr.upload.progressBar = document.getElementById("file_" + i.toString());
-    xhr.upload.statusBar = document.getElementById("status_file_" + i.toString());
-    xhr.upload.onprogress = function (e) {
-      if (e.lengthComputable) {
-        this.progressBar.max = e.total;
-        this.progressBar.value = e.loaded;
-      }
-    }
-    xhr.upload.onloadstart = function (e) { this.progressBar.value = 0; }
-    xhr.upload.onloadend = function (e) { this.progressBar.value = e.loaded; }
-    xhr.onload = function() {
-      nrFiles--;
-      if (this.readyState == 4 && (this.status == 201 || this.status == 204)) {
-        this.upload.statusBar.style = "color:green";
-        if (this.status == 201) {
-          this.upload.statusBar.innerHTML = " Uploaded";
-        } else {
-          this.upload.statusBar.innerHTML = " Updated";
-        } 
-      } else if (this.status == 0) {
-        this.upload.statusBar.style = "color:red";
-        this.upload.statusBar.innerHTML = " Canceled";
-      } else {
-        this.upload.statusBar.style = "color:red";
-        this.upload.statusBar.innerHTML = " ERROR: " + this.status;
-      }
-      if (nrFiles == 0) {
-        setTimeout(function(){ location.reload(true); }, 1500);
-      }
-    }
-    xhr.onabort = function() {
-      this.upload.statusBar.style = "color:red";
-      this.upload.statusBar.innerHTML = " Canceled by user";
-    }
-    xhr.onerror = function() {
-      this.upload.statusBar.style = "color:red";
-      this.readyState = 0;
-      var button = "<button type=\"button\" onclick=\"sendFile(" + this.upload.nr + ")\">Retry</button>";
-      this.upload.statusBar.innerHTML = " ERROR: " + this.statusText + button;
-    }
-    xhr.ontimeout = function() {
-      console.log("An timeout occurred while transferring the file.");
-      console.log(this);
-    }
-    sendFile(xhr.upload.nr);
-  }
-}
-
-function sendFile(nr) {
-  var request = uploads[nr];
-  request.open("PUT", request.upload.url, true);
-  var button = "<button type=\"button\" id=\"cancel_" + nr.toString() + "\" onclick=\"abortUpload(" + nr.toString() + ")\">Cancel</button>";
-  request.upload.statusBar.innerHTML = button;
-  request.send(request.upload.filename);
-}
-
-function abortUpload(nr) { uploads[nr].abort(); }
-
-document.getElementById("filesInput").onchange = function() {
-  var fileTable = "<TABLE>";
-  if (this.files.length > 0) {
-    for (i = 0; i < this.files.length; i++) {
-      var file = this.files[i];
-      var progressBar = "file_" + i.toString();
-      var index = (i + 1).toString();
-      fileTable += "<TR><TD>" + index + ".) " +file.name + ":</TD><TD><progress id=\"" + progressBar + "\" value=\"0\"></progress><span id=\"status_" + progressBar + "\"></span></TD></TR>";
-    }
-    fileTable += "</TABLE>";
-    updateProgress(fileTable);
-    document.forms["uploadFiles"].submit.disabled = false;
-    document.forms["uploadFiles"].submit.style.visibility = "visible";
-  } else {
-    document.forms["uploadFiles"].submit.disabled = true;
-    document.forms["uploadFiles"].submit.style.visibility = "hidden";
-  }
-}
-</script>
 HTML;
     }
 

--- a/lib/DAV/Locks/Plugin.php
+++ b/lib/DAV/Locks/Plugin.php
@@ -234,6 +234,7 @@ class Plugin extends DAV\ServerPlugin
         }
 
         $this->lockNode($uri, $lockInfo);
+        $lockInfo->uri = urlencode($lockInfo->uri);
 
         $response->setHeader('Content-Type', 'application/xml; charset=utf-8');
         $response->setHeader('Lock-Token', '<opaquelocktoken:'.$lockInfo->token.'>');

--- a/tests/Sabre/DAV/Locks/PluginTest.php
+++ b/tests/Sabre/DAV/Locks/PluginTest.php
@@ -920,4 +920,14 @@ class PluginTest extends DAV\AbstractServerTestCase
         $this->server->httpRequest = $request;
         $this->locksPlugin->getTimeoutHeader();
     }
+
+    public function testLockWithSpaces()
+    {
+        $request = new HTTP\Request('LOCK', '/test .txt', [
+            'Timeout' => 'second-5, infinite',
+        ]);
+        $this->server->httpRequest = $request;
+        $this->server->exec();
+        self::assertEquals(201, $this->response->status);
+    }
 }

--- a/tests/Sabre/DAV/Locks/PluginTest.php
+++ b/tests/Sabre/DAV/Locks/PluginTest.php
@@ -929,5 +929,9 @@ class PluginTest extends DAV\AbstractServerTestCase
         $this->server->httpRequest = $request;
         $this->server->exec();
         self::assertEquals(201, $this->response->status);
+        $xml = $this->getSanitizedBodyAsXml();
+        $xml->registerXPathNamespace('d', 'prop:DAV');
+        $token = $xml->xpath('/d:prop/d:lockdiscovery/d:activelock/d:locktoken/d:href');
+        self::assertEquals($this->response->getHeader('Lock-Token'), '<'.(string) $token[0].'>', 'Token in response body didn\'t match token in response header.');	
     }
 }


### PR DESCRIPTION
The Uri is derived from the request with the method getPath, which generates a valid path fragment suitable for file and directory names.

In the XML-response to a lock-request the uri is used for lockroot element. If the uri contains a space or german umlauts, a strict client like libneon, which is used in davfs2, refuses the lock reponse and files cannot be copied.