### PR TITLE
fix(CalDAV/Backend/PDO): bind transparent as int in updateCalendar

### DIFF
--- a/lib/CalDAV/Backend/PDO.php
+++ b/lib/CalDAV/Backend/PDO.php
@@ -306,7 +306,7 @@ SQL
                 switch ($propertyName) {
                     case '{'.CalDAV\Plugin::NS_CALDAV.'}schedule-calendar-transp':
                         $fieldName = 'transparent';
-                        $newValues[$fieldName] = 'transparent' === $propertyValue->getValue();
+                        $newValues[$fieldName] = 'transparent' === $propertyValue->getValue() ? 1 : 0;
                         break;
                     default:
                         $fieldName = $this->propertyMap[$propertyName];

--- a/tests/Sabre/CalDAV/Backend/AbstractPDOTestCase.php
+++ b/tests/Sabre/CalDAV/Backend/AbstractPDOTestCase.php
@@ -123,6 +123,22 @@ abstract class AbstractPDOTestCase extends TestCase
             self::assertArrayHasKey($name, $calendars[0]);
             self::assertEquals($value, $calendars[0][$name]);
         }
+
+        // Round-trip the other direction. Regression: prior to the fix,
+        // the pgsql PDO driver rejected this with
+        //   SQLSTATE[22P02]: invalid input syntax for type smallint: ""
+        // because updateCalendar bound a PHP bool (false) instead of int 0.
+        $propPatch = new PropPatch([
+            '{urn:ietf:params:xml:ns:caldav}schedule-calendar-transp' => new CalDAV\Xml\Property\ScheduleCalendarTransp('opaque'),
+        ]);
+        $backend->updateCalendar($newId, $propPatch);
+        self::assertTrue($propPatch->commit());
+
+        $calendars = $backend->getCalendarsForUser('principals/user2');
+        self::assertEquals(
+            new CalDAV\Xml\Property\ScheduleCalendarTransp('opaque'),
+            $calendars[0]['{urn:ietf:params:xml:ns:caldav}schedule-calendar-transp']
+        );
     }
 
     /**


### PR DESCRIPTION
`updateCalendar` stored the `transparent` field as a PHP boolean, which the pgsql PDO driver serializes as the empty string `''` when the value is `false`. The `transparent SMALLINT NOT NULL` column then rejects the parameter with SQLSTATE 22P02.

This looks like a follow-up, 10 years later (!), of #816 :-)