### PR TITLE
chore: bump tool versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "ext-sqlite3": "*",
         "friendsofphp/php-cs-fixer": "^2.19",
         "monolog/monolog": "^2.9",
-        "phpstan/phpstan": "^2.1",
+        "phpstan/phpstan": "^2.2",
         "phpstan/phpstan-phpunit": "^2.0",
         "phpunit/phpunit": "^9.6"
     },


### PR DESCRIPTION
to record the actual latest minor releases that are in use in practice in CI.

Also, I want to confirm that CI passes with the versions of `event` and `vobject` that were released in the last days.