### PR TITLE
docs(caldav): fix RFC section for calendar query report

### DIFF
--- a/lib/CalDAV/Xml/Request/CalendarQueryReport.php
+++ b/lib/CalDAV/Xml/Request/CalendarQueryReport.php
@@ -15,7 +15,7 @@ use Sabre\Xml\XmlDeserializable;
  * This class parses the {urn:ietf:params:xml:ns:caldav}calendar-query
  * REPORT, as defined in:
  *
- * https://tools.ietf.org/html/rfc4791#section-7.9
+ * https://tools.ietf.org/html/rfc4791#section-7.8
  *
  * @copyright Copyright (C) fruux GmbH (https://fruux.com/)
  * @author Evert Pot (http://www.rooftopsolutions.nl/)


### PR DESCRIPTION
This seems to be a copy-paste error from https://github.com/sabre-io/dav/blob/09ac4fd0411ae660efd6858d0da44e77de6f408a/lib/CalDAV/Xml/Request/CalendarMultiGetReport.php#L18