### PR TITLE
fix: parse Not independently for token and etag in If header

### DIFF
--- a/lib/DAV/Server.php
+++ b/lib/DAV/Server.php
@@ -1587,15 +1587,43 @@ class Server implements LoggerAwareInterface, EmitterInterface
         $conditions = [];
 
         foreach ($matches as $match) {
+            $negate = $match['not'] ? true : false;
+            $token = $match['token'];
+            $etag = isset($match['etag']) ? $match['etag'] : '';
+
+            // Build the token entries. Per RFC 4918, 'Not' applies only to
+            // the immediately following resource (token or etag). When both
+            // a token and an etag appear in the same list and 'Not' is
+            // present, we must split them so that the negation applies only
+            // to the token, not the etag.
+            $tokenEntries = [];
+            if ($negate && $token && $etag) {
+                // (Not <token> [etag]) means: NOT token AND etag
+                $tokenEntries[] = [
+                    'negate' => true,
+                    'token' => $token,
+                    'etag' => '',
+                ];
+                $tokenEntries[] = [
+                    'negate' => false,
+                    'token' => '',
+                    'etag' => $etag,
+                ];
+            } else {
+                $tokenEntries[] = [
+                    'negate' => $negate,
+                    'token' => $token,
+                    'etag' => $etag,
+                ];
+            }
+
             // If there was no uri specified in this match, and there were
             // already conditions parsed, we add the condition to the list of
             // conditions for the previous uri.
             if (!$match['uri'] && count($conditions)) {
-                $conditions[count($conditions) - 1]['tokens'][] = [
-                    'negate' => $match['not'] ? true : false,
-                    'token' => $match['token'],
-                    'etag' => isset($match['etag']) ? $match['etag'] : '',
-                ];
+                foreach ($tokenEntries as $entry) {
+                    $conditions[count($conditions) - 1]['tokens'][] = $entry;
+                }
             } else {
                 if (!$match['uri']) {
                     $realUri = $request->getPath();
@@ -1605,13 +1633,7 @@ class Server implements LoggerAwareInterface, EmitterInterface
 
                 $conditions[] = [
                     'uri' => $realUri,
-                    'tokens' => [
-                        [
-                            'negate' => $match['not'] ? true : false,
-                            'token' => $match['token'],
-                            'etag' => isset($match['etag']) ? $match['etag'] : '',
-                        ],
-                    ],
+                    'tokens' => $tokenEntries,
                 ];
             }
         }

--- a/tests/Sabre/DAV/GetIfConditionsTest.php
+++ b/tests/Sabre/DAV/GetIfConditionsTest.php
@@ -232,6 +232,67 @@ class GetIfConditionsTest extends AbstractServerTestCase
         self::assertEquals($compare, $conditions);
     }
 
+    public function testNotWithTokenAndEtag()
+    {
+        // Per RFC 4918, (Not <token> [etag]) means: NOT token AND etag
+        // The Not applies only to the token, not the etag.
+        $request = new HTTP\Request('GET', '/foo', [
+            'If' => '(Not <DAV:no-lock> ["c3d40b11121145ec31f5c1acc078b658"])',
+        ]);
+
+        $conditions = $this->server->getIfConditions($request);
+
+        $compare = [
+            [
+                'uri' => 'foo',
+                'tokens' => [
+                    [
+                        'negate' => true,
+                        'token' => 'DAV:no-lock',
+                        'etag' => '',
+                    ],
+                    [
+                        'negate' => false,
+                        'token' => '',
+                        'etag' => '"c3d40b11121145ec31f5c1acc078b658"',
+                    ],
+                ],
+            ],
+        ];
+
+        self::assertEquals($compare, $conditions);
+    }
+
+    public function testNotWithTokenAndEtagUrl()
+    {
+        // Same test but with a URI prefix
+        $request = new HTTP\Request('GET', '/foo', [
+            'If' => '<http://www.example.org/> (Not <DAV:no-lock> ["etag1"])',
+        ]);
+
+        $conditions = $this->server->getIfConditions($request);
+
+        $compare = [
+            [
+                'uri' => '',
+                'tokens' => [
+                    [
+                        'negate' => true,
+                        'token' => 'DAV:no-lock',
+                        'etag' => '',
+                    ],
+                    [
+                        'negate' => false,
+                        'token' => '',
+                        'etag' => '"etag1"',
+                    ],
+                ],
+            ],
+        ];
+
+        self::assertEquals($compare, $conditions);
+    }
+
     public function testComplexIf()
     {
         $request = new HTTP\Request('GET', '/foo', [


### PR DESCRIPTION
## Description

Fixes the WebDAV `If` header parser so that `Not` is applied independently to the token and etag, rather than to the entire `(token etag)` group.

**The Bug:** When the `If` header contains `(Not <lock-token> ["etag"])`, the current code applies `Not` to both the token AND the etag together. This means the condition is evaluated as `NOT (token AND etag)` — it passes if either the token OR etag doesn't match.

**The Fix:** Per RFC 4918, `Not` applies only to the immediately following resource. `(Not <lock-token> ["etag"])` should mean `NOT <lock-token> AND ["etag"]`. The fix splits the token and etag into separate condition entries when both are present with a `Not` prefix, so each has its own negation flag.

This fixes the litmus test `locks:20` (`fail_complex_cond_put`) which was returning `204 No Content` instead of `412 Precondition Failed`.

## Changes

- **`lib/DAV/Server.php`**: Modified `getIfConditions()` to split token+etag into separate entries when `Not` is present, applying negation only to the token
- **`tests/Sabre/DAV/GetIfConditionsTest.php`**: Added two new test cases:
  - `testNotWithTokenAndEtag` — tests `(Not <token> ["etag"])` parsing
  - `testNotWithTokenAndEtagUrl` — same with a URI prefix

## Testing

All 12 tests in `GetIfConditionsTest` pass, including existing tests (backward compatibility) and the new regression tests.

Fixes #715
Related to #702