### PR TITLE
feat: add JsonSerializable to GetLastModified and ResourceType

### DIFF
--- a/lib/DAV/Xml/Property/GetLastModified.php
+++ b/lib/DAV/Xml/Property/GetLastModified.php
@@ -6,6 +6,7 @@ namespace Sabre\DAV\Xml\Property;
 
 use DateTime;
 use DateTimeZone;
+use JsonSerializable;
 use Sabre\HTTP;
 use Sabre\Xml\Element;
 use Sabre\Xml\Reader;
@@ -21,7 +22,7 @@ use Sabre\Xml\Writer;
  * @author Evert Pot (http://www.rooftopsolutions.nl/)
  * @license http://sabre.io/license/ Modified BSD License
  */
-class GetLastModified implements Element
+class GetLastModified implements Element, JsonSerializable
 {
     /**
      * time.
@@ -99,5 +100,10 @@ class GetLastModified implements Element
     public static function xmlDeserialize(Reader $reader)
     {
         return new self(new DateTime($reader->parseInnerTree()));
+    }
+
+    public function jsonSerialize()
+    {
+        return HTTP\toDate($this->time);
     }
 }

--- a/lib/DAV/Xml/Property/ResourceType.php
+++ b/lib/DAV/Xml/Property/ResourceType.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace Sabre\DAV\Xml\Property;
 
+use JsonSerializable;
 use Sabre\DAV\Browser\HtmlOutput;
 use Sabre\DAV\Browser\HtmlOutputHelper;
 use Sabre\Xml\Element;
 use Sabre\Xml\Reader;
+use Sabre\Xml\Writer;
 
 /**
  * {DAV:}resourcetype property.
@@ -20,7 +22,7 @@ use Sabre\Xml\Reader;
  * @author Evert Pot (http://evertpot.com/)
  * @license http://sabre.io/license/ Modified BSD License
  */
-class ResourceType extends Element\Elements implements HtmlOutput
+class ResourceType extends Element\Elements implements HtmlOutput, JsonSerializable
 {
     /**
      * Constructor.
@@ -42,7 +44,7 @@ class ResourceType extends Element\Elements implements HtmlOutput
      *
      * For example array('{DAV:}collection')
      *
-     * @return array
+     * @return string[]
      */
     public function getValue()
     {
@@ -115,6 +117,20 @@ class ResourceType extends Element\Elements implements HtmlOutput
         return implode(
             ', ',
             array_map([$html, 'xmlName'], $this->getValue())
+        );
+    }
+
+    /**
+     * Returns an array that produces the correct XML when serialized by Writer.
+     * @see Writer
+     *
+     * @return string[][]
+     */
+    public function jsonSerialize(): array
+    {
+        return array_map(
+            static fn(string $type) => [ $type => null ],
+            $this->getValue()
         );
     }
 }


### PR DESCRIPTION
When serializing file properties to JSON, most of the properties are retained. However properties represented by objects disappear, as they are not serializable. For this reason, this PR implements `JsonSerializable` in `GetLastModified` and `ResourceType` so that they can be serialized as JSON in a format that Xml/Writer can serialize to XML correctly.