### PR TITLE
chore: prepare 4.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,20 @@
 ChangeLog
 =========
 
+4.7.1 (2026-07-07)
+-------------------------
+* #1561 Refactor ternary to elvis operator where possible (@ChristophWurst)
+* #1562 refactor: Change class strings to ::class constants (@ChristophWurst)
+* #1595 Check for instanceof INode instead of Node (@CarlSchwan)
+* #1598 docs(caldav): fix RFC section for calendar query report (@ChristophWurst)
+* #1495 fix: Handle Depth header for COPY as this is required by RFC (@provokateurin)
+* #1604 Remove redundant getLocks() call on a lock refresh (@alecpl)
+* #1610 No return from delete() according to INode::delete() (@alecpl)
+* #1612 Use Uri\Split() instead of basename() (@alecpl)
+* #1623 Fix PDO::PARAM_LOB binding for BYTEA columns in CalDAV and CardDAV (@sylvinus)
+* #1625 Fix error on a HEAD request with a Range header (@alecpl)
+* #1637 fix(CalDAV/Backend/PDO): bind transparent as int in updateCalendar (@sylvinus)
+
 4.7.0 (2024-10-29)
 -------------------------
 * #1074 Add event to allow inspecting and changing multipart responses (@icewind1991)

--- a/lib/DAV/Version.php
+++ b/lib/DAV/Version.php
@@ -16,5 +16,5 @@ class Version
     /**
      * Full version number.
      */
-    public const VERSION = '4.7.0';
+    public const VERSION = '4.7.1';
 }


### PR DESCRIPTION
I have backported all the fixes that were merged to `master` in the last >18 months since a release was done.

Doing this so that I can release all this code as a patch release for everyone who is currently using 4.7.0.

The 4.7 release supports from PHP 7.1 and up, and all these backports were easy - the code already worked on PHP 7.1 through 8.5.

IMO this will be the last release of this code stream. Next, I plan to release what is now in `master` as probably 4.8.0. That dropped support for the old PHP 7.1 7.2 7.3, and just supports 7.4 and up.

Then think about dropping more old PHP versions, and supporting only PHP 8.2 and up, like has been done in the other sabre repos.