### PR TITLE
Fix If header Not parsing without whitespace

### DIFF
--- a/lib/DAV/Server.php
+++ b/lib/DAV/Server.php
@@ -1581,7 +1581,7 @@ class Server implements LoggerAwareInterface, EmitterInterface
 
         $matches = [];
 
-        $regex = '/(?:\<(?P<uri>.*?)\>\s)?\((?P<not>Not\s*)?(?:\<(?P<token>[^\>]*)\>)?(?:\s?)(?:\[(?P<etag>[^\]]*)\])?\)/im';
+        $regex = '/(?:\<(?P<uri>.*?)\>\s)?\((?P<not>not\b[\x20\t]*)?(?:\<(?P<token>[^\>]*)\>)?(?:\s?)(?:\[(?P<etag>[^\]]*)\])?\)/im';
         preg_match_all($regex, $header, $matches, PREG_SET_ORDER);
 
         $conditions = [];

--- a/lib/DAV/Server.php
+++ b/lib/DAV/Server.php
@@ -1581,7 +1581,7 @@ class Server implements LoggerAwareInterface, EmitterInterface
 
         $matches = [];
 
-        $regex = '/(?:\<(?P<uri>.*?)\>\s)?\((?P<not>Not\s)?(?:\<(?P<token>[^\>]*)\>)?(?:\s?)(?:\[(?P<etag>[^\]]*)\])?\)/im';
+        $regex = '/(?:\<(?P<uri>.*?)\>\s)?\((?P<not>Not\s*)?(?:\<(?P<token>[^\>]*)\>)?(?:\s?)(?:\[(?P<etag>[^\]]*)\])?\)/im';
         preg_match_all($regex, $header, $matches, PREG_SET_ORDER);
 
         $conditions = [];

