### PR TITLE
[4.7] Remove redundant getLocks() call on a lock refresh

### DIFF
--- a/lib/DAV/Locks/Plugin.php
+++ b/lib/DAV/Locks/Plugin.php
@@ -179,7 +179,6 @@ class Plugin extends DAV\ServerPlugin
             }
         } else {
             // Gonna check if this was a lock refresh.
-            $existingLocks = $this->getLocks($uri);
             $conditions = $this->server->getIfConditions($request);
             $found = null;
 


### PR DESCRIPTION
Backport #1604 to 4.7 branch.
