### PR TITLE
feat(carddav): allow pushing down filtering of reports

### DIFF
--- a/lib/CardDAV/IAddressBookObjectContainer.php
+++ b/lib/CardDAV/IAddressBookObjectContainer.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sabre\CardDAV;
+
+use Sabre\CardDAV\Xml\Request\AddressBookQueryReport;
+use Sabre\DAV\ICollection;
+
+/**
+ * This interface represents a node that may contain address book objects.
+ *
+ * This is the shared parent for both the Inbox collection and calendars
+ * resources.
+ *
+ * @license http://sabre.io/license/ Modified BSD License
+ */
+interface IAddressBookObjectContainer extends ICollection
+{
+    /**
+     * Performs an addressbook-query on the contents of this calendar.
+     *
+     * This method should just return a list of (relative) urls that match this
+     * query.
+     *
+	 * @see CalendarQueryValidator
+     * @return string[]
+     */
+    public function addressBookQuery(AddressBookQueryReport $report): array;
+}


### PR DESCRIPTION
A `addressbook-query` currently loads the full address book to filter in memory. Depending on the implementation it should be possible to push some of the filtering down to the implementation, e.g. to filter on a DB level first. This improves memory footprint and performance drastically.

I'm opening this as proof of concept and hope to get some input on the approach and whether this would be accepted.

The same mechanism exists for caldav, where I took inspiration from. For BC I chose to not add a new method to the carddav backend interface.

https://github.com/nextcloud/server/pull/55669 shows what it will look like in an implementation.