### PR TITLE
[4.7] docs(caldav): fix RFC section for calendar query report

### DIFF
--- a/lib/CalDAV/Xml/Request/CalendarQueryReport.php
+++ b/lib/CalDAV/Xml/Request/CalendarQueryReport.php
@@ -15,7 +15,7 @@ use Sabre\Xml\XmlDeserializable;
  * This class parses the {urn:ietf:params:xml:ns:caldav}calendar-query
  * REPORT, as defined in:
  *
- * https://tools.ietf.org/html/rfc4791#section-7.9
+ * https://tools.ietf.org/html/rfc4791#section-7.8
  *
  * @copyright Copyright (C) fruux GmbH (https://fruux.com/)
  * @author Evert Pot (http://www.rooftopsolutions.nl/)


### PR DESCRIPTION
Backport #1598 to 4.7