### PR TITLE
Return 204 status if no locks are present

### DIFF
--- a/lib/DAV/Locks/Plugin.php
+++ b/lib/DAV/Locks/Plugin.php
@@ -235,6 +235,13 @@ class Plugin extends DAV\ServerPlugin
         $path = $request->getPath();
         $locks = $this->getLocks($path);
 
+        // No locks at all. Treat as OK
+        if(!count($locks)) {
+            $response->setHeader('Content-Length', '0');
+            $response->setStatus(204);
+            return false;
+        }
+
         // Windows sometimes forgets to include < and > in the Lock-Token
         // header
         if ('<' !== $lockToken[0]) {


### PR DESCRIPTION
I ran into an issue with Mountain Duck and file locking. When I opened a file it locks it as expected. I left the file open for a day and then the next day the lock has expired. MD keeps sending that expired lock token and there was no way to re-edit the file. Even when reconnecting the webdav drive. I figured that the UNLOCK request does not necessarily have to fail if the file is not locked at all. So these lines of code fixed the issue for me. I hope you can merge this!