### PR TITLE
Return HTTP 403 instead of 500 on NoInstancesException

### DIFF
--- a/lib/CalDAV/Backend/PDO.php
+++ b/lib/CalDAV/Backend/PDO.php
@@ -661,7 +661,11 @@ SQL
                     $lastOccurence = $firstOccurence;
                 }
             } else {
-                $it = new VObject\Recur\EventIterator($vObject, (string) $component->UID);
+                try {
+                    $it = new VObject\Recur\EventIterator($vObject, (string) $component->UID);
+                } catch (VObject\Recur\NoInstancesException $e) {
+                    throw new Forbidden($e->getMessage());
+                }
                 $maxDate = new \DateTime(self::MAX_DATE);
                 if ($it->isInfinite()) {
                     $lastOccurence = $maxDate->getTimeStamp();


### PR DESCRIPTION
Partially mitigates issues caused by sabre/dav not accepting recurrence events without any instances (which technically doesn't satisfy RFC 5545, but is an understandable compromise).

This fix is essentially equal to the fix applied in Nextcloud https://github.com/nextcloud/server/pull/46593
Concerns with HTTP 500 are best explained by https://github.com/nextcloud/server/issues/30514#issuecomment-2223552202
