### PR TITLE
Fix PDO::PARAM_LOB binding for BYTEA columns in CalDAV and CardDAV

### DIFF
--- a/lib/CalDAV/Backend/PDO.php
+++ b/lib/CalDAV/Backend/PDO.php
@@ -466,7 +466,7 @@ SQL
             'lastmodified' => (int) $row['lastmodified'],
             'etag' => '"'.$row['etag'].'"',
             'size' => (int) $row['size'],
-            'calendardata' => $row['calendardata'],
+            'calendardata' => is_resource($row['calendardata']) ? stream_get_contents($row['calendardata']) : $row['calendardata'],
             'component' => strtolower($row['componenttype']),
          ];
     }
@@ -507,7 +507,7 @@ SQL
                     'lastmodified' => (int) $row['lastmodified'],
                     'etag' => '"'.$row['etag'].'"',
                     'size' => (int) $row['size'],
-                    'calendardata' => $row['calendardata'],
+                    'calendardata' => is_resource($row['calendardata']) ? stream_get_contents($row['calendardata']) : $row['calendardata'],
                     'component' => strtolower($row['componenttype']),
                 ];
             }
@@ -544,19 +544,19 @@ SQL
 
         $extraData = $this->getDenormalizedData($calendarData);
 
-        $stmt = $this->pdo->prepare('INSERT INTO '.$this->calendarObjectTableName.' (calendarid, uri, calendardata, lastmodified, etag, size, componenttype, firstoccurence, lastoccurence, uid) VALUES (?,?,?,?,?,?,?,?,?,?)');
-        $stmt->execute([
-            $calendarId,
-            $objectUri,
-            $calendarData,
-            time(),
-            $extraData['etag'],
-            $extraData['size'],
-            $extraData['componentType'],
-            $extraData['firstOccurence'],
-            $extraData['lastOccurence'],
-            $extraData['uid'],
-        ]);
+        $stmt = $this->pdo->prepare('INSERT INTO '.$this->calendarObjectTableName.' (calendarid, uri, calendardata, lastmodified, etag, size, componenttype, firstoccurence, lastoccurence, uid) VALUES (:calendarid, :uri, :calendardata, :lastmodified, :etag, :size, :componenttype, :firstoccurence, :lastoccurence, :uid)');
+        $lastmodified = time();
+        $stmt->bindParam('calendarid', $calendarId, \PDO::PARAM_INT);
+        $stmt->bindParam('uri', $objectUri, \PDO::PARAM_STR);
+        $stmt->bindParam('calendardata', $calendarData, \PDO::PARAM_LOB);
+        $stmt->bindParam('lastmodified', $lastmodified, \PDO::PARAM_INT);
+        $stmt->bindParam('etag', $extraData['etag'], \PDO::PARAM_STR);
+        $stmt->bindParam('size', $extraData['size'], \PDO::PARAM_INT);
+        $stmt->bindParam('componenttype', $extraData['componentType'], \PDO::PARAM_STR);
+        $stmt->bindParam('firstoccurence', $extraData['firstOccurence'], \PDO::PARAM_INT);
+        $stmt->bindParam('lastoccurence', $extraData['lastOccurence'], \PDO::PARAM_INT);
+        $stmt->bindParam('uid', $extraData['uid'], \PDO::PARAM_STR);
+        $stmt->execute();
         $this->addChange($calendarId, $objectUri, 1);
 
         return '"'.$extraData['etag'].'"';
@@ -590,8 +590,19 @@ SQL
 
         $extraData = $this->getDenormalizedData($calendarData);
 
