### PR TITLE
ci: add PHP 8.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: [ '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5' ]
+        php-versions: [ '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5', '8.6' ]
         coverage: [ 'xdebug' ]
         streaming: [ false ]
         include:


### PR DESCRIPTION
leaving the other test matrices for PHP unchanged for now.

This is just a draft PR to check that CI passes. When PHP 8.6 gets to the RC stage, then I will make a real PR to add 8.6.