### PR TITLE
Allow passing calendar-user-type value from PrincipalBackend.

### DIFF
--- a/lib/CalDAV/Schedule/Plugin.php
+++ b/lib/CalDAV/Schedule/Plugin.php
@@ -257,9 +257,12 @@ class Plugin extends ServerPlugin
                 }
             });
 
-            // The server currently reports every principal to be of type
-            // 'INDIVIDUAL'
-            $propFind->handle('{'.self::NS_CALDAV.'}calendar-user-type', function () {
+            $propFind->handle('{'.self::NS_CALDAV.'}calendar-user-type', function () use ($node) {
+                $propertyName = '{'.self::NS_CALDAV.'}calendar-user-type';
+                $type = $node->getProperties([$propertyName]);
+                if(!empty($type[$propertyName])) {
+                    return $type[$propertyName];
+                }
                 return 'INDIVIDUAL';
             });
         }


### PR DESCRIPTION
Enhanced principal calendar-user-type property handle to allow passing a value from the PrincipalBackend instead of always default as INDIVIDUAL allowed values are RESOURCE, ROOM, GROUP and INDIVIDUAL