--- a/tests/Sabre/DAV/GetIfConditionsTest.php
+++ b/tests/Sabre/DAV/GetIfConditionsTest.php
@@ -86,7 +86,7 @@ class GetIfConditionsTest extends AbstractServerTestCase
     public function testUppercaseNotLockTokenWithTab()
     {
         $request = new HTTP\Request('GET', '/bla', [
-            'If' => '(NOT\t<opaquelocktoken:token1>)',
+            'If' => "(NOT\t<opaquelocktoken:token1>)",
         ]);
 
         $conditions = $this->server->getIfConditions($request);
@@ -276,7 +276,7 @@ class GetIfConditionsTest extends AbstractServerTestCase
     public function testUppercaseNotEtagWithTab()
     {
         $request = new HTTP\Request('GET', '/foo', [
-            'If' => '(NOT\t["etag1"])',
+            'If' => "(NOT\t[\"etag1\"])",
         ]);
 
         $conditions = $this->server->getIfConditions($request);

--- a/tests/Sabre/DAV/GetIfConditionsTest.php
+++ b/tests/Sabre/DAV/GetIfConditionsTest.php
@@ -106,6 +106,29 @@ class GetIfConditionsTest extends AbstractServerTestCase
         self::assertEquals($compare, $conditions);
     }
 
+    public function testUppercaseNotLockTokenWithoutSpace()
+    {
+        $request = new HTTP\Request('GET', '/bla', [
+            'If' => '(NOT<opaquelocktoken:token1>)',
+        ]);
+
+        $conditions = $this->server->getIfConditions($request);
+
+        $compare = [
+            [
+                'uri' => 'bla',
+                'tokens' => [
+                    [
+                        'negate' => true,
+                        'token' => 'opaquelocktoken:token1',
+                        'etag' => '',
+                    ],
+                ],
+            ],
+        ];
+        self::assertEquals($compare, $conditions);
+    }
+
     public function testLockTokenUrl()
     {
         $request = new HTTP\Request('GET', '/bla', [
@@ -277,6 +300,29 @@ class GetIfConditionsTest extends AbstractServerTestCase
     {
         $request = new HTTP\Request('GET', '/foo', [
             'If' => "(NOT\t[\"etag1\"])",
+        ]);
+
+        $conditions = $this->server->getIfConditions($request);
+
+        $compare = [
+            [
+                'uri' => 'foo',
+                'tokens' => [
+                    [
+                        'negate' => true,
+                        'token' => '',
+                        'etag' => '"etag1"',
+                    ],
+                 ],
+            ],
+        ];
+        self::assertEquals($compare, $conditions);
+    }
+
+    public function testUppercaseNotEtagWithoutSpace()
+    {
+        $request = new HTTP\Request('GET', '/foo', [
+            'If' => '(NOT["etag1"])',
         ]);
 
         $conditions = $this->server->getIfConditions($request);

--- a/tests/Sabre/DAV/GetIfConditionsTest.php
+++ b/tests/Sabre/DAV/GetIfConditionsTest.php
@@ -227,6 +227,29 @@ class GetIfConditionsTest extends AbstractServerTestCase
         self::assertEquals($compare, $conditions);
     }
 
+    public function testNotEtagWithoutSpace()
+    {
+        $request = new HTTP\Request('GET', '/foo', [
+            'If' => '(Not["etag1"])',
+        ]);
+
+        $conditions = $this->server->getIfConditions($request);
+
+        $compare = [
+            [
+                'uri' => 'foo',
+                'tokens' => [
+                    [
+                        'negate' => true,
+                        'token' => '',
+                        'etag' => '"etag1"',
+                    ],
+                 ],
+            ],
+        ];
+        self::assertEquals($compare, $conditions);
+    }
+
     public function test2Etags()
     {
         $request = new HTTP\Request('GET', '/foo', [

--- a/tests/Sabre/DAV/GetIfConditionsTest.php
+++ b/tests/Sabre/DAV/GetIfConditionsTest.php
@@ -83,6 +83,29 @@ class GetIfConditionsTest extends AbstractServerTestCase
         self::assertEquals($compare, $conditions);
     }
 
+    public function testUppercaseNotLockTokenWithTab()
+    {
+        $request = new HTTP\Request('GET', '/bla', [
+            'If' => '(NOT\t<opaquelocktoken:token1>)',
+        ]);
+
+        $conditions = $this->server->getIfConditions($request);
+
+        $compare = [
+            [
+                'uri' => 'bla',
+                'tokens' => [
+                    [
+                        'negate' => true,
+                        'token' => 'opaquelocktoken:token1',
+                        'etag' => '',
+                    ],
+                ],
+            ],
+        ];
+        self::assertEquals($compare, $conditions);
+    }
+
     public function testLockTokenUrl()
     {
         $request = new HTTP\Request('GET', '/bla', [
@@ -231,6 +254,29 @@ class GetIfConditionsTest extends AbstractServerTestCase
     {
         $request = new HTTP\Request('GET', '/foo', [
             'If' => '(Not["etag1"])',
+        ]);
+
+        $conditions = $this->server->getIfConditions($request);
+
+        $compare = [
+            [
+                'uri' => 'foo',
+                'tokens' => [
+                    [
+                        'negate' => true,
+                        'token' => '',
+                        'etag' => '"etag1"',
+                    ],
+                 ],
+            ],
+        ];
+        self::assertEquals($compare, $conditions);
+    }
+
+    public function testUppercaseNotEtagWithTab()
+    {
+        $request = new HTTP\Request('GET', '/foo', [
+            'If' => '(NOT\t["etag1"])',
         ]);
 
         $conditions = $this->server->getIfConditions($request);

--- a/tests/Sabre/DAV/GetIfConditionsTest.php
+++ b/tests/Sabre/DAV/GetIfConditionsTest.php
@@ -60,6 +60,29 @@ class GetIfConditionsTest extends AbstractServerTestCase
         self::assertEquals($compare, $conditions);
     }
 
+    public function testNotLockTokenWithoutSpace()
+    {
+        $request = new HTTP\Request('GET', '/bla', [
+            'If' => '(Not<opaquelocktoken:token1>)',
+        ]);
+
+        $conditions = $this->server->getIfConditions($request);
+
+        $compare = [
+            [
+                'uri' => 'bla',
+                'tokens' => [
+                    [
+                        'negate' => true,
+                        'token' => 'opaquelocktoken:token1',
+                        'etag' => '',
+                    ],
+                ],
+            ],
+        ];
+        self::assertEquals($compare, $conditions);
+    }
+
     public function testLockTokenUrl()
     {
         $request = new HTTP\Request('GET', '/bla', [


### PR DESCRIPTION
## Summary
- fix `If` header parser to support `Not` conditions without a required trailing space (`Not<token>`)
- keep existing behavior for standard `Not <token>` syntax
- add regression test for the no-whitespace case

## Changes
- `lib/DAV/Server.php`
  - regex update: `Not\s` -> `Not\s*`
- `tests/Sabre/DAV/GetIfConditionsTest.php`
  - new test: `testNotLockTokenWithoutSpace()`

## Validation
- `php -l lib/DAV/Server.php`
- `php -l tests/Sabre/DAV/GetIfConditionsTest.php`
