### PR TITLE
[4.7] fix: Handle Depth header for COPY as this is required by RFC

### DIFF
--- a/lib/DAV/CorePlugin.php
+++ b/lib/DAV/CorePlugin.php
@@ -650,7 +650,7 @@ class CorePlugin extends ServerPlugin
         if (!$this->server->emit('beforeBind', [$copyInfo['destination']])) {
             return false;
         }
-        if (!$this->server->emit('beforeCopy', [$path, $copyInfo['destination']])) {
+        if (!$this->server->emit('beforeCopy', [$path, $copyInfo['destination'], $copyInfo['depth']])) {
             return false;
         }
 
@@ -661,8 +661,8 @@ class CorePlugin extends ServerPlugin
             $this->server->tree->delete($copyInfo['destination']);
         }
 
-        $this->server->tree->copy($path, $copyInfo['destination']);
-        $this->server->emit('afterCopy', [$path, $copyInfo['destination']]);
+        $this->server->tree->copy($path, $copyInfo['destination'], $copyInfo['depth']);
+        $this->server->emit('afterCopy', [$path, $copyInfo['destination'], $copyInfo['depth']]);
         $this->server->emit('afterBind', [$copyInfo['destination']]);
 
         // If a resource was overwritten we should send a 204, otherwise a 201

--- a/lib/DAV/CorePlugin.php
+++ b/lib/DAV/CorePlugin.php
@@ -590,7 +590,7 @@ class CorePlugin extends ServerPlugin
         $moveInfo = $this->server->getCopyAndMoveInfo($request);
 
         // MOVE does only allow "infinity" every other header value is considered invalid
