### PR TITLE
Use Uri\Split() instead of basename()

### DIFF
--- a/bin/migrateto30.php
+++ b/bin/migrateto30.php
@@ -149,7 +149,7 @@ $stmt1 = $pdo->prepare('INSERT INTO propertystorage (path, name, valuetype, valu
 while ($row = $result->fetch(\PDO::FETCH_ASSOC)) {
     // Inserting the new record
     $stmt1->execute([
-        'addressbooks/' .  \Sabre\Uri\split($row['uri'])[1],
+        'addressbooks/'.\Sabre\Uri\split($row['uri'])[1],
         '{http://calendarserver.org/ns/}me-card',
         serialize(new Sabre\DAV\Xml\Property\Href($row['vcardurl'])),
     ]);


### PR DESCRIPTION
Fixes #1348.