-        $stmt = $this->pdo->prepare('UPDATE '.$this->calendarObjectTableName.' SET calendardata = ?, lastmodified = ?, etag = ?, size = ?, componenttype = ?, firstoccurence = ?, lastoccurence = ?, uid = ? WHERE calendarid = ? AND uri = ?');
-        $stmt->execute([$calendarData, time(), $extraData['etag'], $extraData['size'], $extraData['componentType'], $extraData['firstOccurence'], $extraData['lastOccurence'], $extraData['uid'], $calendarId, $objectUri]);
+        $stmt = $this->pdo->prepare('UPDATE '.$this->calendarObjectTableName.' SET calendardata = :calendardata, lastmodified = :lastmodified, etag = :etag, size = :size, componenttype = :componenttype, firstoccurence = :firstoccurence, lastoccurence = :lastoccurence, uid = :uid WHERE calendarid = :calendarid AND uri = :uri');
+        $lastmodified = time();
+        $stmt->bindParam('calendardata', $calendarData, \PDO::PARAM_LOB);
+        $stmt->bindParam('lastmodified', $lastmodified, \PDO::PARAM_INT);
+        $stmt->bindParam('etag', $extraData['etag'], \PDO::PARAM_STR);
+        $stmt->bindParam('size', $extraData['size'], \PDO::PARAM_INT);
+        $stmt->bindParam('componenttype', $extraData['componentType'], \PDO::PARAM_STR);
+        $stmt->bindParam('firstoccurence', $extraData['firstOccurence'], \PDO::PARAM_INT);
+        $stmt->bindParam('lastoccurence', $extraData['lastOccurence'], \PDO::PARAM_INT);
+        $stmt->bindParam('uid', $extraData['uid'], \PDO::PARAM_STR);
+        $stmt->bindParam('calendarid', $calendarId, \PDO::PARAM_INT);
+        $stmt->bindParam('uri', $objectUri, \PDO::PARAM_STR);
+        $stmt->execute();
 
         $this->addChange($calendarId, $objectUri, 2);
 