-        if ('infinity' !== $moveInfo['depth']) {
+        if (Server::DEPTH_INFINITY !== $moveInfo['depth']) {
             throw new BadRequest('The HTTP Depth header must only contain "infinity" for MOVE');
         }
 

--- a/lib/DAV/CorePlugin.php
+++ b/lib/DAV/CorePlugin.php
@@ -589,6 +589,11 @@ class CorePlugin extends ServerPlugin
 
         $moveInfo = $this->server->getCopyAndMoveInfo($request);
 
+        // MOVE does only allow "infinity" every other header value is considered invalid
+        if ($moveInfo['depth'] !== 'infinity') {
+            throw new BadRequest('The HTTP Depth header must only contain "infinity" for MOVE');
+        }
+
         if ($moveInfo['destinationExists']) {
             if (!$this->server->emit('beforeUnbind', [$moveInfo['destination']])) {
                 return false;

--- a/lib/DAV/CorePlugin.php
+++ b/lib/DAV/CorePlugin.php
@@ -590,7 +590,7 @@ class CorePlugin extends ServerPlugin
         $moveInfo = $this->server->getCopyAndMoveInfo($request);
 
         // MOVE does only allow "infinity" every other header value is considered invalid
-        if ($moveInfo['depth'] !== 'infinity') {
+        if ('infinity' !== $moveInfo['depth']) {
             throw new BadRequest('The HTTP Depth header must only contain "infinity" for MOVE');
         }
 

--- a/lib/DAV/ICopyTarget.php
+++ b/lib/DAV/ICopyTarget.php
@@ -28,12 +28,12 @@ interface ICopyTarget extends ICollection
      * is that the copy was successful.
      * If you return false, sabre/dav will handle the copy itself.
      *
-     * @param string $targetName new local file/collection name
-     * @param string $sourcePath Full path to source node
-     * @param INode  $sourceNode Source node itself
-     * @param string|int $depth How many level of children to copy.
-     *                          The value can be 'infinity' or a positiv number including zero.
-     *                          Zero means to only copy a shallow collection with props but without children.
+     * @param string     $targetName new local file/collection name
+     * @param string     $sourcePath Full path to source node
+     * @param INode      $sourceNode Source node itself
+     * @param string|int $depth      How many level of children to copy.
+     *                               The value can be 'infinity' or a positiv number including zero.
+     *                               Zero means to only copy a shallow collection with props but without children.
      *
      * @return bool
      */

--- a/lib/DAV/ICopyTarget.php
+++ b/lib/DAV/ICopyTarget.php
@@ -28,14 +28,14 @@ interface ICopyTarget extends ICollection
      * is that the copy was successful.
      * If you return false, sabre/dav will handle the copy itself.
      *
-     * @param string     $targetName new local file/collection name
-     * @param string     $sourcePath Full path to source node
-     * @param INode      $sourceNode Source node itself
-     * @param string|int $depth      How many level of children to copy.
-     *                               The value can be 'infinity' or a positiv number including zero.
-     *                               Zero means to only copy a shallow collection with props but without children.
+     * @param string $targetName new local file/collection name
+     * @param string $sourcePath Full path to source node
+     * @param INode  $sourceNode Source node itself
+     * @param int    $depth      How many level of children to copy.
+     *                           The value can be 'infinity' (Sabre\DAV\Server::DEPTH_INFINITY) or a positive number including zero.
+     *                           Zero means to only copy a shallow collection with props but without children.
      *
      * @return bool
      */
-    public function copyInto($targetName, $sourcePath, INode $sourceNode, $depth);
+    public function copyInto($targetName, $sourcePath, INode $sourceNode, int $depth);
 }

--- a/lib/DAV/ICopyTarget.php
+++ b/lib/DAV/ICopyTarget.php
@@ -31,8 +31,11 @@ interface ICopyTarget extends ICollection
      * @param string $targetName new local file/collection name
      * @param string $sourcePath Full path to source node
      * @param INode  $sourceNode Source node itself
+     * @param string|int $depth How many level of children to copy.
+     *                          The value can be 'infinity' or a positiv number including zero.
+     *                          Zero means to only copy a shallow collection with props but without children.
      *
      * @return bool
      */
-    public function copyInto($targetName, $sourcePath, INode $sourceNode);
+    public function copyInto($targetName, $sourcePath, INode $sourceNode, $depth);
 }

--- a/lib/DAV/Server.php
+++ b/lib/DAV/Server.php
@@ -728,10 +728,10 @@ class Server implements LoggerAwareInterface, EmitterInterface
 
         // Depth of inifinty is valid for MOVE and COPY. If it is not set the RFC requires to act like it was 'infinity'.
         $depth = strtolower($request->getHeader('Depth') ?? 'infinity');
-        if ($depth !== 'infinity' && is_numeric($depth)) {
-            $depth = (int)$depth;
+        if ('infinity' !== $depth && is_numeric($depth)) {
+            $depth = (int) $depth;
             if ($depth < 0) {
-                throw new Exception\BadRequest('The HTTP Depth header may only be "infinity", 0 or a positiv number');
+                throw new Exception\BadRequest('The HTTP Depth header may only be "infinity", 0 or a positive number');
             }
         }
 

--- a/lib/DAV/Tree.php
+++ b/lib/DAV/Tree.php
@@ -135,11 +135,11 @@ class Tree implements INodeByPath
     /**
      * Copies a file from path to another.
      *
-     * @param string $sourcePath      The source location
-     * @param string $destinationPath The full destination path
-     * @param int|string $depth How much levle of children to copy.
-     *                          The value can be 'infinity' or a positiv integer, including zero.
-     *                          Zero means only copy the collection without children but with its properties.
+     * @param string     $sourcePath      The source location
+     * @param string     $destinationPath The full destination path
+     * @param int|string $depth           How much levle of children to copy.
+     *                                    The value can be 'infinity' or a positiv integer, including zero.
+     *                                    Zero means only copy the collection without children but with its properties.
      */
     public function copy($sourcePath, $destinationPath, $depth = 'infinity')
     {
@@ -310,8 +310,8 @@ class Tree implements INodeByPath
     /**
      * copyNode.
      *
-     * @param string $destinationName
-     * @param int|string $depth How many children of the node to copy
+     * @param string     $destinationName
+     * @param int|string $depth           How many children of the node to copy
      */
     protected function copyNode(INode $source, ICollection $destinationParent, ?string $destinationName = null, $depth = 'infinity')
     {
@@ -338,9 +338,9 @@ class Tree implements INodeByPath
             $destination = $destinationParent->getChild($destinationName);
 
             // Copy children if depth is not zero
-            if ($depth !== 0) {
+            if (0 !== $depth) {
                 // Adjust next depth for children (keep 'infinity' or decrease)
-                $depth = $depth === 'infinity' ? 'infinity' : $depth - 1;
+                $depth = 'infinity' === $depth ? 'infinity' : $depth - 1;
                 $destination = $destinationParent->getChild($destinationName);
                 foreach ($source->getChildren() as $child) {
                     $this->copyNode($child, $destination, null, $depth);

--- a/lib/DAV/Tree.php
+++ b/lib/DAV/Tree.php
@@ -137,8 +137,11 @@ class Tree implements INodeByPath
      *
      * @param string $sourcePath      The source location
      * @param string $destinationPath The full destination path
+     * @param int|string $depth How much levle of children to copy.
+     *                          The value can be 'infinity' or a positiv integer, including zero.
+     *                          Zero means only copy the collection without children but with its properties.
      */
-    public function copy($sourcePath, $destinationPath)
+    public function copy($sourcePath, $destinationPath, $depth = 'infinity')
     {
         $sourceNode = $this->getNodeForPath($sourcePath);
 
@@ -147,8 +150,8 @@ class Tree implements INodeByPath
 
         $destinationParent = $this->getNodeForPath($destinationDir);
         // Check if the target can handle the copy itself. If not, we do it ourselves.
-        if (!$destinationParent instanceof ICopyTarget || !$destinationParent->copyInto($destinationName, $sourcePath, $sourceNode)) {
-            $this->copyNode($sourceNode, $destinationParent, $destinationName);
+        if (!$destinationParent instanceof ICopyTarget || !$destinationParent->copyInto($destinationName, $sourcePath, $sourceNode, $depth)) {
+            $this->copyNode($sourceNode, $destinationParent, $destinationName, $depth);
         }
 
         $this->markDirty($destinationDir);
@@ -178,7 +181,8 @@ class Tree implements INodeByPath
                 $moveSuccess = $newParentNode->moveInto($destinationName, $sourcePath, $sourceNode);
             }
             if (!$moveSuccess) {
-                $this->copy($sourcePath, $destinationPath);
+                // Move is a copy with depth = infinity and deleting the source afterwards
+                $this->copy($sourcePath, $destinationPath, 'infinity');
                 $this->getNodeForPath($sourcePath)->delete();
             }
         }
@@ -215,9 +219,13 @@ class Tree implements INodeByPath
             $basePath .= '/';
         }
 
-        foreach ($node->getChildren() as $child) {
-            $this->cache[$basePath.$child->getName()] = $child;
-            yield $child;
+        if ($node instanceof ICollection) {
+            foreach ($node->getChildren() as $child) {
+                $this->cache[$basePath.$child->getName()] = $child;
+                yield $child;
+            }
+        } else {
+            yield from [];
         }
     }
 
@@ -303,8 +311,9 @@ class Tree implements INodeByPath
      * copyNode.
      *
      * @param string $destinationName
+     * @param int|string $depth How many children of the node to copy
      */
-    protected function copyNode(INode $source, ICollection $destinationParent, $destinationName = null)
+    protected function copyNode(INode $source, ICollection $destinationParent, ?string $destinationName = null, $depth = 'infinity')
     {
         if ('' === (string) $destinationName) {
             $destinationName = $source->getName();
@@ -326,10 +335,16 @@ class Tree implements INodeByPath
             $destination = $destinationParent->getChild($destinationName);
         } elseif ($source instanceof ICollection) {
             $destinationParent->createDirectory($destinationName);
-
             $destination = $destinationParent->getChild($destinationName);
-            foreach ($source->getChildren() as $child) {
-                $this->copyNode($child, $destination);
+
+            // Copy children if depth is not zero
+            if ($depth !== 0) {
+                // Adjust next depth for children (keep 'infinity' or decrease)
+                $depth = $depth === 'infinity' ? 'infinity' : $depth - 1;
+                $destination = $destinationParent->getChild($destinationName);
+                foreach ($source->getChildren() as $child) {
+                    $this->copyNode($child, $destination, null, $depth);
+                }
             }
         }
         if ($source instanceof IProperties && $destination instanceof IProperties) {

--- a/lib/DAV/Tree.php
+++ b/lib/DAV/Tree.php
@@ -135,13 +135,13 @@ class Tree implements INodeByPath
     /**
      * Copies a file from path to another.
      *
-     * @param string     $sourcePath      The source location
-     * @param string     $destinationPath The full destination path
-     * @param int|string $depth           How much levle of children to copy.
-     *                                    The value can be 'infinity' or a positiv integer, including zero.
-     *                                    Zero means only copy the collection without children but with its properties.
+     * @param string $sourcePath      The source location
+     * @param string $destinationPath The full destination path
+     * @param int    $depth           How many levels of children to copy.
+     *                                The value can be 'infinity' (\Sabre\DAV\Server::DEPTH_INFINITY) or a positive integer, including zero.
+     *                                Zero means only copy the collection without children but with its properties.
      */
-    public function copy($sourcePath, $destinationPath, $depth = 'infinity')
+    public function copy($sourcePath, $destinationPath, int $depth = Server::DEPTH_INFINITY)
     {
         $sourceNode = $this->getNodeForPath($sourcePath);
 
@@ -182,7 +182,7 @@ class Tree implements INodeByPath
             }
             if (!$moveSuccess) {
                 // Move is a copy with depth = infinity and deleting the source afterwards
-                $this->copy($sourcePath, $destinationPath, 'infinity');
+                $this->copy($sourcePath, $destinationPath, Server::DEPTH_INFINITY);
                 $this->getNodeForPath($sourcePath)->delete();
             }
         }
@@ -310,10 +310,10 @@ class Tree implements INodeByPath
     /**
      * copyNode.
      *
-     * @param string     $destinationName
-     * @param int|string $depth           How many children of the node to copy
+     * @param string $destinationName
+     * @param int    $depth           How many children of the node to copy
      */
-    protected function copyNode(INode $source, ICollection $destinationParent, ?string $destinationName = null, $depth = 'infinity')
+    protected function copyNode(INode $source, ICollection $destinationParent, ?string $destinationName = null, int $depth = Server::DEPTH_INFINITY)
     {
         if ('' === (string) $destinationName) {
             $destinationName = $source->getName();
@@ -340,7 +340,7 @@ class Tree implements INodeByPath
             // Copy children if depth is not zero
             if (0 !== $depth) {
                 // Adjust next depth for children (keep 'infinity' or decrease)
-                $depth = 'infinity' === $depth ? 'infinity' : $depth - 1;
+                $depth = Server::DEPTH_INFINITY === $depth ? Server::DEPTH_INFINITY : $depth - 1;
                 $destination = $destinationParent->getChild($destinationName);
                 foreach ($source->getChildren() as $child) {
                     $this->copyNode($child, $destination, null, $depth);

--- a/tests/Sabre/DAV/CorePluginTest.php
+++ b/tests/Sabre/DAV/CorePluginTest.php
@@ -4,11 +4,61 @@ declare(strict_types=1);
 
 namespace Sabre\DAV;
 
+use PHPUnit\Framework\MockObject\MockObject;
+use Sabre\DAV\Exception\BadRequest;
+use Sabre\HTTP;
+
 class CorePluginTest extends \PHPUnit\Framework\TestCase
 {
     public function testGetInfo()
     {
         $corePlugin = new CorePlugin();
         self::assertEquals('core', $corePlugin->getPluginInfo()['name']);
+    }
+
+    public function moveInvalidDepthHeaderProvider() {
+        return [
+            [0],
+            [1],
+        ];
+    }
+
+    /**
+     * MOVE does only allow "infinity" every other header value is considered invalid
+     * @dataProvider moveInvalidDepthHeaderProvider
+     */
+    public function testMoveWithInvalidDepth($depthHeader) {
+        $request = new HTTP\Request('MOVE', '/path/');
+        $response = new HTTP\Response();
+
+        /** @var Server|MockObject */
+        $server = $this->getMockBuilder(Server::class)->getMock();
+        $corePlugin = new CorePlugin();
+        $corePlugin->initialize($server);
+
+        $server->expects($this->once())
+            ->method('getCopyAndMoveInfo')
+            ->willReturn(['depth' => $depthHeader]);
+
+        $this->expectException(BadRequest::class);
+        $corePlugin->httpMove($request, $response);
+    }
+
+    /**
+     * MOVE does only allow "infinity" every other header value is considered invalid
+     */
+    public function testMoveSupportsDepth() {
+        $request = new HTTP\Request('MOVE', '/path/');
+        $response = new HTTP\Response();
+
+        /** @var Server|MockObject */
+        $server = $this->getMockBuilder(Server::class)->getMock();
+        $corePlugin = new CorePlugin();
+        $corePlugin->initialize($server);
+
+        $server->expects($this->once())
+            ->method('getCopyAndMoveInfo')
+            ->willReturn(['depth' => 'infinity', 'destinationExists' => true, 'destination' => 'dst']);
+        $corePlugin->httpMove($request, $response);
     }
 }

--- a/tests/Sabre/DAV/CorePluginTest.php
+++ b/tests/Sabre/DAV/CorePluginTest.php
@@ -16,7 +16,8 @@ class CorePluginTest extends \PHPUnit\Framework\TestCase
         self::assertEquals('core', $corePlugin->getPluginInfo()['name']);
     }
 
-    public function moveInvalidDepthHeaderProvider() {
+    public function moveInvalidDepthHeaderProvider()
+    {
         return [
             [0],
             [1],
@@ -24,10 +25,12 @@ class CorePluginTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * MOVE does only allow "infinity" every other header value is considered invalid
+     * MOVE does only allow "infinity" every other header value is considered invalid.
+     *
      * @dataProvider moveInvalidDepthHeaderProvider
      */
-    public function testMoveWithInvalidDepth($depthHeader) {
+    public function testMoveWithInvalidDepth($depthHeader)
+    {
         $request = new HTTP\Request('MOVE', '/path/');
         $response = new HTTP\Response();
 
@@ -45,9 +48,10 @@ class CorePluginTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * MOVE does only allow "infinity" every other header value is considered invalid
+     * MOVE does only allow "infinity" every other header value is considered invalid.
      */
-    public function testMoveSupportsDepth() {
+    public function testMoveSupportsDepth()
+    {
         $request = new HTTP\Request('MOVE', '/path/');
         $response = new HTTP\Response();
 

--- a/tests/Sabre/DAV/CorePluginTest.php
+++ b/tests/Sabre/DAV/CorePluginTest.php
@@ -62,7 +62,7 @@ class CorePluginTest extends \PHPUnit\Framework\TestCase
 
         $server->expects($this->once())
             ->method('getCopyAndMoveInfo')
-            ->willReturn(['depth' => 'infinity', 'destinationExists' => true, 'destination' => 'dst']);
+            ->willReturn(['depth' => Server::DEPTH_INFINITY, 'destinationExists' => true, 'destination' => 'dst']);
         $corePlugin->httpMove($request, $response);
     }
 }

--- a/tests/Sabre/DAV/FSExt/ServerTest.php
+++ b/tests/Sabre/DAV/FSExt/ServerTest.php
@@ -234,7 +234,10 @@ class ServerTest extends DAV\AbstractServer
     {
         mkdir($this->tempDir.'/testcol');
 
-        $request = new HTTP\Request('COPY', '/test.txt', ['Destination' => '/testcol/test2.txt']);
+        $request = new HTTP\Request('COPY', '/test.txt', [
+            'Destination' => '/testcol/test2.txt',
+            'Depth' => 'infinity',
+        ]);
         $this->server->httpRequest = ($request);
         $this->server->exec();
 

--- a/tests/Sabre/DAV/HttpCopyTest.php
+++ b/tests/Sabre/DAV/HttpCopyTest.php
@@ -21,13 +21,21 @@ class HttpCopyTest extends DAVServerTest
      */
     public function setUpTree()
     {
-        $this->tree = new Mock\Collection('root', [
+        $propsCollection = new Mock\PropertiesCollection('propscoll', [
+            'file3' => 'content3',
+            'file4' => 'content4',
+        ], [
+            'my-prop' => 'my-value',
+        ]);
+        $propsCollection->failMode = 'updatepropstrue';
+        $this->tree = new Mock\PropertiesCollection('root', [
             'file1' => 'content1',
             'file2' => 'content2',
-            'coll1' => [
+            'coll1' => new Mock\Collection('coll1', [
                 'file3' => 'content3',
                 'file4' => 'content4',
-            ],
+            ]),
+            'propscoll' => $propsCollection,
         ]);
     }
 
@@ -35,6 +43,7 @@ class HttpCopyTest extends DAVServerTest
     {
         $request = new HTTP\Request('COPY', '/file1', [
             'Destination' => '/file5',
+            'Depth' => 'infinity',
         ]);
         $response = $this->request($request);
         self::assertEquals(201, $response->getStatus());
@@ -54,6 +63,7 @@ class HttpCopyTest extends DAVServerTest
     {
         $request = new HTTP\Request('COPY', '/file1', [
             'Destination' => '/file2',
+            'Depth' => 'infinity',
         ]);
         $response = $this->request($request);
         self::assertEquals(204, $response->getStatus());
@@ -64,6 +74,7 @@ class HttpCopyTest extends DAVServerTest
     {
         $request = new HTTP\Request('COPY', '/file1', [
             'Destination' => '/file2',
+            'Depth' => 'infinity',
             'Overwrite' => 'T',
         ]);
         $response = $this->request($request);
@@ -75,6 +86,7 @@ class HttpCopyTest extends DAVServerTest
     {
         $request = new HTTP\Request('COPY', '/file1', [
             'Destination' => '/file2',
+            'Depth' => 'infinity',
             'Overwrite' => 'B',
         ]);
         $response = $this->request($request);
@@ -85,6 +97,7 @@ class HttpCopyTest extends DAVServerTest
     {
         $request = new HTTP\Request('COPY', '/file1', [
             'Destination' => '/notfound/file2',
+            'Depth' => 'infinity',
         ]);
         $response = $this->request($request);
         self::assertEquals(409, $response->getStatus());
@@ -94,6 +107,7 @@ class HttpCopyTest extends DAVServerTest
     {
         $request = new HTTP\Request('COPY', '/file1', [
             'Destination' => '/file2',
+            'Depth' => 'infinity',
             'Overwrite' => 'F',
         ]);
         $response = $this->request($request);
@@ -110,6 +124,7 @@ class HttpCopyTest extends DAVServerTest
         });
         $request = new HTTP\Request('COPY', '/file1', [
             'Destination' => '/file2',
+            'Depth' => 'infinity',
             'Overwrite' => 'T',
         ]);
         $response = $this->request($request);
@@ -122,16 +137,39 @@ class HttpCopyTest extends DAVServerTest
     {
         $request = new HTTP\Request('COPY', '/coll1', [
             'Destination' => '/coll2',
+            'Depth' => 'infinity',
         ]);
         $response = $this->request($request);
         self::assertEquals(201, $response->getStatus());
         self::assertEquals('content3', $this->tree->getChild('coll2')->getChild('file3')->get());
     }
 
+    public function testShallowCopyColl()
+    {
+        // Ensure proppatches are applied
+        $this->tree->failMode = 'updatepropstrue';
+        $request = new HTTP\Request('COPY', '/propscoll', [
+            'Destination' => '/shallow-coll',
+            'Depth' => '0',
+        ]);
+        $response = $this->request($request);
+        // reset
+        $this->tree->failMode = false;
+
+        self::assertEquals(201, $response->getStatus());
+        // The copied collection exists
+        self::assertEquals(true, $this->tree->childExists('shallow-coll'));
+        // But it does not contain children
+        self::assertEquals([], $this->tree->getChild('shallow-coll')->getChildren());
+        // But the properties are preserved
+        self::assertEquals(['my-prop' => 'my-value'], $this->tree->getChild('shallow-coll')->getProperties([]));
+    }
+
     public function testCopyCollToSelf()
     {
         $request = new HTTP\Request('COPY', '/coll1', [
             'Destination' => '/coll1',
+            'Depth' => 'infinity',
         ]);
         $response = $this->request($request);
         self::assertEquals(403, $response->getStatus());
@@ -141,6 +179,7 @@ class HttpCopyTest extends DAVServerTest
     {
         $request = new HTTP\Request('COPY', '/coll1', [
             'Destination' => '/file2',
+            'Depth' => 'infinity',
         ]);
         $response = $this->request($request);
         self::assertEquals(204, $response->getStatus());
@@ -151,6 +190,7 @@ class HttpCopyTest extends DAVServerTest
     {
         $request = new HTTP\Request('COPY', '/coll1', [
             'Destination' => '/file2',
+            'Depth' => 'infinity',
             'Overwrite' => 'T',
         ]);
         $response = $this->request($request);
@@ -162,6 +202,7 @@ class HttpCopyTest extends DAVServerTest
     {
         $request = new HTTP\Request('COPY', '/coll1', [
             'Destination' => '/file2',
+            'Depth' => 'infinity',
             'Overwrite' => 'F',
         ]);
         $response = $this->request($request);
@@ -173,6 +214,7 @@ class HttpCopyTest extends DAVServerTest
     {
         $request = new HTTP\Request('COPY', '/coll1', [
             'Destination' => '/coll1/subcol',
+            'Depth' => 'infinity',
         ]);
         $response = $this->request($request);
         self::assertEquals(409, $response->getStatus());

--- a/tests/Sabre/DAV/Locks/PluginTest.php
+++ b/tests/Sabre/DAV/Locks/PluginTest.php
@@ -585,6 +585,7 @@ class PluginTest extends DAV\AbstractServer
 
         $request = new HTTP\Request('COPY', '/dir/child.txt', [
             'Destination' => '/dir/child2.txt',
+            'Depth' => 'infinity',
         ]);
 
         $this->server->httpRequest = $request;
@@ -619,6 +620,7 @@ class PluginTest extends DAV\AbstractServer
 
         $request = new HTTP\Request('COPY', '/dir/child.txt', [
             'Destination' => '/dir/child2.txt',
+            'Depth' => 'infinity',
         ]);
         $this->server->httpRequest = $request;
         $this->server->exec();

--- a/tests/Sabre/DAV/Mock/Collection.php
+++ b/tests/Sabre/DAV/Mock/Collection.php
@@ -118,7 +118,7 @@ class Collection extends DAV\Collection
      */
     public function getChildren()
     {
-        return $this->children;
+        return $this->children ?? [];
     }
 
     /**

--- a/tests/Sabre/DAV/Mock/PropertiesCollection.php
+++ b/tests/Sabre/DAV/Mock/PropertiesCollection.php
@@ -49,6 +49,7 @@ class PropertiesCollection extends Collection implements IProperties
                     foreach ($updateProperties as $k => $v) {
                         $this->properties[$k] = $v;
                     }
+
                     return true;
                 case 'updatepropsarray':
                     $r = [];
@@ -81,7 +82,7 @@ class PropertiesCollection extends Collection implements IProperties
      */
     public function getProperties($requestedProperties)
     {
-        if (count($requestedProperties) === 0) {
+        if (0 === count($requestedProperties)) {
             return $this->properties;
         }
 
@@ -97,7 +98,7 @@ class PropertiesCollection extends Collection implements IProperties
     }
 
     /**
-     * Creates a new subdirectory. (Override to ensure props are preserved)
+     * Creates a new subdirectory. (Override to ensure props are preserved).
      *
      * @param string $name
      */

--- a/tests/Sabre/DAV/Mock/PropertiesCollection.php
+++ b/tests/Sabre/DAV/Mock/PropertiesCollection.php
@@ -45,6 +45,11 @@ class PropertiesCollection extends Collection implements IProperties
         $proppatch->handleRemaining(function ($updateProperties) {
             switch ($this->failMode) {
                 case 'updatepropsfalse': return false;
+                case 'updatepropstrue':
+                    foreach ($updateProperties as $k => $v) {
+                        $this->properties[$k] = $v;
+                    }
+                    return true;
                 case 'updatepropsarray':
                     $r = [];
                     foreach ($updateProperties as $k => $v) {
@@ -76,6 +81,10 @@ class PropertiesCollection extends Collection implements IProperties
      */
     public function getProperties($requestedProperties)
     {
+        if (count($requestedProperties) === 0) {
+            return $this->properties;
+        }
+
         $returnedProperties = [];
         foreach ($requestedProperties as $requestedProperty) {
             if (isset($this->properties[$requestedProperty])) {
@@ -85,5 +94,18 @@ class PropertiesCollection extends Collection implements IProperties
         }
 
         return $returnedProperties;
+    }
+
+    /**
+     * Creates a new subdirectory. (Override to ensure props are preserved)
+     *
+     * @param string $name
+     */
+    public function createDirectory($name)
+    {
+        $child = new self($name, []);
+        // keep same setting
+        $child->failMode = $this->failMode;
+        $this->children[] = $child;
     }
 }

--- a/tests/Sabre/DAV/ServerCopyMoveTest.php
+++ b/tests/Sabre/DAV/ServerCopyMoveTest.php
@@ -7,21 +7,23 @@ namespace Sabre\DAV;
 use Sabre\DAV\Exception\BadRequest;
 use Sabre\HTTP;
 
-class ServerCopyMoveTest extends AbstractServer
+class ServerCopyMoveTest extends AbstractServerTestCase
 {
     /**
-     * Only 'infinity' and positiv (incl. 0) numbers are allowed
+     * Only 'infinity' and positive (incl. 0) numbers are allowed.
+     *
      * @dataProvider dataInvalidDepthHeader
      */
     public function testInvalidDepthHeader(?string $headerValue)
     {
-        $request = new HTTP\Request('COPY', '/', $headerValue !== null ? ['Depth' => $headerValue] : []);
+        $request = new HTTP\Request('COPY', '/', null !== $headerValue ? ['Depth' => $headerValue] : []);
 
         $this->expectException(BadRequest::class);
         $this->server->getCopyAndMoveInfo($request);
     }
 
-    public function dataInvalidDepthHeader() {
+    public function dataInvalidDepthHeader()
+    {
         return [
             ['-1'],
             ['0.5'],
@@ -31,17 +33,21 @@ class ServerCopyMoveTest extends AbstractServer
     }
 
     /**
-     * Only 'infinity' and positiv (incl. 0) numbers are allowed
+     * Only 'infinity' and positive (incl. 0) numbers are allowed.
+     *
      * @dataProvider dataDepthHeader
+     *
+     * @param string|int $expectedDepth
      */
-    public function testValidDepthHeader(array $depthHeader, string|int $expectedDepth)
+    public function testValidDepthHeader(array $depthHeader, $expectedDepth)
     {
         $request = new HTTP\Request('COPY', '/', array_merge(['Destination' => '/dst'], $depthHeader));
 
         $this->assertEquals($expectedDepth, $this->server->getCopyAndMoveInfo($request)['depth']);
     }
 
-    public function dataDepthHeader() {
+    public function dataDepthHeader()
+    {
         return [
             [
                 [],

--- a/tests/Sabre/DAV/ServerCopyMoveTest.php
+++ b/tests/Sabre/DAV/ServerCopyMoveTest.php
@@ -9,16 +9,33 @@ use Sabre\HTTP;
 
 class ServerCopyMoveTest extends AbstractServerTestCase
 {
+    public function testMissingDestinationHeader()
+    {
+        $request = new HTTP\Request('COPY', '/', ['Depth' => 'infinity']);
+
+        $this->expectException(BadRequest::class);
+        $this->expectExceptionMessage('The destination header was not supplied');
+        $this->server->getCopyAndMoveInfo($request);
+    }
+
+    public function testMissingDepthHeader()
+    {
+        $request = new HTTP\Request('COPY', '/', ['Destination' => '/destination']);
+
+        $this->assertEquals(Server::DEPTH_INFINITY, $this->server->getCopyAndMoveInfo($request)['depth']);
+    }
+
     /**
      * Only 'infinity' and positive (incl. 0) numbers are allowed.
      *
      * @dataProvider dataInvalidDepthHeader
      */
-    public function testInvalidDepthHeader(?string $headerValue)
+    public function testInvalidDepthHeader(string $headerValue)
     {
-        $request = new HTTP\Request('COPY', '/', null !== $headerValue ? ['Depth' => $headerValue] : []);
+        $request = new HTTP\Request('COPY', '/', ['Destination' => '/destination', 'Depth' => $headerValue]);
 
         $this->expectException(BadRequest::class);
+        $this->expectExceptionMessage('The HTTP Depth header may only be "infinity", 0 or a positive integer');
         $this->server->getCopyAndMoveInfo($request);
     }
 
@@ -51,15 +68,15 @@ class ServerCopyMoveTest extends AbstractServerTestCase
         return [
             [
                 [],
-                'infinity',
+                Server::DEPTH_INFINITY,
             ],
             [
                 ['Depth' => 'infinity'],
-                'infinity',
+                Server::DEPTH_INFINITY,
             ],
             [
                 ['Depth' => 'INFINITY'],
-                'infinity',
+                Server::DEPTH_INFINITY,
             ],
             [
                 ['Depth' => '0'],

--- a/tests/Sabre/DAV/ServerCopyMoveTest.php
+++ b/tests/Sabre/DAV/ServerCopyMoveTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sabre\DAV;
+
+use Sabre\DAV\Exception\BadRequest;
+use Sabre\HTTP;
+
+class ServerCopyMoveTest extends AbstractServer
+{
+    /**
+     * Only 'infinity' and positiv (incl. 0) numbers are allowed
+     * @dataProvider dataInvalidDepthHeader
+     */
+    public function testInvalidDepthHeader(?string $headerValue)
+    {
+        $request = new HTTP\Request('COPY', '/', $headerValue !== null ? ['Depth' => $headerValue] : []);
+
+        $this->expectException(BadRequest::class);
+        $this->server->getCopyAndMoveInfo($request);
+    }
+
+    public function dataInvalidDepthHeader() {
+        return [
+            ['-1'],
+            ['0.5'],
+            ['2f'],
+            ['inf'],
+        ];
+    }
+
+    /**
+     * Only 'infinity' and positiv (incl. 0) numbers are allowed
+     * @dataProvider dataDepthHeader
+     */
+    public function testValidDepthHeader(array $depthHeader, string|int $expectedDepth)
+    {
+        $request = new HTTP\Request('COPY', '/', array_merge(['Destination' => '/dst'], $depthHeader));
+
+        $this->assertEquals($expectedDepth, $this->server->getCopyAndMoveInfo($request)['depth']);
+    }
+
+    public function dataDepthHeader() {
+        return [
+            [
+                [],
+                'infinity',
+            ],
+            [
+                ['Depth' => 'infinity'],
+                'infinity',
+            ],
+            [
+                ['Depth' => 'INFINITY'],
+                'infinity',
+            ],
+            [
+                ['Depth' => '0'],
+                0,
+            ],
+            [
+                ['Depth' => '10'],
+                10,
+            ],
+        ];
+    }
+}

--- a/tests/Sabre/DAV/ServerCopyMoveTest.php
+++ b/tests/Sabre/DAV/ServerCopyMoveTest.php
@@ -7,7 +7,7 @@ namespace Sabre\DAV;
 use Sabre\DAV\Exception\BadRequest;
 use Sabre\HTTP;
 
-class ServerCopyMoveTest extends AbstractServerTestCase
+class ServerCopyMoveTest extends AbstractServer
 {
     public function testMissingDestinationHeader()
     {

--- a/tests/Sabre/DAV/ServerEventsTest.php
+++ b/tests/Sabre/DAV/ServerEventsTest.php
@@ -69,6 +69,7 @@ class ServerEventsTest extends AbstractServer
         $this->server->createFile($oldPath, 'body');
         $request = new HTTP\Request('COPY', $oldPath, [
             'Destination' => $newPath,
+            'Depth' => 'infinity',
         ]);
         $this->server->httpRequest = $request;
 


### PR DESCRIPTION
Backport #1495 