### PR TITLE
PDOBasicAuth: compare email usernames case-insensitively

### DIFF
--- a/lib/DAV/Auth/Backend/PDOBasicAuth.php
+++ b/lib/DAV/Auth/Backend/PDOBasicAuth.php
@@ -95,6 +95,14 @@ class PDOBasicAuth extends AbstractBasic
         $stmt->execute([$username]);
         $result = $stmt->fetchAll();
 
+        // Email local/domain lookups should be case-insensitive.
+        // Keep exact-match behavior for non-email usernames to avoid changing existing semantics.
+        if (!count($result) && false !== strpos($username, '@')) {
+            $stmt = $this->pdo->prepare('SELECT '.$this->digestColumn.' FROM '.$this->tableName.' WHERE lower('.$this->uuidColumn.') = lower(?)');
+            $stmt->execute([$username]);
+            $result = $stmt->fetchAll();
+        }
+
         if (!count($result)) {
             return false;
         } else {

--- a/tests/Sabre/DAV/Auth/Backend/AbstractPDOBasicAuthTestCase.php
+++ b/tests/Sabre/DAV/Auth/Backend/AbstractPDOBasicAuthTestCase.php
@@ -24,6 +24,9 @@ abstract class AbstractPDOBasicAuthTestCase extends TestCase
         $this->getPDO()->query(
             "INSERT INTO users (username,digesta1) VALUES ('prefix_user','bcrypt\$\$2b\$12\$IwetRH4oj6.AWFGGVy8fpet7Pgp1TafspB6iq1/fiLDxfsGZfi2jS')"
         );
+        $this->getPDO()->query(
+            "INSERT INTO users (username,digesta1) VALUES ('user@example.org','\$2b\$12\$IwetRH4oj6.AWFGGVy8fpet7Pgp1TafspB6iq1/fiLDxfsGZfi2jS')"
+        );
     }
 
     public function testConstruct()
@@ -140,6 +143,29 @@ abstract class AbstractPDOBasicAuthTestCase extends TestCase
         $backend = new PDOBasicAuth($pdo, $options);
         self::assertEquals(
             [true, 'principals/prefix_user'],
+            $backend->check($request, $response)
+        );
+    }
+
+    public function testEmailCaseInsensitiveSuccess()
+    {
+        $request = HTTP\Sapi::createFromServerArray([
+            'REQUEST_METHOD' => 'GET',
+            'REQUEST_URI' => '/',
+            'PHP_AUTH_USER' => 'USER@EXAMPLE.ORG',
+            'PHP_AUTH_PW' => 'password',
+        ]);
+        $response = new HTTP\Response();
+
+        $options = [
+            'tableName' => 'users',
+            'digestColumn' => 'digesta1',
+            'uuidColumn' => 'username',
+        ];
+        $pdo = $this->getPDO();
+        $backend = new PDOBasicAuth($pdo, $options);
+        self::assertEquals(
+            [true, 'principals/USER@EXAMPLE.ORG'],
             $backend->check($request, $response)
         );
     }


### PR DESCRIPTION
Fixes #1250

## What changed
- In `PDOBasicAuth::validateUserPass`, keep exact lookup first.
- If not found and username looks like an email (`contains @`), perform fallback lookup using `lower(uuidColumn) = lower(?)`.
- Add regression test for uppercase email login against lowercase stored value.

## Why
Email addresses are generally treated case-insensitively in authentication flows.
This keeps existing semantics for non-email usernames while fixing email login mismatch caused by case differences.

## Validation
- `php -l lib/DAV/Auth/Backend/PDOBasicAuth.php`
- `php -l tests/Sabre/DAV/Auth/Backend/AbstractPDOBasicAuthTestCase.php`