@@ -828,6 +839,9 @@ SQL
         $result = [];
         while ($row = $stmt->fetch(\PDO::FETCH_ASSOC)) {
             if ($requirePostFilter) {
+                if (isset($row['calendardata']) && is_resource($row['calendardata'])) {
+                    $row['calendardata'] = stream_get_contents($row['calendardata']);
+                }
                 if (!$this->validateFilterForObject($row, $filters)) {
                     continue;
                 }
@@ -1252,7 +1266,7 @@ SQL;
 
         return [
             'uri' => $row['uri'],
-            'calendardata' => $row['calendardata'],
+            'calendardata' => is_resource($row['calendardata']) ? stream_get_contents($row['calendardata']) : $row['calendardata'],
             'lastmodified' => $row['lastmodified'],
             'etag' => '"'.$row['etag'].'"',
             'size' => (int) $row['size'],
@@ -1279,7 +1293,7 @@ SQL;
         $result = [];
         foreach ($stmt->fetchAll(\PDO::FETCH_ASSOC) as $row) {
             $result[] = [
-                'calendardata' => $row['calendardata'],
+                'calendardata' => is_resource($row['calendardata']) ? stream_get_contents($row['calendardata']) : $row['calendardata'],
                 'uri' => $row['uri'],
                 'lastmodified' => $row['lastmodified'],
                 'etag' => '"'.$row['etag'].'"',
@@ -1311,13 +1325,22 @@ SQL;
      */
     public function createSchedulingObject($principalUri, $objectUri, $objectData)
     {
-        $stmt = $this->pdo->prepare('INSERT INTO '.$this->schedulingObjectTableName.' (principaluri, calendardata, uri, lastmodified, etag, size) VALUES (?, ?, ?, ?, ?, ?)');
+        $stmt = $this->pdo->prepare('INSERT INTO '.$this->schedulingObjectTableName.' (principaluri, calendardata, uri, lastmodified, etag, size) VALUES (:principaluri, :calendardata, :uri, :lastmodified, :etag, :size)');
 
         if (is_resource($objectData)) {
             $objectData = stream_get_contents($objectData);
         }
 
-        $stmt->execute([$principalUri, $objectData, $objectUri, time(), md5($objectData), strlen($objectData)]);
+        $lastmodified = time();
+        $etag = md5($objectData);
+        $size = strlen($objectData);
+        $stmt->bindParam('principaluri', $principalUri, \PDO::PARAM_STR);
+        $stmt->bindParam('calendardata', $objectData, \PDO::PARAM_LOB);
+        $stmt->bindParam('uri', $objectUri, \PDO::PARAM_STR);
+        $stmt->bindParam('lastmodified', $lastmodified, \PDO::PARAM_INT);
+        $stmt->bindParam('etag', $etag, \PDO::PARAM_STR);
+        $stmt->bindParam('size', $size, \PDO::PARAM_INT);
+        $stmt->execute();
     }
 
     /**

--- a/lib/CalDAV/Backend/PDO.php
+++ b/lib/CalDAV/Backend/PDO.php
@@ -466,7 +466,7 @@ SQL
             'lastmodified' => (int) $row['lastmodified'],
             'etag' => '"'.$row['etag'].'"',
             'size' => (int) $row['size'],
-            'calendardata' => is_resource($row['calendardata']) ? stream_get_contents($row['calendardata']) : $row['calendardata'],
+            'calendardata' => $row['calendardata'],
             'component' => strtolower($row['componenttype']),
          ];
     }
@@ -507,7 +507,7 @@ SQL
                     'lastmodified' => (int) $row['lastmodified'],
                     'etag' => '"'.$row['etag'].'"',
                     'size' => (int) $row['size'],
-                    'calendardata' => is_resource($row['calendardata']) ? stream_get_contents($row['calendardata']) : $row['calendardata'],
+                    'calendardata' => $row['calendardata'],
                     'component' => strtolower($row['componenttype']),
                 ];
             }
@@ -839,9 +839,6 @@ SQL
         $result = [];
         while ($row = $stmt->fetch(\PDO::FETCH_ASSOC)) {
             if ($requirePostFilter) {
-                if (isset($row['calendardata']) && is_resource($row['calendardata'])) {
-                    $row['calendardata'] = stream_get_contents($row['calendardata']);
-                }
                 if (!$this->validateFilterForObject($row, $filters)) {
                     continue;
                 }
@@ -1266,7 +1263,7 @@ SQL;
 
         return [
             'uri' => $row['uri'],
-            'calendardata' => is_resource($row['calendardata']) ? stream_get_contents($row['calendardata']) : $row['calendardata'],
+            'calendardata' => $row['calendardata'],
             'lastmodified' => $row['lastmodified'],
             'etag' => '"'.$row['etag'].'"',
             'size' => (int) $row['size'],
@@ -1293,7 +1290,7 @@ SQL;
         $result = [];
         foreach ($stmt->fetchAll(\PDO::FETCH_ASSOC) as $row) {
             $result[] = [
-                'calendardata' => is_resource($row['calendardata']) ? stream_get_contents($row['calendardata']) : $row['calendardata'],
+                'calendardata' => $row['calendardata'],
                 'uri' => $row['uri'],
                 'lastmodified' => $row['lastmodified'],
                 'etag' => '"'.$row['etag'].'"',

--- a/lib/CardDAV/Backend/PDO.php
+++ b/lib/CardDAV/Backend/PDO.php
@@ -253,9 +253,6 @@ class PDO extends AbstractBackend implements SyncSupport
 
         $result['etag'] = '"'.$result['etag'].'"';
         $result['lastmodified'] = (int) $result['lastmodified'];
-        if (is_resource($result['carddata'])) {
-            $result['carddata'] = stream_get_contents($result['carddata']);
-        }
 
         return $result;
     }
@@ -285,9 +282,6 @@ class PDO extends AbstractBackend implements SyncSupport
         while ($row = $stmt->fetch(\PDO::FETCH_ASSOC)) {
             $row['etag'] = '"'.$row['etag'].'"';
             $row['lastmodified'] = (int) $row['lastmodified'];
-            if (is_resource($row['carddata'])) {
-                $row['carddata'] = stream_get_contents($row['carddata']);
-            }
             $result[] = $row;
         }
 

--- a/lib/CardDAV/Backend/PDO.php
+++ b/lib/CardDAV/Backend/PDO.php
@@ -253,6 +253,9 @@ class PDO extends AbstractBackend implements SyncSupport
 
         $result['etag'] = '"'.$result['etag'].'"';
         $result['lastmodified'] = (int) $result['lastmodified'];
+        if (is_resource($result['carddata'])) {
+            $result['carddata'] = stream_get_contents($result['carddata']);
+        }
 
         return $result;
     }
@@ -282,6 +285,9 @@ class PDO extends AbstractBackend implements SyncSupport
         while ($row = $stmt->fetch(\PDO::FETCH_ASSOC)) {
             $row['etag'] = '"'.$row['etag'].'"';
             $row['lastmodified'] = (int) $row['lastmodified'];
+            if (is_resource($row['carddata'])) {
+                $row['carddata'] = stream_get_contents($row['carddata']);
+            }
             $result[] = $row;
         }
 
@@ -316,18 +322,18 @@ class PDO extends AbstractBackend implements SyncSupport
      */
     public function createCard($addressBookId, $cardUri, $cardData)
     {
-        $stmt = $this->pdo->prepare('INSERT INTO '.$this->cardsTableName.' (carddata, uri, lastmodified, addressbookid, size, etag) VALUES (?, ?, ?, ?, ?, ?)');
+        $stmt = $this->pdo->prepare('INSERT INTO '.$this->cardsTableName.' (carddata, uri, lastmodified, addressbookid, size, etag) VALUES (:carddata, :uri, :lastmodified, :addressbookid, :size, :etag)');
 
         $etag = md5($cardData);
-
-        $stmt->execute([
-            $cardData,
-            $cardUri,
-            time(),
-            $addressBookId,
-            strlen($cardData),
-            $etag,
-        ]);
+        $lastmodified = time();
+        $size = strlen($cardData);
+        $stmt->bindParam('carddata', $cardData, \PDO::PARAM_LOB);
+        $stmt->bindParam('uri', $cardUri, \PDO::PARAM_STR);
+        $stmt->bindParam('lastmodified', $lastmodified, \PDO::PARAM_INT);
+        $stmt->bindParam('addressbookid', $addressBookId, \PDO::PARAM_INT);
+        $stmt->bindParam('size', $size, \PDO::PARAM_INT);
+        $stmt->bindParam('etag', $etag, \PDO::PARAM_STR);
+        $stmt->execute();
 
         $this->addChange($addressBookId, $cardUri, 1);
 
@@ -362,17 +368,18 @@ class PDO extends AbstractBackend implements SyncSupport
      */
     public function updateCard($addressBookId, $cardUri, $cardData)
     {
-        $stmt = $this->pdo->prepare('UPDATE '.$this->cardsTableName.' SET carddata = ?, lastmodified = ?, size = ?, etag = ? WHERE uri = ? AND addressbookid =?');
+        $stmt = $this->pdo->prepare('UPDATE '.$this->cardsTableName.' SET carddata = :carddata, lastmodified = :lastmodified, size = :size, etag = :etag WHERE uri = :uri AND addressbookid = :addressbookid');
 
         $etag = md5($cardData);
-        $stmt->execute([
-            $cardData,
-            time(),
-            strlen($cardData),
-            $etag,
-            $cardUri,
-            $addressBookId,
-        ]);
+        $lastmodified = time();
+        $size = strlen($cardData);
+        $stmt->bindParam('carddata', $cardData, \PDO::PARAM_LOB);
+        $stmt->bindParam('lastmodified', $lastmodified, \PDO::PARAM_INT);
+        $stmt->bindParam('size', $size, \PDO::PARAM_INT);
+        $stmt->bindParam('etag', $etag, \PDO::PARAM_STR);
+        $stmt->bindParam('uri', $cardUri, \PDO::PARAM_STR);
+        $stmt->bindParam('addressbookid', $addressBookId, \PDO::PARAM_INT);
+        $stmt->execute();
 
         $this->addChange($addressBookId, $cardUri, 2);
 

--- a/tests/Sabre/CalDAV/Backend/AbstractPDOTestCase.php
+++ b/tests/Sabre/CalDAV/Backend/AbstractPDOTestCase.php
@@ -243,6 +243,27 @@ abstract class AbstractPDOTestCase extends TestCase
         ], $row);
     }
 
+    /**
+     * @see https://github.com/sabre-io/dav/issues/1587
+     */
+    public function testCreateCalendarObjectWithIcsEscapes()
+    {
+        $backend = new PDO($this->pdo);
+        $returnedId = $backend->createCalendar('principals/user2', 'somerandomid', []);
+
+        // ICS data with escaped comma (\,) and newline (\n) in DESCRIPTION.
+        // These are standard RFC 5545 TEXT escapes but trigger PostgreSQL
+        // "invalid input syntax for type bytea" when calendardata is BYTEA
+        // and the parameter is bound as PARAM_STR instead of PARAM_LOB.
+        $object = "BEGIN:VCALENDAR\r\nBEGIN:VEVENT\r\nDTSTART;VALUE=DATE:20120101\r\nDESCRIPTION:Hello\\, world\\nSecond line\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n";
+
+        $backend->createCalendarObject($returnedId, 'ics-escapes-id', $object);
+
+        // Verify round-trip: read it back and compare
+        $result = $backend->getCalendarObject($returnedId, 'ics-escapes-id');
+        self::assertEquals($object, $result['calendardata']);
+    }
+
     public function testGetMultipleObjects()
     {
         $backend = new PDO($this->pdo);

--- a/tests/Sabre/CalDAV/Backend/AbstractPDOTestCase.php
+++ b/tests/Sabre/CalDAV/Backend/AbstractPDOTestCase.php
@@ -261,6 +261,9 @@ abstract class AbstractPDOTestCase extends TestCase
 
         // Verify round-trip: read it back and compare
         $result = $backend->getCalendarObject($returnedId, 'ics-escapes-id');
+        if (is_resource($result['calendardata'])) {
+            $result['calendardata'] = stream_get_contents($result['calendardata']);
+        }
         self::assertEquals($object, $result['calendardata']);
     }
 


### PR DESCRIPTION
Fixes #1587 and #917

## Problem

On PostgreSQL, inserting iCalendar or vCard data containing backslash escape sequences (e.g. `\,` or `\n`, which are standard RFC 5545 TEXT escapes) into the `calendardata` or `carddata` BYTEA columns fails with:

      SQLSTATE[22P02]: Invalid text representation: 7 ERROR:
      invalid input syntax for type bytea

This happens because PDO binds parameters as `PARAM_STR` by default. For BYTEA columns, PostgreSQL's text input parser then interprets backslash sequences as invalid octal escapes.

## Fix

Bind `calendardata`/`carddata` parameters with `PDO::PARAM_LOB` in all write methods, consistent with the existing fix in `Sabre\DAV\PropertyStorage\Backend\PDO::propPatch()`. Also switch to named parameters with `bindParam()` and explicit types for all parameters, matching the PropertyStorage style.

Read methods now handle the `is_resource()` case since PDO may return BYTEA data as a PHP stream.

## Test

Added `testCreateCalendarObjectWithIcsEscapes` in `AbstractPDOTestCase` — inserts ICS data with `\,` and `\n` escapes, verifies round-trip integrity. Passes on PostgreSQL with the fix, fails without it.

I can also confirm this fixes our own codebase where we had large ICS import break 10% of the time because of such characters in events.